### PR TITLE
chore: add Cloudflare Preview launch config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,15 @@
       "name": "Next.js Dev Server",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
+    },
+    {
+      "name": "Cloudflare Preview",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "preview"],
+      "port": 8787,
+      "autoPort": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds a \"Cloudflare Preview\" entry to `.claude/launch.json` so QA sessions can spin up the workerd-based preview (`npm run preview`) for verification against the actual Cloudflare runtime, not just `next dev`.

This was added during the Propylaea v2 redesign QA (PR #2) — Cloudflare preview QA caught no issues but the launch config made the workflow scriptable, and is generally useful to keep around.

## What changed

- `.claude/launch.json`: added \"Cloudflare Preview\" config (port 8787, runs `npm run preview` which calls `npx @opennextjs/cloudflare build && npx @opennextjs/cloudflare preview`)
- `autoPort: true` added to the existing \"Next.js Dev Server\" entry for consistency

## Test plan

- [x] \`npm run preview\` builds the OpenNext bundle and serves on workerd
- [x] Used in PR #2 QA — caught no false negatives, all routes render correctly
- [ ] (Optional) Switch a future session to this config to confirm it still resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)