### PR TITLE
fix(security): make mark_inquiry_email_sent idempotent

### DIFF
--- a/supabase/migrations/021_mark_inquiry_email_sent_idempotent.sql
+++ b/supabase/migrations/021_mark_inquiry_email_sent_idempotent.sql
@@ -1,0 +1,26 @@
+-- ============================================================
+-- Migration 021: Make mark_inquiry_email_sent() idempotent.
+-- ============================================================
+-- The original helper (added in 020) did an unconditional UPDATE,
+-- so anyone with a leaked inquiry_id could repeatedly bump
+-- email_sent_at to now() and poison any future
+-- "WHERE email_sent_at IS NULL" backfill. Restrict the UPDATE to
+-- rows that have not yet been marked sent — first call wins,
+-- subsequent calls are no-ops.
+
+CREATE OR REPLACE FUNCTION public.mark_inquiry_email_sent(p_inquiry_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+BEGIN
+  UPDATE inquiries
+     SET email_sent_at = now()
+   WHERE inquiry_id = p_inquiry_id
+     AND email_sent_at IS NULL;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.mark_inquiry_email_sent(uuid)
+  TO anon, authenticated;


### PR DESCRIPTION
## Summary
- Replace `mark_inquiry_email_sent(p_inquiry_id uuid)` with an idempotent version that only updates rows where `email_sent_at IS NULL`.
- Closes the abuse vector where anyone with a leaked `inquiry_id` could repeatedly call the helper to bump `email_sent_at`, poisoning any future `WHERE email_sent_at IS NULL` backfill.
- Single migration file, no app code changes — the existing single caller in \`src/app/api/inquiries/route.js\` calls the function exactly once per inquiry and benefits transparently.

## Test plan
- [x] Apply migration to dev via Supabase MCP
- [x] Insert a test inquiry, call \`mark_inquiry_email_sent\` twice, confirm the second call does NOT overwrite the timestamp
- [x] Delete the test row
- [x] \`grep\` repo: only caller is \`src/app/api/inquiries/route.js:160\` — single-shot call, behaviour unchanged for the happy path
- [ ] CI green

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)