### PR TITLE
style: complete --color-night migration to teal (#01828D)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,16 +11,16 @@
   --color-gold: #B8860B;        /* Seal gold — verified pills, focus rings, partner seals ONLY */
   --color-stone: #FAF8F3;       /* Canvas / page background */
   --color-parchment: #F0EBDF;   /* Surface / cards / inputs */
-  --color-night: #0A1436;       /* Ink — body text, dark surfaces */
+  --color-night: #01828D;       /* Ink / dark surfaces — repointed to teal per design directive */
 
   /* Legacy aliases — repointed to Propylaea values so existing components */
   /* using these utilities pick up the new palette without manual migration. */
   /* Remove once every page is migrated to the new tokens. */
   --color-navy: #01828D;
-  --color-midnight: #0A1436;
-  --color-ink: #0A1436;
+  --color-midnight: #01828D;
+  --color-ink: #01828D;
   --color-white: #FFFFFF;
-  --color-text: #0A1436;
+  --color-text: #01828D;
   --color-gray-light: #F0EBDF;
 }
 

--- a/src/templates/email/confirmation.js
+++ b/src/templates/email/confirmation.js
@@ -23,7 +23,7 @@ export function confirmationEmailHtml({ label, manageUrl, frequency }) {
         <table width="560" cellpadding="0" cellspacing="0" style="background:#F0EBDF;border-radius:12px;overflow:hidden;border:1px solid #E5DFD0;">
           <!-- Header -->
           <tr>
-            <td style="background:#0A1436;padding:24px 32px;">
+            <td style="background:#01828D;padding:24px 32px;">
               <p style="margin:0;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:11px;font-weight:700;letter-spacing:0.18em;text-transform:uppercase;color:#B8860B;">StudentX</p>
               <p style="margin:4px 0 0;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:11px;color:#FAF8F3B3;">Student Housing · Thessaloniki</p>
             </td>
@@ -31,7 +31,7 @@ export function confirmationEmailHtml({ label, manageUrl, frequency }) {
           <!-- Body -->
           <tr>
             <td style="padding:32px;">
-              <h1 style="margin:0 0 8px;font-family:'EB Garamond',Garamond,Georgia,'Times New Roman',serif;font-size:24px;font-weight:600;color:#0A1436;letter-spacing:-0.01em;">${title}</h1>
+              <h1 style="margin:0 0 8px;font-family:'EB Garamond',Garamond,Georgia,'Times New Roman',serif;font-size:24px;font-weight:600;color:#01828D;letter-spacing:-0.01em;">${title}</h1>
               <p style="margin:0 0 24px;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:15px;color:#555;line-height:1.6;">
                 You will receive a ${freqLabel} digest whenever new listings match your saved filters.
               </p>

--- a/src/templates/email/digest.js
+++ b/src/templates/email/digest.js
@@ -28,7 +28,7 @@ export function digestEmailHtml({ label, listings, manageUrl, appUrl }) {
               <img src="${photo}" width="80" height="60" alt="" style="border-radius:6px;object-fit:cover;display:block;" />
             </td>` : ''}
             <td style="vertical-align:top;">
-              <p style="margin:0 0 4px;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;color:#0A1436;">${price}</p>
+              <p style="margin:0 0 4px;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;color:#01828D;">${price}</p>
               ${type ? `<p style="margin:0 0 2px;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#555;">${type}${neighborhood ? ' · ' + neighborhood : ''}</p>` : ''}
               <a href="${listingUrl}" style="display:inline-block;margin-top:8px;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;font-weight:600;color:#B8860B;text-decoration:none;">View listing →</a>
             </td>
@@ -52,7 +52,7 @@ export function digestEmailHtml({ label, listings, manageUrl, appUrl }) {
         <table width="560" cellpadding="0" cellspacing="0" style="background:#F0EBDF;border-radius:12px;overflow:hidden;border:1px solid #E5DFD0;">
           <!-- Header -->
           <tr>
-            <td style="background:#0A1436;padding:24px 32px;">
+            <td style="background:#01828D;padding:24px 32px;">
               <p style="margin:0;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:11px;font-weight:700;letter-spacing:0.18em;text-transform:uppercase;color:#B8860B;">StudentX</p>
               <p style="margin:4px 0 0;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:11px;color:#FAF8F3B3;">Student Housing · Thessaloniki</p>
             </td>
@@ -60,7 +60,7 @@ export function digestEmailHtml({ label, listings, manageUrl, appUrl }) {
           <!-- Body -->
           <tr>
             <td style="padding:32px;">
-              <h1 style="margin:0 0 8px;font-family:'EB Garamond',Garamond,Georgia,'Times New Roman',serif;font-size:24px;font-weight:600;color:#0A1436;letter-spacing:-0.01em;">${title}</h1>
+              <h1 style="margin:0 0 8px;font-family:'EB Garamond',Garamond,Georgia,'Times New Roman',serif;font-size:24px;font-weight:600;color:#01828D;letter-spacing:-0.01em;">${title}</h1>
               <p style="margin:0 0 24px;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:15px;color:#555;line-height:1.6;">
                 Here are the latest listings that match your saved search:
               </p>


### PR DESCRIPTION
## Summary

Repoints the Propylaea v2 brand-ink token from `#0A1436` (dark blue-black) to `#01828D` (Propylaea teal), finishing an in-progress design-token migration. Body text, landlord sidebar, auth split-panel brand panel, all headings, and email header bands shift from dark ink to teal.

## (1) What tokens changed

`src/app/globals.css` — 4 hex literals updated:

| Token | Before | After |
|---|---|---|
| `--color-night` | `#0A1436` | `#01828D` |
| `--color-midnight` (legacy alias) | `#0A1436` | `#01828D` |
| `--color-ink` (legacy alias) | `#0A1436` | `#01828D` |
| `--color-text` (legacy alias) | `#0A1436` | `#01828D` |

The `@theme inline { --color-night: var(--color-night) }` exposure to Tailwind utilities and the `body { color: var(--color-night) }` base rule pick up the new value automatically — no class renames needed. Every `text-night`, `bg-night`, `border-night/N`, `text-gray-dark`, etc. retains its original semantic name and now resolves to teal.

`src/templates/email/{digest,confirmation}.js` — 5 inline hex literals updated (`#0A1436` → `#01828D`) for the header background and h1 in both templates plus the listing-price color in `digest.js`. Email clients can't read CSS vars, so these have to be literal.

Total surface: 8 hex changes, 3 files, +9/-9 lines.

## (2) Why this finishes a started migration

`globals.css` already had `--color-navy: #01828D` (the *other* dark-ink alias) repointed to teal in the v2 design system rollout — the comment in the file calls it out: "Legacy aliases — repointed to Propylaea values so existing components using these utilities pick up the new palette without manual migration." Only `--color-night`, `--color-midnight`, `--color-ink`, and `--color-text` were left on the old hex, creating a split where some surfaces using `text-navy` were already teal but adjacent surfaces using `text-night` / `text-ink` / `text-gray-dark` were still dark blue-black.

This PR closes that gap. After merge, all five tokens point to the same teal value and the system has a single brand-ink color again.

## (3) Pre-approval

PM has pre-approved the design direction (teal-everywhere for dark surfaces). No further design review needed; this PR is purely the implementation that delivers what was already signed off.

## Visual impact

- Body text becomes teal (was dark blue-black)
- Landlord sidebar background (`bg-night`) becomes teal
- Auth split-panel brand panel (`bg-night`) becomes teal
- All headings (`text-night`, `text-midnight`, `text-ink`) become teal
- Email header bands and h1s become teal
- Subtitle on email header (stone-with-70%-alpha on the now-teal background) — contrast drops vs. the dark background; verify in real-client render. If it reads poorly, follow-up can switch the subtitle to plain stone or adjust alpha.

## Test plan

- [x] `npx eslint` on changed files: clean
- [ ] Workers Builds CI green on PR
- [ ] Visual QA post-merge in production at https://studentx.studentx-gr.workers.dev (`/`, `/en/landlord/login`, dashboard, listing detail)
- [ ] Email visual QA: render `digest` + `confirmation` templates with mock data and inspect in Gmail / Apple Mail
- [ ] PM review per project SOP

🤖 Generated with [Claude Code](https://claude.com/claude-code)