### PR TITLE
fix(ci): add cf:build script for Cloudflare Workers Builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "deploy": "npx @opennextjs/cloudflare build && npx @opennextjs/cloudflare deploy",
-    "preview": "npx @opennextjs/cloudflare build && npx @opennextjs/cloudflare preview"
+    "cf:build": "opennextjs-cloudflare build",
+    "deploy": "npm run cf:build && opennextjs-cloudflare deploy",
+    "preview": "npm run cf:build && opennextjs-cloudflare preview"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.101.0",


### PR DESCRIPTION
## Summary

- Cloudflare Workers Builds defaults to `npm run build` → `next build`, which only produces `.next/`. `wrangler.jsonc` declares `main: \".open-next/worker.js\"`, an artifact only generated by `@opennextjs/cloudflare build`. Every Workers Build has been failing to find the worker entrypoint.
- Adds a dedicated `cf:build` script and routes `deploy` / `preview` through it. Leaves `build` = `next build` so Vercel keeps working during the migration.

## Required manual follow-up

After merge, set the Cloudflare dashboard build command for the `studentx` Worker:

> Cloudflare → Workers & Pages → `studentx` → Settings → Builds → **Build command**: `npm run cf:build`

Without this dashboard change, Workers Builds will still default to `npm run build` and continue failing.

## Test plan

- [x] `npm run cf:build` locally → produces `.open-next/worker.js`
- [x] `npx wrangler deploy --dry-run` → green
- [ ] After merge + dashboard config update → Cloudflare Workers Builds run goes green
- [ ] PM review per project SOP

🤖 Generated with [Claude Code](https://claude.com/claude-code)