### PR TITLE
chore: remove redundant non-localized route shims

### DIFF
--- a/src/app/landlord/dashboard/page.js
+++ b/src/app/landlord/dashboard/page.js
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function Page() {
-  redirect('/el/landlord/dashboard');
-}

--- a/src/app/landlord/forgot-password/page.js
+++ b/src/app/landlord/forgot-password/page.js
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function Page() {
-  redirect('/el/landlord/forgot-password');
-}

--- a/src/app/landlord/inquiries/page.js
+++ b/src/app/landlord/inquiries/page.js
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function Page() {
-  redirect('/el/landlord/inquiries');
-}

--- a/src/app/landlord/listings/[id]/edit/page.js
+++ b/src/app/landlord/listings/[id]/edit/page.js
@@ -1,6 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default async function Page({ params }) {
-  const { id } = await params;
-  redirect(`/el/landlord/listings/${id}/edit`);
-}

--- a/src/app/landlord/listings/new/page.js
+++ b/src/app/landlord/listings/new/page.js
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function Page() {
-  redirect('/el/landlord/listings/new');
-}

--- a/src/app/landlord/login/page.js
+++ b/src/app/landlord/login/page.js
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function Page() {
-  redirect('/el/landlord/login');
-}

--- a/src/app/landlord/onboarding/page.js
+++ b/src/app/landlord/onboarding/page.js
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function Page() {
-  redirect('/el/landlord/onboarding');
-}

--- a/src/app/landlord/reset-password/page.js
+++ b/src/app/landlord/reset-password/page.js
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function Page() {
-  redirect('/el/landlord/reset-password');
-}

--- a/src/app/landlord/signup/page.js
+++ b/src/app/landlord/signup/page.js
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function Page() {
-  redirect('/el/landlord/signup');
-}

--- a/src/app/landlord/verify-email/page.js
+++ b/src/app/landlord/verify-email/page.js
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function Page() {
-  redirect('/el/landlord/verify-email');
-}

--- a/src/app/listing/[id]/page.js
+++ b/src/app/listing/[id]/page.js
@@ -1,6 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default async function Page({ params }) {
-  const { id } = await params;
-  redirect(`/el/listing/${id}`);
-}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function Page() {
-  redirect('/el');
-}

--- a/src/app/results/page.js
+++ b/src/app/results/page.js
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function Page() {
-  redirect('/el/results');
-}


### PR DESCRIPTION
## Summary

Removes 13 hand-written redirect shims that duplicate behavior already handled by the next-intl middleware. Every removed file was a one-line `redirect('/el/...')` call.

The middleware (`middleware.js`) matches all non-API paths and, combined with `localePrefix: 'as-needed'` + `defaultLocale: 'el'` from `src/i18n/routing.js`, automatically redirects unlocalized URLs to their `/el/...` equivalents.

## Removed (13 files)

**Top-level:**
- `src/app/page.js` → `/el`
- `src/app/results/page.js` → `/el/results`
- `src/app/listing/[id]/page.js` → `/el/listing/{id}`

**Under `src/app/landlord/` (10 files):**
- `login`, `signup`, `dashboard`, `onboarding`, `forgot-password`, `reset-password`, `verify-email`, `inquiries`, `listings/new`, `listings/[id]/edit`

## Verified locally

Started `next dev` and fetched each unlocalized path. All 5 tested resolve correctly via middleware with HTTP 200:

| Request | Final URL |
|---|---|
| `/` | `/el` |
| `/results` | `/el/results` |
| `/listing/test-id` | `/el/listing/test-id` |
| `/landlord/login` | `/el/landlord/login` |
| `/landlord/dashboard` | `/el/landlord/dashboard` |

## Test plan

- [x] All 13 shims confirmed to be 1-line `redirect()` calls before deletion (no metadata, no logic)
- [x] Critical files preserved: `src/app/{layout.js, globals.css, sitemap.js, favicon.ico, [locale]/, api/}`
- [x] Local smoke test: 5 unlocalized paths still resolve correctly
- [ ] Workers Builds CI green on PR
- [ ] PM review per project SOP

🤖 Generated with [Claude Code](https://claude.com/claude-code)