### PR TITLE
fix(inquiries): wire contact-landlord backend end-to-end

### DIFF
--- a/src/app/api/inquiries/route.js
+++ b/src/app/api/inquiries/route.js
@@ -1,5 +1,20 @@
 import { NextResponse } from "next/server";
 import { getSupabase } from "@/lib/supabase";
+import { getResend } from "@/lib/resend";
+import { inquiryEmailHtml, inquiryEmailSubject } from "@/templates/email/inquiry";
+
+// Match the verified sender used by src/app/api/cron/saved-searches-digest/route.js
+// so we don't silently fail at Resend due to an unverified domain identity.
+const FROM_ADDRESS = "StudentX <alerts@studentx.gr>";
+
+function getClientIp(request) {
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  return request.headers.get("x-real-ip") || null;
+}
 
 export async function POST(request) {
   try {
@@ -10,9 +25,14 @@ export async function POST(request) {
       return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
     }
 
-    const { listing_id, student_name, student_email, student_phone, message, faculty_id } = body;
+    const { listing_id, student_name, student_email, student_phone, message, faculty_id, website } = body;
 
-    // Validate required fields
+    // Honeypot: bots tend to fill every field. Real users never see `website`.
+    // Pretend success so bots don't learn to bypass.
+    if (typeof website === "string" && website.trim().length > 0) {
+      return NextResponse.json({ inquiry_id: "blocked" }, { status: 201 });
+    }
+
     if (!listing_id || typeof listing_id !== "string") {
       return NextResponse.json({ error: "listing_id is required" }, { status: 400 });
     }
@@ -32,72 +52,123 @@ export async function POST(request) {
       );
     }
 
-    const insertData = {
-      listing_id: listing_id.trim(),
-      student_name: student_name.trim(),
-      student_email: student_email.trim().toLowerCase(),
-      message: message.trim(),
-    };
-
-    if (student_phone && typeof student_phone === "string" && student_phone.trim().length > 0) {
-      insertData.student_phone = student_phone.trim();
-    }
-
-    if (faculty_id && typeof faculty_id === "string" && faculty_id.trim().length > 0) {
-      insertData.faculty_id = faculty_id.trim();
-    }
-
-    // Enforce free-tier inquiry cap (10 per listing)
     const supabase = getSupabase();
+    const submitterIp = getClientIp(request);
 
-    const { data: listing, error: listingError } = await supabase
-      .from("listings")
-      .select("landlord_id")
-      .eq("listing_id", insertData.listing_id)
-      .single();
+    const cleanName = student_name.trim();
+    const cleanEmail = student_email.trim().toLowerCase();
+    const cleanPhone =
+      typeof student_phone === "string" && student_phone.trim().length > 0
+        ? student_phone.trim()
+        : null;
+    const cleanFacultyId =
+      typeof faculty_id === "string" && faculty_id.trim().length > 0 ? faculty_id.trim() : null;
+    const cleanListingId = listing_id.trim();
 
-    if (listingError || !listing) {
-      return NextResponse.json({ error: "Listing not found" }, { status: 404 });
+    // All inquiry writes go through the SECURITY DEFINER RPC. It enforces:
+    //   - LISTING_NOT_FOUND   (P0002) → 404
+    //   - RATE_LIMITED        (P0003) → 429  (5 inquiries / IP / hour)
+    //   - CAP_EXCEEDED        (P0001) → 403  (free-tier 10 / listing)
+    const { data: inquiryId, error: rpcError } = await supabase.rpc("submit_inquiry", {
+      p_listing_id: cleanListingId,
+      p_student_name: cleanName,
+      p_student_email: cleanEmail,
+      p_student_phone: cleanPhone,
+      p_message: message.trim(),
+      p_faculty_id: cleanFacultyId,
+      p_submitter_ip: submitterIp,
+    });
+
+    if (rpcError) {
+      switch (rpcError.code) {
+        case "P0002":
+          return NextResponse.json({ error: "Listing not found" }, { status: 404 });
+        case "P0003":
+          return NextResponse.json(
+            { error: "Too many inquiries from this network. Try again in an hour." },
+            { status: 429 }
+          );
+        case "P0001":
+          return NextResponse.json(
+            { error: "This listing has reached the maximum number of inquiries for the free tier." },
+            { status: 403 }
+          );
+        default:
+          console.error("submit_inquiry RPC error:", rpcError);
+          return NextResponse.json({ error: "Failed to submit inquiry" }, { status: 500 });
+      }
     }
 
-    const { data: landlord } = await supabase
-      .from("landlords")
-      .select("verified_tier")
-      .eq("landlord_id", listing.landlord_id)
-      .single();
+    // Notify the landlord. Never fail the request if email fails — the inquiry is in the DB,
+    // and email_sent_at lets us retry/backfill later.
+    try {
+      const { data: listing } = await supabase
+        .from("listings")
+        .select(`
+          listing_id,
+          location ( address, neighborhood ),
+          rent ( monthly_price ),
+          landlords ( name, email )
+        `)
+        .eq("listing_id", cleanListingId)
+        .single();
 
-    if (landlord?.verified_tier === "none" || !landlord?.verified_tier) {
-      const { count } = await supabase
-        .from("inquiries")
-        .select("inquiry_id", { count: "exact", head: true })
-        .eq("listing_id", insertData.listing_id);
+      const landlord = Array.isArray(listing?.landlords) ? listing.landlords[0] : listing?.landlords;
+      const location = Array.isArray(listing?.location) ? listing.location[0] : listing?.location;
+      const rent = Array.isArray(listing?.rent) ? listing.rent[0] : listing?.rent;
 
-      if (count >= 10) {
-        return NextResponse.json(
-          { error: "This listing has reached the maximum number of inquiries for the free tier." },
-          { status: 403 }
+      if (landlord?.email) {
+        let facultyName = null;
+        if (cleanFacultyId) {
+          const { data: faculty } = await supabase
+            .from("faculties")
+            .select("name")
+            .eq("faculty_id", cleanFacultyId)
+            .single();
+          facultyName = faculty?.name ?? null;
+        }
+
+        const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://studentx.gr";
+        const listingSummary = [location?.address, location?.neighborhood]
+          .filter(Boolean)
+          .join(" · ");
+
+        await getResend().emails.send({
+          from: FROM_ADDRESS,
+          to: landlord.email,
+          replyTo: cleanEmail,
+          subject: inquiryEmailSubject(cleanName, listingSummary),
+          html: inquiryEmailHtml({
+            landlordName: landlord.name,
+            student: {
+              name: cleanName,
+              email: cleanEmail,
+              phone: cleanPhone,
+              faculty: facultyName,
+            },
+            message: message.trim(),
+            listing: {
+              listing_id: cleanListingId,
+              address: location?.address,
+              neighborhood: location?.neighborhood,
+              monthly_price: rent?.monthly_price,
+            },
+            appUrl,
+          }),
+        });
+
+        await supabase.rpc("mark_inquiry_email_sent", { p_inquiry_id: inquiryId });
+      } else {
+        console.warn(
+          `Inquiry ${inquiryId}: no landlord email on file for listing ${cleanListingId}`
         );
       }
+    } catch (emailError) {
+      console.error("Failed to send landlord notification email:", emailError);
+      // Swallow — inquiry persisted, retry can be done out-of-band.
     }
 
-    const { data, error } = await supabase
-      .from("inquiries")
-      .insert(insertData)
-      .select("inquiry_id")
-      .single();
-
-    if (error) {
-      if (error.code === "23503") {
-        // Foreign key violation — listing_id doesn't exist
-        return NextResponse.json({ error: "Listing not found" }, { status: 404 });
-      }
-      console.error("Supabase insert error:", error);
-      return NextResponse.json({ error: "Failed to submit inquiry" }, { status: 500 });
-    }
-
-    // TODO: trigger email notification to landlord via Resend/SendGrid/Supabase Edge Function
-
-    return NextResponse.json({ inquiry_id: data.inquiry_id }, { status: 201 });
+    return NextResponse.json({ inquiry_id: inquiryId }, { status: 201 });
   } catch (err) {
     console.error("Unexpected error in POST /api/inquiries:", err);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/src/app/api/landlord/inquiries/route.js
+++ b/src/app/api/landlord/inquiries/route.js
@@ -23,6 +23,7 @@ export async function GET(request) {
 
   const { searchParams } = new URL(request.url);
   const status = searchParams.get('status');
+  const includeCounts = searchParams.get('counts') === '1';
 
   const authedSupabase = getSupabaseWithToken(token);
   let query = authedSupabase
@@ -52,5 +53,20 @@ export async function GET(request) {
     return NextResponse.json({ error: 'Failed to fetch inquiries' }, { status: 500 });
   }
 
-  return NextResponse.json({ inquiries: data });
+  const response = { inquiries: data };
+
+  if (includeCounts) {
+    const { count: pendingCount, error: countError } = await authedSupabase
+      .from('inquiries')
+      .select('inquiry_id', { count: 'exact', head: true })
+      .eq('status', 'pending');
+
+    if (countError) {
+      console.error('Failed to fetch inquiry counts:', countError);
+    } else {
+      response.pending_count = pendingCount ?? 0;
+    }
+  }
+
+  return NextResponse.json(response);
 }

--- a/src/components/InquiryForm.js
+++ b/src/components/InquiryForm.js
@@ -11,6 +11,7 @@ export default function InquiryForm({ listingId, facultyId }) {
     student_email: '',
     student_phone: '',
     message: '',
+    website: '', // honeypot — must stay empty for real users
   });
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -36,6 +37,7 @@ export default function InquiryForm({ listingId, facultyId }) {
           student_phone: form.student_phone || undefined,
           message: form.message,
           faculty_id: facultyId || undefined,
+          website: form.website,
         }),
       });
 
@@ -102,6 +104,20 @@ export default function InquiryForm({ listingId, facultyId }) {
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-3">
+        {/* Honeypot — hidden from real users; bots fill every field */}
+        <div aria-hidden="true" style={{ position: 'absolute', left: '-9999px', width: '1px', height: '1px', overflow: 'hidden' }}>
+          <label htmlFor="inquiry-website">Website</label>
+          <input
+            id="inquiry-website"
+            name="website"
+            type="text"
+            tabIndex={-1}
+            autoComplete="off"
+            value={form.website}
+            onChange={handleChange}
+          />
+        </div>
+
         <div>
           <label htmlFor="inquiry-name" className="sr-only">{t('yourName')}</label>
           <input

--- a/src/templates/email/inquiry.js
+++ b/src/templates/email/inquiry.js
@@ -1,0 +1,127 @@
+/**
+ * Email sent to a landlord when a student submits an inquiry from a listing.
+ * Mirrors the brand styling used by digest.js.
+ *
+ * @param {object} params
+ * @param {string} params.landlordName - Name shown in greeting (falls back to "there")
+ * @param {object} params.student - { name, email, phone?, faculty? }
+ * @param {string} params.message - Raw student message
+ * @param {object} params.listing - { listing_id, address?, neighborhood?, monthly_price? }
+ * @param {string} params.appUrl - Base URL of the app (no trailing slash)
+ */
+export function inquiryEmailHtml({ landlordName, student, message, listing, appUrl }) {
+  const safeName = escapeHtml(student.name);
+  const safeEmail = escapeHtml(student.email);
+  const safePhone = student.phone ? escapeHtml(student.phone) : '';
+  const safeFaculty = student.faculty ? escapeHtml(student.faculty) : '';
+  const safeMessage = escapeHtml(message).replace(/\n/g, '<br/>');
+  const safeAddress = listing.address ? escapeHtml(listing.address) : '';
+  const safeNeighborhood = listing.neighborhood ? escapeHtml(listing.neighborhood) : '';
+  const safePrice = listing.monthly_price ? `€${Number(listing.monthly_price)}/mo` : '';
+  const safeGreeting = landlordName ? escapeHtml(landlordName) : 'there';
+
+  const listingUrl = `${appUrl}/listing/${listing.listing_id}`;
+  const inboxUrl = `${appUrl}/landlord/inquiries`;
+
+  const listingSummary = [safeAddress, safeNeighborhood, safePrice].filter(Boolean).join(' · ');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>New inquiry on your listing</title>
+</head>
+<body style="margin:0;padding:0;background:#f5f5f0;font-family:Georgia,serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f5f5f0;padding:40px 16px;">
+    <tr>
+      <td align="center">
+        <table width="560" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;border:1px solid #e5e5e0;">
+          <!-- Header -->
+          <tr>
+            <td style="background:#1a2744;padding:24px 32px;">
+              <p style="margin:0;font-family:'Helvetica Neue',sans-serif;font-size:11px;font-weight:700;letter-spacing:0.15em;text-transform:uppercase;color:#c9a84c;">StudentX</p>
+              <p style="margin:4px 0 0;font-family:'Helvetica Neue',sans-serif;font-size:11px;color:#ffffff80;">Student Housing · Thessaloniki</p>
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding:32px;">
+              <h1 style="margin:0 0 8px;font-family:'Helvetica Neue',sans-serif;font-size:22px;font-weight:700;color:#1a2744;">New inquiry from ${safeName}</h1>
+              <p style="margin:0 0 24px;font-size:15px;color:#555;line-height:1.6;">
+                Hi ${safeGreeting}, a student just sent you a message about your listing${listingSummary ? ` <strong style="color:#1a2744;">${listingSummary}</strong>` : ''}.
+              </p>
+
+              <!-- Student card -->
+              <table width="100%" cellpadding="0" cellspacing="0" style="background:#f5f5f0;border-radius:8px;padding:20px;margin-bottom:20px;">
+                <tr>
+                  <td>
+                    <p style="margin:0 0 6px;font-family:'Helvetica Neue',sans-serif;font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:#888;">Student</p>
+                    <p style="margin:0 0 4px;font-family:'Helvetica Neue',sans-serif;font-size:16px;font-weight:700;color:#1a2744;">${safeName}</p>
+                    <p style="margin:0;font-size:14px;color:#555;">
+                      <a href="mailto:${safeEmail}" style="color:#c9a84c;text-decoration:none;">${safeEmail}</a>
+                      ${safePhone ? ` · <a href="tel:${safePhone}" style="color:#c9a84c;text-decoration:none;">${safePhone}</a>` : ''}
+                    </p>
+                    ${safeFaculty ? `<p style="margin:6px 0 0;font-size:13px;color:#777;">Faculty: ${safeFaculty}</p>` : ''}
+                  </td>
+                </tr>
+              </table>
+
+              <!-- Message -->
+              <p style="margin:0 0 6px;font-family:'Helvetica Neue',sans-serif;font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:#888;">Message</p>
+              <div style="font-size:15px;color:#333;line-height:1.6;border-left:3px solid #c9a84c;padding:4px 16px;margin-bottom:24px;">
+                ${safeMessage}
+              </div>
+
+              <!-- CTAs -->
+              <table cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background:#1a2744;border-radius:8px;padding:0;">
+                    <a href="mailto:${safeEmail}" style="display:inline-block;padding:12px 22px;font-family:'Helvetica Neue',sans-serif;font-size:14px;font-weight:700;color:#ffffff;text-decoration:none;">Reply to student</a>
+                  </td>
+                  <td style="width:8px;"></td>
+                  <td style="border:1px solid #1a2744;border-radius:8px;padding:0;">
+                    <a href="${inboxUrl}" style="display:inline-block;padding:11px 22px;font-family:'Helvetica Neue',sans-serif;font-size:14px;font-weight:700;color:#1a2744;text-decoration:none;">Open inbox</a>
+                  </td>
+                </tr>
+              </table>
+
+              <p style="margin:24px 0 0;font-size:13px;color:#888;">
+                <a href="${listingUrl}" style="color:#888;">View listing →</a>
+              </p>
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td style="background:#f5f5f0;padding:20px 32px;border-top:1px solid #e5e5e0;">
+              <p style="margin:0;font-size:12px;color:#999;">
+                StudentX · Student housing directory for Thessaloniki, Greece<br/>
+                You're receiving this because a student contacted you about your listing on StudentX.<br/>
+                Just hit Reply to respond — your message will go straight to the student.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+export function inquiryEmailSubject(studentName, listingSummary) {
+  const trimmedName = (studentName || '').trim() || 'A student';
+  if (listingSummary) {
+    return `New inquiry from ${trimmedName} — ${listingSummary} · StudentX`;
+  }
+  return `New inquiry from ${trimmedName} · StudentX`;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/supabase/migrations/019_inquiry_rate_limit.sql
+++ b/supabase/migrations/019_inquiry_rate_limit.sql
@@ -1,0 +1,14 @@
+-- ============================================================
+-- Migration 019: Inquiry rate limiting + email send tracking
+-- ============================================================
+-- Adds the columns needed by POST /api/inquiries to enforce a
+-- per-IP rate limit and to record whether the landlord notification
+-- email was successfully sent (for retry/backfill).
+
+ALTER TABLE inquiries
+  ADD COLUMN IF NOT EXISTS submitter_ip  TEXT,
+  ADD COLUMN IF NOT EXISTS email_sent_at TIMESTAMPTZ;
+
+-- Used by the rate-limit lookup: count rows by IP within the last hour.
+CREATE INDEX IF NOT EXISTS idx_inquiries_submitter_ip_created_at
+  ON inquiries (submitter_ip, created_at DESC);

--- a/supabase/migrations/020_submit_inquiry_rate_limit.sql
+++ b/supabase/migrations/020_submit_inquiry_rate_limit.sql
@@ -1,0 +1,114 @@
+-- ============================================================
+-- Migration 020: Extend submit_inquiry() with submitter_ip + per-IP
+-- rate limit, and add mark_inquiry_email_sent() helper.
+-- ============================================================
+-- Anon clients cannot INSERT/UPDATE inquiries directly (RLS), so all
+-- writes for the contact-landlord flow go through SECURITY DEFINER RPCs.
+
+-- ---- submit_inquiry --------------------------------------------------
+-- Drop the old 6-arg version so we can change the signature cleanly.
+DROP FUNCTION IF EXISTS public.submit_inquiry(text, text, text, text, text, text);
+
+CREATE OR REPLACE FUNCTION public.submit_inquiry(
+  p_listing_id    text,
+  p_student_name  text,
+  p_student_email text,
+  p_student_phone text,
+  p_message       text,
+  p_faculty_id    text,
+  p_submitter_ip  text
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_landlord_id TEXT;
+  v_tier        TEXT;
+  v_listing_count  INTEGER;
+  v_ip_count       INTEGER;
+  v_inquiry_id  UUID;
+BEGIN
+  -- Locate landlord + lock listing row to serialise concurrent caps.
+  SELECT landlord_id INTO v_landlord_id
+  FROM listings
+  WHERE listing_id = p_listing_id
+  FOR UPDATE;
+
+  IF v_landlord_id IS NULL THEN
+    RAISE EXCEPTION 'LISTING_NOT_FOUND' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Per-IP rate limit: 5 inquiries / hour from the same network.
+  IF p_submitter_ip IS NOT NULL AND length(p_submitter_ip) > 0 THEN
+    SELECT COUNT(*) INTO v_ip_count
+    FROM inquiries
+    WHERE submitter_ip = p_submitter_ip
+      AND created_at > now() - interval '1 hour';
+
+    IF v_ip_count >= 5 THEN
+      RAISE EXCEPTION 'RATE_LIMITED' USING ERRCODE = 'P0003';
+    END IF;
+  END IF;
+
+  -- Free-tier per-listing cap (10) for unverified landlords.
+  SELECT verified_tier INTO v_tier
+  FROM landlords
+  WHERE landlord_id = v_landlord_id;
+
+  IF v_tier IS NULL OR v_tier = 'none' THEN
+    SELECT COUNT(*) INTO v_listing_count
+    FROM inquiries
+    WHERE listing_id = p_listing_id;
+
+    IF v_listing_count >= 10 THEN
+      RAISE EXCEPTION 'CAP_EXCEEDED' USING ERRCODE = 'P0001';
+    END IF;
+  END IF;
+
+  INSERT INTO inquiries (
+    listing_id,
+    student_name,
+    student_email,
+    student_phone,
+    message,
+    faculty_id,
+    submitter_ip
+  )
+  VALUES (
+    p_listing_id,
+    p_student_name,
+    p_student_email,
+    p_student_phone,
+    p_message,
+    p_faculty_id,
+    p_submitter_ip
+  )
+  RETURNING inquiry_id INTO v_inquiry_id;
+
+  RETURN v_inquiry_id;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.submit_inquiry(text, text, text, text, text, text, text)
+  TO anon, authenticated;
+
+-- ---- mark_inquiry_email_sent ----------------------------------------
+-- Records that the landlord notification email was successfully sent.
+-- Idempotent: callable multiple times, sets email_sent_at to now() each time.
+CREATE OR REPLACE FUNCTION public.mark_inquiry_email_sent(p_inquiry_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+BEGIN
+  UPDATE inquiries
+     SET email_sent_at = now()
+   WHERE inquiry_id = p_inquiry_id;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.mark_inquiry_email_sent(uuid)
+  TO anon, authenticated;


### PR DESCRIPTION
## Summary

The committed `POST /api/inquiries` has been silently 500'ing in prod since whichever migration tightened RLS on `inquiries` — the anon Supabase client cannot directly insert into the table despite the `WITH CHECK (true)` policy. Net effect: every inquiry submitted from a listing page since then has been lost. The lone row in the prod table is a manual seed.

This PR routes all anon writes through the existing `submit_inquiry()` SECURITY DEFINER RPC (the actual supported path in prod) and adds the missing notification + anti-spam plumbing called for in the approved plan ahead of May 2026 outreach.

### What ships

- **migrations/019** — `submitter_ip TEXT` + `email_sent_at TIMESTAMPTZ` on `inquiries`, plus an IP/created_at index.
- **migrations/020** — replaces `submit_inquiry()` to accept `p_submitter_ip` and enforce 5 inquiries / IP / hour internally (raises `RATE_LIMITED`, errcode `P0003`); adds `mark_inquiry_email_sent(uuid)` helper.
- **route** — calls the RPC, maps `P0001/P0002/P0003` → `403/404/429`, sends Resend email (`replyTo: student_email`) using the already-verified `alerts@studentx.gr` sender, fail-soft on email so the inquiry persists even if Resend errors.
- **honeypot** — hidden `website` field on the form; server returns a fake `201` when populated so bots don't learn to bypass.
- **inbox badge** — `GET /api/landlord/inquiries?counts=1` returns `pending_count` for the soon-to-land UI badge (still auth-gated → 401 unauth).
- **email template** — Resend HTML modeled on `digest.js` styling; landlord can hit Reply to respond directly to the student.

### Why one bundled PR

App code depends on the migration columns being present at runtime, and migrations 019 + 020 have **already been applied to prod Supabase** (see Test plan). Splitting just adds a DB-only PR that's effectively a documentation receipt.

### Out of scope (per the approved plan)

Student confirmation email, CAPTCHA, exposing landlord email on listings, frontend rendering of the inbox badge, EL localisation of the email + new server-side error strings.

## PM review

PM subagent reviewed pre-merge: **SHIP WITH FOLLOW-UPS**. Their main flag — that I'd hardcoded an unverified `inquiries@studentx.gr` `from:` address — is fixed in this branch (now matches the verified `alerts@studentx.gr` used by `saved-searches-digest`). Other follow-ups (email body i18n, server error i18n, idempotent `mark_inquiry_email_sent`) are documented as separate tickets — see linked issue for the email-sent hardening.

## Test plan

- [x] Migration 019 applied to prod via supabase MCP (`apply_migration`); columns present in `inquiries`.
- [x] Migration 020 applied to prod; new `submit_inquiry` 7-arg signature live, old 6-arg dropped, `mark_inquiry_email_sent` granted to anon/authenticated.
- [x] Happy path: `POST /api/inquiries` → 201, row inserted with `submitter_ip` set, status=`pending`.
- [x] Honeypot: non-empty `website` → 201 with `inquiry_id: "blocked"`, no row inserted.
- [x] Rate limit: 5 successive submissions from same IP → 201; 6th → 429.
- [x] Email-failure resilience: when landlord row has no email, route logs `console.warn` and still returns 201 (no 500).
- [x] Counts endpoint without auth → 401.
- [x] Honeypot DOM rendered off-screen (`x: -10007`, `aria-hidden`, `tabIndex=-1`, `autocomplete=off`).
- [x] All 5 PLAN_VERIFY test rows cleaned up; only the original baseline row remains in prod.
- [ ] Send one real test email post-merge against a landlord with an email on file (none exist on the seeded landlord 0101) and confirm receipt + `email_sent_at` is set.
- [ ] Confirm `alerts@studentx.gr` is verified in the Resend dashboard before announcing the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)