### PR TITLE
fix: restore non-localized route shims (revert #6)

### DIFF
--- a/src/app/landlord/dashboard/page.js
+++ b/src/app/landlord/dashboard/page.js
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/el/landlord/dashboard');
+}

--- a/src/app/landlord/forgot-password/page.js
+++ b/src/app/landlord/forgot-password/page.js
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/el/landlord/forgot-password');
+}

--- a/src/app/landlord/inquiries/page.js
+++ b/src/app/landlord/inquiries/page.js
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/el/landlord/inquiries');
+}

--- a/src/app/landlord/listings/[id]/edit/page.js
+++ b/src/app/landlord/listings/[id]/edit/page.js
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation';
+
+export default async function Page({ params }) {
+  const { id } = await params;
+  redirect(`/el/landlord/listings/${id}/edit`);
+}

--- a/src/app/landlord/listings/new/page.js
+++ b/src/app/landlord/listings/new/page.js
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/el/landlord/listings/new');
+}

--- a/src/app/landlord/login/page.js
+++ b/src/app/landlord/login/page.js
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/el/landlord/login');
+}

--- a/src/app/landlord/onboarding/page.js
+++ b/src/app/landlord/onboarding/page.js
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/el/landlord/onboarding');
+}

--- a/src/app/landlord/reset-password/page.js
+++ b/src/app/landlord/reset-password/page.js
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/el/landlord/reset-password');
+}

--- a/src/app/landlord/signup/page.js
+++ b/src/app/landlord/signup/page.js
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/el/landlord/signup');
+}

--- a/src/app/landlord/verify-email/page.js
+++ b/src/app/landlord/verify-email/page.js
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/el/landlord/verify-email');
+}

--- a/src/app/listing/[id]/page.js
+++ b/src/app/listing/[id]/page.js
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation';
+
+export default async function Page({ params }) {
+  const { id } = await params;
+  redirect(`/el/listing/${id}`);
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/el');
+}

--- a/src/app/results/page.js
+++ b/src/app/results/page.js
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/el/results');
+}


### PR DESCRIPTION
## Summary

Reverts PR #6. The 13 redirect shims it removed were doing real work — next-intl middleware does NOT actually rewrite/redirect un-prefixed paths in this Next.js 16.2.1 + next-intl 4.9.0 setup, despite the \`localePrefix: 'as-needed'\` config suggesting it should.

## Why my pre-merge smoke test missed this

In PR #6 I tested via fetch from a long-running dev server and got HTTP 200 with redirects to \`/el/...\`. That worked because the Turbopack dev server still had the just-deleted shim routes compiled in its in-memory manifest. A fresh dev server (or a real production deploy) does not have those routes — and middleware is not picking up the slack.

## Repro / verification

**With main as-is (post PR #6 merge), fresh dev server:**
\`\`\`
/                  => 404
/results           => 404
/listing/test-id   => 404
/landlord/login    => 404
/landlord/dashboard => 404
/el                => 200 ✅
/en/landlord/login => 200 ✅
\`\`\`

**With this revert applied:**
\`\`\`
/                  => 200, final /el ✅
/results           => 200, final /el/results ✅
/listing/test-id   => 200, final /el/listing/test-id ✅
/landlord/login    => 200, final /el/landlord/login ✅
/landlord/dashboard => 200, final /el/landlord/dashboard ✅
/el                => 200 ✅
/en/landlord/login => 200 ✅
\`\`\`

I also confirmed via debug logging that the next-intl middleware never fires on un-prefixed paths in this setup (regardless of matcher pattern, file location, or extension). The shims are not redundant — they are the actual mechanism.

## Test plan

- [x] Fresh dev server with revert applied: all 7 tested paths return HTTP 200
- [ ] Workers Builds CI green on PR
- [ ] Confirm production behavior matches dev (Cloudflare Workers preview URL, if available)
- [ ] PM review per project SOP

## Follow-up

Worth investigating *why* next-intl middleware isn't firing in this codebase — could be a Next 16.2.1 + next-intl 4.9.0 compat issue, a config problem, or a known regression upstream. If middleware can be made to work, the shims could be removed in a future PR. Filing as a separate concern; not blocking this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)