### PR TITLE
style(landlord): wrap out-of-scope auth pages in Propylaea v2 shells

### DIFF
--- a/src/app/[locale]/landlord/forgot-password/page.js
+++ b/src/app/[locale]/landlord/forgot-password/page.js
@@ -5,6 +5,10 @@ import { Link } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 import { useTranslations } from 'next-intl';
 
+import AuthShell from '@/components/landlord/AuthShell';
+import FormField from '@/components/landlord/FormField';
+import Button from '@/components/ui/Button';
+
 export default function ForgotPasswordPage() {
   const t = useTranslations('landlord.forgotPassword');
   const [email, setEmail] = useState('');
@@ -33,62 +37,56 @@ export default function ForgotPasswordPage() {
 
   if (submitted) {
     return (
-      <div className="min-h-[80vh] flex items-center justify-center px-4">
-        <div className="w-full max-w-sm text-center">
-          <div className="mb-4 text-4xl">✉️</div>
-          <h1 className="font-heading text-2xl font-bold text-navy mb-2">{t('successTitle')}</h1>
-          <p className="text-sm text-gray-dark/60 mb-8">{t('successMessage')}</p>
-          <Link href="/landlord/login" className="text-gold font-medium hover:underline text-sm">
-            {t('backToLogin')}
+      <AuthShell eyebrow="Reset link sent" title={t('successTitle')} subtitle={t('successMessage')}>
+        <p className="text-sm">
+          <Link
+            href="/landlord/login"
+            className="text-blue font-medium hover:text-night"
+          >
+            {t('backToLogin')} →
           </Link>
-        </div>
-      </div>
+        </p>
+      </AuthShell>
     );
   }
 
   return (
-    <div className="min-h-[80vh] flex items-center justify-center px-4">
-      <div className="w-full max-w-sm">
-        <h1 className="font-heading text-2xl font-bold text-navy mb-2 text-center">{t('title')}</h1>
-        <p className="text-sm text-gray-dark/60 text-center mb-8">{t('subtitle')}</p>
+    <AuthShell eyebrow="Forgot password" title={t('title')} subtitle={t('subtitle')}>
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <FormField
+          id="email"
+          label={t('emailLabel')}
+          type="email"
+          required
+          value={email}
+          onChange={setEmail}
+          placeholder={t('emailPlaceholder')}
+        />
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-dark mb-1">
-              {t('emailLabel')}
-            </label>
-            <input
-              id="email"
-              type="email"
-              required
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-gold/40 focus:border-gold"
-              placeholder={t('emailPlaceholder')}
-            />
-          </div>
+        {error && (
+          <p className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-sm px-3 py-2">
+            {error}
+          </p>
+        )}
 
-          {error && (
-            <p className="text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
-              {error}
-            </p>
-          )}
+        <Button
+          type="submit"
+          variant="primary"
+          disabled={loading}
+          className="w-full justify-center"
+        >
+          {loading ? t('submitting') : t('submit')}
+        </Button>
+      </form>
 
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full bg-navy text-white font-heading font-semibold py-2.5 rounded-lg hover:bg-navy/90 transition-colors disabled:opacity-50"
-          >
-            {loading ? t('submitting') : t('submit')}
-          </button>
-        </form>
-
-        <p className="mt-6 text-sm text-center">
-          <Link href="/landlord/login" className="text-gold font-medium hover:underline">
-            {t('backToLogin')}
-          </Link>
-        </p>
-      </div>
-    </div>
+      <p className="mt-8 text-sm text-night/60">
+        <Link
+          href="/landlord/login"
+          className="text-blue font-medium hover:text-night"
+        >
+          {t('backToLogin')} →
+        </Link>
+      </p>
+    </AuthShell>
   );
 }

--- a/src/app/[locale]/landlord/reset-password/page.js
+++ b/src/app/[locale]/landlord/reset-password/page.js
@@ -1,13 +1,16 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { useRouter, Link } from '@/i18n/navigation';
+import { Link } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 import { useTranslations } from 'next-intl';
 
+import AuthShell from '@/components/landlord/AuthShell';
+import FormField from '@/components/landlord/FormField';
+import Button from '@/components/ui/Button';
+
 export default function ResetPasswordPage() {
   const t = useTranslations('landlord.resetPassword');
-  const router = useRouter();
   const [password, setPassword] = useState('');
   const [confirm, setConfirm] = useState('');
   const [loading, setLoading] = useState(false);
@@ -64,94 +67,82 @@ export default function ResetPasswordPage() {
 
   if (done) {
     return (
-      <div className="min-h-[80vh] flex items-center justify-center px-4">
-        <div className="w-full max-w-sm text-center">
-          <div className="mb-4 text-4xl">✅</div>
-          <h1 className="font-heading text-2xl font-bold text-navy mb-2">{t('successTitle')}</h1>
-          <p className="text-sm text-gray-dark/60 mb-8">{t('successMessage')}</p>
-          <Link href="/landlord/login" className="text-gold font-medium hover:underline text-sm">
-            {t('goToLogin')}
+      <AuthShell eyebrow="Password reset" title={t('successTitle')} subtitle={t('successMessage')}>
+        <p className="text-sm">
+          <Link
+            href="/landlord/login"
+            className="text-blue font-medium hover:text-night"
+          >
+            {t('goToLogin')} →
           </Link>
-        </div>
-      </div>
+        </p>
+      </AuthShell>
     );
   }
 
   if (ready === null) {
     return (
-      <div className="min-h-[80vh] flex items-center justify-center px-4">
-        <div className="w-full max-w-sm text-center">
-          <div className="w-8 h-8 border-2 border-gold border-t-transparent rounded-full animate-spin mx-auto" />
+      <AuthShell eyebrow="Reset password" title={t('title')}>
+        <div className="flex justify-center py-8">
+          <div className="w-8 h-8 border-2 border-gold border-t-transparent rounded-full animate-spin" />
         </div>
-      </div>
+      </AuthShell>
     );
   }
 
   if (ready === false) {
     return (
-      <div className="min-h-[80vh] flex items-center justify-center px-4">
-        <div className="w-full max-w-sm text-center">
-          <p className="text-sm text-gray-dark/60 mb-4">{t('invalidLink')}</p>
-          <Link href="/landlord/forgot-password" className="text-gold font-medium hover:underline text-sm">
-            {t('requestNewLink')}
+      <AuthShell eyebrow="Reset password" title={t('invalidLinkTitle') || t('title')} subtitle={t('invalidLink')}>
+        <p className="text-sm">
+          <Link
+            href="/landlord/forgot-password"
+            className="text-blue font-medium hover:text-night"
+          >
+            {t('requestNewLink')} →
           </Link>
-        </div>
-      </div>
+        </p>
+      </AuthShell>
     );
   }
 
   return (
-    <div className="min-h-[80vh] flex items-center justify-center px-4">
-      <div className="w-full max-w-sm">
-        <h1 className="font-heading text-2xl font-bold text-navy mb-2 text-center">{t('title')}</h1>
-        <p className="text-sm text-gray-dark/60 text-center mb-8">{t('subtitle')}</p>
+    <AuthShell eyebrow="Reset password" title={t('title')} subtitle={t('subtitle')}>
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <FormField
+          id="password"
+          label={t('passwordLabel')}
+          type="password"
+          required
+          value={password}
+          onChange={setPassword}
+          placeholder={t('passwordPlaceholder')}
+        />
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-dark mb-1">
-              {t('passwordLabel')}
-            </label>
-            <input
-              id="password"
-              type="password"
-              required
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-gold/40 focus:border-gold"
-              placeholder={t('passwordPlaceholder')}
-            />
-          </div>
+        <FormField
+          id="confirm"
+          label={t('confirmLabel')}
+          type="password"
+          required
+          value={confirm}
+          onChange={setConfirm}
+          placeholder={t('confirmPlaceholder')}
+        />
 
-          <div>
-            <label htmlFor="confirm" className="block text-sm font-medium text-gray-dark mb-1">
-              {t('confirmLabel')}
-            </label>
-            <input
-              id="confirm"
-              type="password"
-              required
-              value={confirm}
-              onChange={(e) => setConfirm(e.target.value)}
-              className="w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-gold/40 focus:border-gold"
-              placeholder={t('confirmPlaceholder')}
-            />
-          </div>
+        {error && (
+          <p className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-sm px-3 py-2">
+            {error}
+          </p>
+        )}
 
-          {error && (
-            <p className="text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
-              {error}
-            </p>
-          )}
-
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full bg-navy text-white font-heading font-semibold py-2.5 rounded-lg hover:bg-navy/90 transition-colors disabled:opacity-50"
-          >
-            {loading ? t('submitting') : t('submit')}
-          </button>
-        </form>
-      </div>
-    </div>
+        <Button
+          type="submit"
+          variant="primary"
+          disabled={loading}
+          className="w-full justify-center"
+        >
+          {loading ? t('submitting') : t('submit')}
+        </Button>
+      </form>
+    </AuthShell>
   );
 }

--- a/src/app/[locale]/landlord/verification/page.js
+++ b/src/app/[locale]/landlord/verification/page.js
@@ -1,11 +1,14 @@
 'use client';
 
 import { useEffect, useState, useRef } from 'react';
-import { useRouter, Link } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 
+import LandlordShell from '@/components/landlord/LandlordShell';
+import Button from '@/components/ui/Button';
+import Card from '@/components/ui/Card';
+import Icon from '@/components/ui/Icon';
+
 export default function LandlordVerificationPage() {
-  const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [verifiedTier, setVerifiedTier] = useState(null);
   const [latestRequest, setLatestRequest] = useState(null);
@@ -13,7 +16,6 @@ export default function LandlordVerificationPage() {
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState('');
   const [submitSuccess, setSubmitSuccess] = useState(false);
-  const [token, setToken] = useState('');
   const fileInputRef = useRef(null);
 
   useEffect(() => {
@@ -21,10 +23,9 @@ export default function LandlordVerificationPage() {
       const supabase = getSupabaseBrowser();
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) {
-        router.replace('/landlord/login');
+        // LandlordShell handles the redirect to /landlord/login
         return;
       }
-      setToken(session.access_token);
 
       try {
         const res = await fetch('/api/landlord/verification', {
@@ -42,7 +43,7 @@ export default function LandlordVerificationPage() {
       }
     }
     init();
-  }, [router]);
+  }, []);
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -51,13 +52,21 @@ export default function LandlordVerificationPage() {
     setSubmitting(true);
     setSubmitError('');
 
+    const supabase = getSupabaseBrowser();
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session) {
+      setSubmitError('Session expired. Please sign in again.');
+      setSubmitting(false);
+      return;
+    }
+
     const formData = new FormData();
     formData.append('id_document', file);
 
     try {
       const res = await fetch('/api/landlord/verification', {
         method: 'POST',
-        headers: { Authorization: `Bearer ${token}` },
+        headers: { Authorization: `Bearer ${session.access_token}` },
         body: formData,
       });
       const data = await res.json();
@@ -74,70 +83,76 @@ export default function LandlordVerificationPage() {
     }
   }
 
-  if (loading) {
-    return (
-      <div className="mx-auto max-w-lg px-4 py-12">
-        <div className="animate-pulse space-y-4">
-          <div className="h-8 w-48 bg-gray-light rounded" />
-          <div className="h-32 bg-gray-light rounded-xl" />
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="mx-auto max-w-lg px-4 py-10">
-      <div className="mb-6">
-        <Link href="/landlord/dashboard" className="text-sm text-gray-dark/50 hover:text-navy transition-colors">
-          ← Back to dashboard
-        </Link>
-      </div>
+    <LandlordShell eyebrow="Verification" title="Get verified">
+      <div className="max-w-lg">
+        <p className="text-night/60 text-sm mb-8">
+          Upload a government-issued ID to receive a free Verified badge shown on all your listings.
+        </p>
 
-      <h1 className="font-heading text-2xl font-bold text-navy mb-2">Get Verified</h1>
-      <p className="text-gray-dark/60 text-sm mb-8">
-        Upload a government-issued ID to receive a free Verified badge shown on all your listings.
-      </p>
-
-      {/* Already verified */}
-      {verifiedTier && verifiedTier !== 'none' ? (
-        <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-6 py-5 flex items-start gap-4">
-          <div className="mt-0.5 flex-shrink-0 w-8 h-8 rounded-full bg-emerald-100 flex items-center justify-center">
-            <svg className="w-5 h-5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-            </svg>
+        {loading ? (
+          <div className="animate-pulse space-y-4">
+            <div className="h-8 w-48 bg-parchment rounded-sm" />
+            <div className="h-32 bg-parchment rounded-sm" />
           </div>
-          <div>
-            <p className="font-heading font-bold text-emerald-800 text-base mb-0.5">Your account is verified</p>
-            <p className="text-sm text-emerald-700">
-              Your listings display the{' '}
-              <span className="font-semibold">
-                {verifiedTier === 'verified_pro' ? 'SuperLandlord Heavy' : 'SuperLandlord'}
-              </span>{' '}
-              badge automatically.
+        ) : verifiedTier && verifiedTier !== 'none' ? (
+          /* Already verified */
+          <Card tone="parchment" className="px-6 py-5 flex items-start gap-4">
+            <div className="mt-0.5 flex-shrink-0 w-9 h-9 rounded-full bg-blue/10 flex items-center justify-center text-blue">
+              <Icon name="shieldCheck" className="w-5 h-5" />
+            </div>
+            <div>
+              <p className="font-display text-lg text-night mb-0.5">
+                Your account is verified
+              </p>
+              <p className="text-sm text-night/70">
+                Your listings display the{' '}
+                <span className="font-semibold text-night">
+                  {verifiedTier === 'verified_pro' ? 'SuperLandlord Heavy' : 'SuperLandlord'}
+                </span>{' '}
+                badge automatically.
+              </p>
+            </div>
+          </Card>
+        ) : latestRequest?.status === 'pending' ? (
+          /* Pending review */
+          <Card tone="parchment" className="px-6 py-5">
+            <p className="label-caps text-gold mb-1">Under review</p>
+            <p className="font-display text-lg text-night mb-1">
+              Your ID is being reviewed
             </p>
+            <p className="text-sm text-night/70">
+              Submitted{' '}
+              {new Date(latestRequest.submitted_at).toLocaleDateString('en-GB', {
+                day: 'numeric', month: 'long', year: 'numeric',
+              })}
+              . We&apos;ll review it within 1–2 business days.
+            </p>
+          </Card>
+        ) : latestRequest?.status === 'rejected' ? (
+          /* Rejected — allow re-upload */
+          <div className="space-y-6">
+            <div className="rounded-sm border border-red-200 bg-red-50 px-6 py-4">
+              <p className="label-caps text-red-700 mb-1">Rejected</p>
+              <p className="font-display text-base text-red-800 mb-1">
+                Previous submission rejected
+              </p>
+              {latestRequest.review_notes && (
+                <p className="text-sm text-red-700">{latestRequest.review_notes}</p>
+              )}
+            </div>
+            <UploadForm
+              file={file}
+              setFile={setFile}
+              fileInputRef={fileInputRef}
+              submitting={submitting}
+              submitError={submitError}
+              submitSuccess={submitSuccess}
+              onSubmit={handleSubmit}
+            />
           </div>
-        </div>
-      ) : latestRequest?.status === 'pending' ? (
-        /* Pending review */
-        <div className="rounded-xl border border-blue-200 bg-blue-50 px-6 py-5">
-          <p className="font-heading font-bold text-blue-800 text-base mb-1">Your ID is under review</p>
-          <p className="text-sm text-blue-700">
-            Submitted{' '}
-            {new Date(latestRequest.submitted_at).toLocaleDateString('en-GB', {
-              day: 'numeric', month: 'long', year: 'numeric',
-            })}
-            . We&apos;ll review it within 1–2 business days.
-          </p>
-        </div>
-      ) : latestRequest?.status === 'rejected' ? (
-        /* Rejected — allow re-upload */
-        <div className="space-y-6">
-          <div className="rounded-xl border border-red-200 bg-red-50 px-6 py-4">
-            <p className="font-heading font-bold text-red-800 text-sm mb-0.5">Previous submission rejected</p>
-            {latestRequest.review_notes && (
-              <p className="text-sm text-red-700">{latestRequest.review_notes}</p>
-            )}
-          </div>
+        ) : (
+          /* No request yet */
           <UploadForm
             file={file}
             setFile={setFile}
@@ -147,48 +162,44 @@ export default function LandlordVerificationPage() {
             submitSuccess={submitSuccess}
             onSubmit={handleSubmit}
           />
-        </div>
-      ) : (
-        /* No request yet */
-        <UploadForm
-          file={file}
-          setFile={setFile}
-          fileInputRef={fileInputRef}
-          submitting={submitting}
-          submitError={submitError}
-          submitSuccess={submitSuccess}
-          onSubmit={handleSubmit}
-        />
-      )}
-    </div>
+        )}
+      </div>
+    </LandlordShell>
   );
 }
 
 function UploadForm({ file, setFile, fileInputRef, submitting, submitError, submitSuccess, onSubmit }) {
   if (submitSuccess) {
     return (
-      <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-6 py-5">
-        <p className="font-heading font-bold text-emerald-800 text-base mb-1">Document submitted!</p>
-        <p className="text-sm text-emerald-700">
-          We&apos;ll review your ID within 1–2 business days and notify you when your badge is activated.
-        </p>
-      </div>
+      <Card tone="parchment" className="px-6 py-5 flex items-start gap-4">
+        <div className="mt-0.5 flex-shrink-0 w-9 h-9 rounded-full bg-blue/10 flex items-center justify-center text-blue">
+          <Icon name="check" className="w-5 h-5" />
+        </div>
+        <div>
+          <p className="font-display text-lg text-night mb-1">Document submitted</p>
+          <p className="text-sm text-night/70">
+            We&apos;ll review your ID within 1–2 business days and notify you when your badge is activated.
+          </p>
+        </div>
+      </Card>
     );
   }
 
   return (
     <form onSubmit={onSubmit} className="space-y-5">
       <div>
-        <label className="block text-sm font-medium text-navy mb-2">
-          Government-issued ID <span className="text-red-500">*</span>
+        <label className="label-caps text-night/70 mb-2 block">
+          Government-issued ID <span className="text-red-600 normal-case">*</span>
         </label>
-        <p className="text-xs text-gray-dark/50 mb-3">
+        <p className="text-xs text-night/50 mb-3">
           Passport, national ID card, or driver&apos;s license. JPEG, PNG, or PDF · max 10 MB.
         </p>
         <div
           onClick={() => fileInputRef.current?.click()}
-          className={`cursor-pointer rounded-xl border-2 border-dashed px-6 py-8 text-center transition-colors ${
-            file ? 'border-emerald-300 bg-emerald-50' : 'border-gray-200 hover:border-gold/50 bg-gray-light/40'
+          className={`cursor-pointer rounded-sm border-2 border-dashed px-6 py-8 text-center transition-colors ${
+            file
+              ? 'border-blue/40 bg-blue/5 text-blue'
+              : 'border-night/15 hover:border-gold/60 bg-parchment text-night/60'
           }`}
         >
           <input
@@ -200,38 +211,37 @@ function UploadForm({ file, setFile, fileInputRef, submitting, submitError, subm
           />
           {file ? (
             <div>
-              <svg className="w-8 h-8 mx-auto text-emerald-500 mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              <p className="text-sm font-medium text-emerald-700">{file.name}</p>
-              <p className="text-xs text-gray-dark/40 mt-1">{(file.size / 1024 / 1024).toFixed(2)} MB · click to change</p>
+              <Icon name="check" className="w-8 h-8 mx-auto text-blue mb-2" />
+              <p className="text-sm font-medium text-night">{file.name}</p>
+              <p className="text-xs text-night/50 mt-1">
+                {(file.size / 1024 / 1024).toFixed(2)} MB · click to change
+              </p>
             </div>
           ) : (
             <div>
-              <svg className="w-8 h-8 mx-auto text-gray-dark/30 mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
-              </svg>
-              <p className="text-sm text-gray-dark/50">Click to select a file</p>
+              <Icon name="plus" className="w-8 h-8 mx-auto text-night/40 mb-2" />
+              <p className="text-sm text-night/60">Click to select a file</p>
             </div>
           )}
         </div>
       </div>
 
       {submitError && (
-        <p className="text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-4 py-3">
+        <p className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-sm px-3 py-2">
           {submitError}
         </p>
       )}
 
-      <button
+      <Button
         type="submit"
+        variant="primary"
         disabled={!file || submitting}
-        className="w-full bg-navy text-white font-heading font-semibold py-3 rounded-lg hover:bg-navy/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        className="w-full justify-center"
       >
         {submitting ? 'Submitting…' : 'Submit for verification'}
-      </button>
+      </Button>
 
-      <p className="text-xs text-gray-dark/40 text-center">
+      <p className="text-xs text-night/50 text-center">
         Your document is stored securely and only reviewed by our team.
       </p>
     </form>

--- a/src/app/[locale]/landlord/verify-email/page.js
+++ b/src/app/[locale]/landlord/verify-email/page.js
@@ -5,6 +5,9 @@ import { Link } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 import { useTranslations } from 'next-intl';
 
+import AuthShell from '@/components/landlord/AuthShell';
+import Button from '@/components/ui/Button';
+
 export default function VerifyEmailPage() {
   const t = useTranslations('landlord.verifyEmail');
   const [resending, setResending] = useState(false);
@@ -39,38 +42,38 @@ export default function VerifyEmailPage() {
   }
 
   return (
-    <div className="min-h-[80vh] flex items-center justify-center px-4">
-      <div className="w-full max-w-sm text-center">
-        <div className="mb-4 text-4xl">✉️</div>
-        <h1 className="font-heading text-2xl font-bold text-navy mb-2">{t('title')}</h1>
-        <p className="text-sm text-gray-dark/60 mb-8">{t('message')}</p>
-
+    <AuthShell eyebrow="Verify email" title={t('title')} subtitle={t('message')}>
+      <div className="space-y-5">
         {error && (
-          <p className="text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2 mb-4">
+          <p className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-sm px-3 py-2">
             {error}
           </p>
         )}
 
         {resent ? (
-          <p className="text-sm text-green-700 bg-green-50 border border-green-100 rounded-lg px-3 py-2 mb-4">
+          <p className="text-sm text-blue bg-blue/10 border border-blue/20 rounded-sm px-3 py-2">
             {t('resentConfirm')}
           </p>
         ) : (
-          <button
+          <Button
             onClick={handleResend}
+            variant="primary"
             disabled={resending}
-            className="w-full bg-navy text-white font-heading font-semibold py-2.5 rounded-lg hover:bg-navy/90 transition-colors disabled:opacity-50 mb-4"
+            className="w-full justify-center"
           >
             {resending ? t('resending') : t('resend')}
-          </button>
+          </Button>
         )}
 
-        <p className="text-sm text-gray-dark/60">
-          <Link href="/landlord/login" className="text-gold font-medium hover:underline">
-            {t('backToLogin')}
+        <p className="text-sm text-night/60">
+          <Link
+            href="/landlord/login"
+            className="text-blue font-medium hover:text-night"
+          >
+            {t('backToLogin')} →
           </Link>
         </p>
       </div>
-    </div>
+    </AuthShell>
   );
 }


### PR DESCRIPTION
## Summary

Four landlord auth pages were left behind by the Propylaea v2 redesign (b555555):

- `verification/page.js` — was rendering standalone (no shell), used legacy `text-navy / bg-gray-light / text-emerald-* / text-blue-* / text-red-*` utilities and inline SVG/emoji
- `forgot-password/page.js`, `reset-password/page.js`, `verify-email/page.js` — hybrid: a few new tokens mixed with `text-gray-dark / bg-red-50 / border-gray-200 / bg-navy / font-heading`, no shared shell

This PR brings them in line with the login/signup pattern.

## Changes per file

### `verification/page.js` — full redesign
- Wrapped in `LandlordShell` (sidebar + topbar, same as dashboard)
- Status states (verified / pending / rejected / submitted) now use `Card tone=\"parchment\"` with `<Icon>` (`shieldCheck`, `check`, `plus`) and v2 night/blue/gold tokens
- Inline-styled submit replaced with `<Button variant=\"primary\">`
- Auth gate is now centralized in `LandlordShell` — page no longer owns the redirect-to-login or pre-fetches an access token; session is fetched at submit time instead

### `forgot-password / reset-password / verify-email`
- Each wrapped in `AuthShell` (split-panel layout)
- Inline `<input>`s replaced with `<FormField>`
- Inline-styled `<button>`s replaced with `<Button variant=\"primary\">`
- Legacy utility classes replaced with v2 tokens. Error states match login/signup: `text-red-700 bg-red-50 border-red-200 rounded-sm`

## Reused components

- `src/components/landlord/AuthShell.js`
- `src/components/landlord/LandlordShell.js`
- `src/components/landlord/FormField.js`
- `src/components/ui/Button.js`
- `src/components/ui/Card.js`
- `src/components/ui/Icon.js`

All auth logic, form handlers, redirects, and i18n keys preserved.

## Test plan

- [x] `npx eslint` on all 4 changed files: 0 warnings
- [x] All 4 pages return HTTP 200 in dev (`/en/landlord/{forgot-password,reset-password,verify-email,verification}`)
- [x] No client-side console errors
- [x] `forgot-password` snapshot shows new AuthShell structure (eyebrow + title + FormField + Button + back-to-login link)
- [x] `reset-password` loading-state spinner renders correctly
- [ ] Workers Builds CI green on PR
- [ ] Visual QA post-merge — full preview of each page on desktop + mobile
- [ ] Manual end-to-end: trigger forgot-password → check inbox → click reset link → land on reset-password → submit new password
- [ ] PM review per project SOP

🤖 Generated with [Claude Code](https://claude.com/claude-code)