### PR TITLE
style(email): adopt Propylaea v2 tokens in email templates

### DIFF
--- a/src/templates/email/confirmation.js
+++ b/src/templates/email/confirmation.js
@@ -16,41 +16,41 @@ export function confirmationEmailHtml({ label, manageUrl, frequency }) {
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>${title}</title>
 </head>
-<body style="margin:0;padding:0;background:#f5f5f0;font-family:Georgia,serif;">
-  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f5f5f0;padding:40px 16px;">
+<body style="margin:0;padding:0;background:#FAF8F3;font-family:'Source Sans 3',Helvetica,Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#FAF8F3;padding:40px 16px;">
     <tr>
       <td align="center">
-        <table width="560" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;border:1px solid #e5e5e0;">
+        <table width="560" cellpadding="0" cellspacing="0" style="background:#F0EBDF;border-radius:12px;overflow:hidden;border:1px solid #E5DFD0;">
           <!-- Header -->
           <tr>
-            <td style="background:#1a2744;padding:24px 32px;">
-              <p style="margin:0;font-family:'Helvetica Neue',sans-serif;font-size:11px;font-weight:700;letter-spacing:0.15em;text-transform:uppercase;color:#c9a84c;">StudentX</p>
-              <p style="margin:4px 0 0;font-family:'Helvetica Neue',sans-serif;font-size:11px;color:#ffffff80;">Student Housing · Thessaloniki</p>
+            <td style="background:#0A1436;padding:24px 32px;">
+              <p style="margin:0;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:11px;font-weight:700;letter-spacing:0.18em;text-transform:uppercase;color:#B8860B;">StudentX</p>
+              <p style="margin:4px 0 0;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:11px;color:#FAF8F3B3;">Student Housing · Thessaloniki</p>
             </td>
           </tr>
           <!-- Body -->
           <tr>
             <td style="padding:32px;">
-              <h1 style="margin:0 0 8px;font-family:'Helvetica Neue',sans-serif;font-size:22px;font-weight:700;color:#1a2744;">${title}</h1>
-              <p style="margin:0 0 24px;font-size:15px;color:#555;line-height:1.6;">
+              <h1 style="margin:0 0 8px;font-family:'EB Garamond',Garamond,Georgia,'Times New Roman',serif;font-size:24px;font-weight:600;color:#0A1436;letter-spacing:-0.01em;">${title}</h1>
+              <p style="margin:0 0 24px;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:15px;color:#555;line-height:1.6;">
                 You will receive a ${freqLabel} digest whenever new listings match your saved filters.
               </p>
               <table cellpadding="0" cellspacing="0" style="margin-bottom:24px;">
                 <tr>
-                  <td style="background:#c9a84c;border-radius:8px;padding:0;">
-                    <a href="${manageUrl}" style="display:inline-block;padding:12px 28px;font-family:'Helvetica Neue',sans-serif;font-size:14px;font-weight:700;color:#ffffff;text-decoration:none;">Manage my alert</a>
+                  <td style="background:#B8860B;border-radius:8px;padding:0;">
+                    <a href="${manageUrl}" style="display:inline-block;padding:12px 28px;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;color:#ffffff;text-decoration:none;">Manage my alert</a>
                   </td>
                 </tr>
               </table>
-              <p style="margin:0;font-size:13px;color:#999;line-height:1.5;">
+              <p style="margin:0;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#999;line-height:1.5;">
                 To unsubscribe at any time, visit your alert management page using the link above.
               </p>
             </td>
           </tr>
           <!-- Footer -->
           <tr>
-            <td style="background:#f5f5f0;padding:20px 32px;border-top:1px solid #e5e5e0;">
-              <p style="margin:0;font-size:12px;color:#999;">
+            <td style="background:#FAF8F3;padding:20px 32px;border-top:1px solid #E5DFD0;">
+              <p style="margin:0;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:12px;color:#999;">
                 StudentX · Student housing directory for Thessaloniki, Greece<br/>
                 <a href="${manageUrl}" style="color:#999;">Unsubscribe</a>
               </p>

--- a/src/templates/email/digest.js
+++ b/src/templates/email/digest.js
@@ -21,16 +21,16 @@ export function digestEmailHtml({ label, listings, manageUrl, appUrl }) {
 
     return `
     <tr>
-      <td style="padding:16px 0;border-bottom:1px solid #e5e5e0;">
+      <td style="padding:16px 0;border-bottom:1px solid #E5DFD0;">
         <table width="100%" cellpadding="0" cellspacing="0">
           <tr>
             ${photo ? `<td width="80" style="vertical-align:top;padding-right:16px;">
               <img src="${photo}" width="80" height="60" alt="" style="border-radius:6px;object-fit:cover;display:block;" />
             </td>` : ''}
             <td style="vertical-align:top;">
-              <p style="margin:0 0 4px;font-family:'Helvetica Neue',sans-serif;font-size:16px;font-weight:700;color:#1a2744;">${price}</p>
-              ${type ? `<p style="margin:0 0 2px;font-size:13px;color:#555;">${type}${neighborhood ? ' · ' + neighborhood : ''}</p>` : ''}
-              <a href="${listingUrl}" style="display:inline-block;margin-top:8px;font-family:'Helvetica Neue',sans-serif;font-size:13px;font-weight:600;color:#c9a84c;text-decoration:none;">View listing →</a>
+              <p style="margin:0 0 4px;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;color:#0A1436;">${price}</p>
+              ${type ? `<p style="margin:0 0 2px;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#555;">${type}${neighborhood ? ' · ' + neighborhood : ''}</p>` : ''}
+              <a href="${listingUrl}" style="display:inline-block;margin-top:8px;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;font-weight:600;color:#B8860B;text-decoration:none;">View listing →</a>
             </td>
           </tr>
         </table>
@@ -45,23 +45,23 @@ export function digestEmailHtml({ label, listings, manageUrl, appUrl }) {
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>${title}</title>
 </head>
-<body style="margin:0;padding:0;background:#f5f5f0;font-family:Georgia,serif;">
-  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f5f5f0;padding:40px 16px;">
+<body style="margin:0;padding:0;background:#FAF8F3;font-family:'Source Sans 3',Helvetica,Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#FAF8F3;padding:40px 16px;">
     <tr>
       <td align="center">
-        <table width="560" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;border:1px solid #e5e5e0;">
+        <table width="560" cellpadding="0" cellspacing="0" style="background:#F0EBDF;border-radius:12px;overflow:hidden;border:1px solid #E5DFD0;">
           <!-- Header -->
           <tr>
-            <td style="background:#1a2744;padding:24px 32px;">
-              <p style="margin:0;font-family:'Helvetica Neue',sans-serif;font-size:11px;font-weight:700;letter-spacing:0.15em;text-transform:uppercase;color:#c9a84c;">StudentX</p>
-              <p style="margin:4px 0 0;font-family:'Helvetica Neue',sans-serif;font-size:11px;color:#ffffff80;">Student Housing · Thessaloniki</p>
+            <td style="background:#0A1436;padding:24px 32px;">
+              <p style="margin:0;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:11px;font-weight:700;letter-spacing:0.18em;text-transform:uppercase;color:#B8860B;">StudentX</p>
+              <p style="margin:4px 0 0;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:11px;color:#FAF8F3B3;">Student Housing · Thessaloniki</p>
             </td>
           </tr>
           <!-- Body -->
           <tr>
             <td style="padding:32px;">
-              <h1 style="margin:0 0 8px;font-family:'Helvetica Neue',sans-serif;font-size:22px;font-weight:700;color:#1a2744;">${title}</h1>
-              <p style="margin:0 0 24px;font-size:15px;color:#555;line-height:1.6;">
+              <h1 style="margin:0 0 8px;font-family:'EB Garamond',Garamond,Georgia,'Times New Roman',serif;font-size:24px;font-weight:600;color:#0A1436;letter-spacing:-0.01em;">${title}</h1>
+              <p style="margin:0 0 24px;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:15px;color:#555;line-height:1.6;">
                 Here are the latest listings that match your saved search:
               </p>
               <table width="100%" cellpadding="0" cellspacing="0">
@@ -69,8 +69,8 @@ export function digestEmailHtml({ label, listings, manageUrl, appUrl }) {
               </table>
               <table cellpadding="0" cellspacing="0" style="margin-top:24px;">
                 <tr>
-                  <td style="background:#1a2744;border-radius:8px;padding:0;">
-                    <a href="${appUrl}/results" style="display:inline-block;padding:12px 28px;font-family:'Helvetica Neue',sans-serif;font-size:14px;font-weight:700;color:#ffffff;text-decoration:none;">View all results</a>
+                  <td style="background:#01828D;border-radius:8px;padding:0;">
+                    <a href="${appUrl}/results" style="display:inline-block;padding:12px 28px;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;color:#ffffff;text-decoration:none;">View all results</a>
                   </td>
                 </tr>
               </table>
@@ -78,8 +78,8 @@ export function digestEmailHtml({ label, listings, manageUrl, appUrl }) {
           </tr>
           <!-- Footer -->
           <tr>
-            <td style="background:#f5f5f0;padding:20px 32px;border-top:1px solid #e5e5e0;">
-              <p style="margin:0;font-size:12px;color:#999;">
+            <td style="background:#FAF8F3;padding:20px 32px;border-top:1px solid #E5DFD0;">
+              <p style="margin:0;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:12px;color:#999;">
                 StudentX · Student housing directory for Thessaloniki, Greece<br/>
                 You're receiving this because you saved a search alert.<br/>
                 <a href="${manageUrl}" style="color:#999;">Manage alerts</a> · <a href="${manageUrl}" style="color:#999;">Unsubscribe</a>


### PR DESCRIPTION
## Summary

Updates both transactional email templates to use the Propylaea v2 design tokens introduced by the b555555 redesign. They were the last surface still on the legacy navy/gold/Georgia palette.

## Token swap (inline hex — email clients don't read CSS vars)

| Surface | Was | Now | Token |
|---|---|---|---|
| Page canvas | `#f5f5f0` | `#FAF8F3` | `--color-stone` |
| Card | `#ffffff` | `#F0EBDF` | `--color-parchment` |
| Header bg + heading text | `#1a2744` | `#0A1436` | `--color-night` |
| Primary CTA | `#1a2744` | `#01828D` | `--color-blue` |
| Accent / "View listing →" | `#c9a84c` | `#B8860B` | `--color-gold` |
| Border | `#e5e5e0` | `#E5DFD0` | (parchment-tinted) |

## Typography

- Body / UI: `'Source Sans 3', Helvetica, Arial, sans-serif`
- Headings: `'EB Garamond', Garamond, Georgia, serif`

Both stacks lead with the Propylaea web font name (won't load in most email clients) and fall through to widely-available system equivalents.

## What stayed the same

- All copy, logic, and HTML structure
- White button text on dark CTAs
- Footer text gray (`#999`) — neutral, brand-agnostic

## Test plan

- [x] `npx eslint src/templates/email/{digest,confirmation}.js` — clean
- [ ] Workers Builds CI green on PR (validates module parses)
- [ ] Visual QA post-merge: trigger a digest + a confirmation email through the saved-search flow and inspect rendering in Gmail / Apple Mail
- [ ] PM review per project SOP

## Out of scope

A shared `lib/emailLayout.js` helper to deduplicate the header/footer/CTA snippets — would be useful follow-up but adds risk to a styling-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)