### PR TITLE
fix(cron): wire scheduled handler for saved-searches digest

### DIFF
--- a/cf/worker-entry.mjs
+++ b/cf/worker-entry.mjs
@@ -43,9 +43,12 @@ async function runCron(event, env, ctx) {
   const startedAt = Date.now();
 
   try {
+    // Abort before CF's ~30s scheduled-handler limit so we get a logged
+    // timeout instead of a silent kill. ctx.waitUntil still respects this.
     const res = await fetch(url, {
       method: "POST",
       headers: { "x-cron-secret": secret },
+      signal: AbortSignal.timeout(25_000),
     });
     const elapsed = Date.now() - startedAt;
     if (!res.ok) {

--- a/cf/worker-entry.mjs
+++ b/cf/worker-entry.mjs
@@ -1,0 +1,74 @@
+// Cloudflare Worker entry: wraps the OpenNext-generated worker so we can
+// add a `scheduled` handler. `@opennextjs/cloudflare` v1.x produces a worker
+// that only exports `default { fetch(...) }`, so cron triggers configured in
+// wrangler.jsonc would never invoke the digest API route without this shim.
+//
+// The cron API route lives at `src/app/api/cron/saved-searches-digest/route.js`
+// and accepts POST with `?frequency=daily|weekly` + `x-cron-secret` header.
+
+import openNextWorker, {
+  DOQueueHandler,
+  DOShardedTagCache,
+  BucketCachePurge,
+} from "../.open-next/worker.js";
+
+// Re-export OpenNext's Durable Object classes — Cloudflare requires them at
+// the top level of the deployed module.
+export { DOQueueHandler, DOShardedTagCache, BucketCachePurge };
+
+// Map cron expressions in wrangler.jsonc to the digest frequency the route
+// expects. Keep in sync with the `triggers.crons` array.
+const CRON_TO_FREQUENCY = {
+  "0 9 * * *": "daily",
+  "0 9 * * 1": "weekly",
+};
+
+async function runCron(event, env, ctx) {
+  const frequency = CRON_TO_FREQUENCY[event.cron];
+  if (!frequency) {
+    console.error(`[cron] unknown cron expression: ${event.cron}`);
+    return;
+  }
+
+  const appUrl = env.NEXT_PUBLIC_APP_URL;
+  const secret = env.CRON_SECRET;
+  if (!appUrl || !secret) {
+    console.error(
+      "[cron] missing NEXT_PUBLIC_APP_URL or CRON_SECRET — cannot dispatch digest",
+    );
+    return;
+  }
+
+  const url = `${appUrl}/api/cron/saved-searches-digest?frequency=${frequency}`;
+  const startedAt = Date.now();
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "x-cron-secret": secret },
+    });
+    const elapsed = Date.now() - startedAt;
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      console.error(
+        `[cron] ${frequency} digest failed: ${res.status} ${res.statusText} (${elapsed}ms) — ${body.slice(0, 200)}`,
+      );
+      return;
+    }
+    const result = await res.json().catch(() => ({}));
+    console.log(
+      `[cron] ${frequency} digest ok: processed=${result.processed ?? "?"} sent=${result.emailsSent ?? "?"} (${elapsed}ms)`,
+    );
+  } catch (err) {
+    console.error(`[cron] ${frequency} digest threw:`, err);
+  }
+}
+
+export default {
+  fetch: openNextWorker.fetch,
+  async scheduled(event, env, ctx) {
+    // ctx.waitUntil keeps the worker alive past the synchronous handler return
+    // until the cron POST completes.
+    ctx.waitUntil(runCron(event, env, ctx));
+  },
+};

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,7 +1,10 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "studentx",
-  "main": ".open-next/worker.js",
+  // cf/worker-entry.mjs wraps .open-next/worker.js to add a `scheduled` handler
+  // (OpenNext v1.x doesn't ship one). The wrapper imports the built worker, so
+  // `npm run cf:build` must have run before `wrangler deploy`.
+  "main": "cf/worker-entry.mjs",
   "compatibility_date": "2025-04-01",
   "compatibility_flags": ["nodejs_compat"],
   "assets": {
@@ -9,11 +12,9 @@
     "binding": "ASSETS"
   },
   // Cron triggers: daily at 09:00 UTC and weekly on Mondays at 09:00 UTC.
-  // The scheduled event calls /api/cron/saved-searches-digest via self-fetch.
-  // NOTE: @opennextjs/cloudflare v1.x worker.js does not export a `scheduled`
-  // handler by default. After `npm run build`, wrap the worker via open-next.config.ts
-  // or a post-build script to forward `scheduled` events to the cron API route
-  // using NEXT_PUBLIC_APP_URL + CRON_SECRET. See src/app/api/cron/saved-searches-digest/route.js.
+  // Dispatched via cf/worker-entry.mjs's `scheduled` handler, which POSTs to
+  // /api/cron/saved-searches-digest using NEXT_PUBLIC_APP_URL + CRON_SECRET.
+  // Keep CRON_TO_FREQUENCY in cf/worker-entry.mjs in sync with these patterns.
   "triggers": {
     "crons": [
       "0 9 * * *",   // daily digest


### PR DESCRIPTION
Fixes #16.

## Problem

`@opennextjs/cloudflare` v1.x emits a worker that exports only `default { fetch }` plus three Durable Object classes — no `scheduled` handler. So the cron triggers configured in `wrangler.jsonc` (daily 09:00 UTC + weekly Mondays 09:00 UTC) fire at Cloudflare's edge but have nothing to dispatch into. **Saved-search digests silently never send.**

Latent blocker for the Jul–Sep peak nurture flow. Saved-search digests are part of the value prop landlords expect.

## Fix

Wrap the OpenNext-generated worker rather than patching its output:

- New `cf/worker-entry.mjs` imports `.open-next/worker.js`'s `default` + DO exports, re-exports the DO classes (Cloudflare requires them at module top level), delegates `fetch` to the OpenNext default, and adds a `scheduled` handler that POSTs to `/api/cron/saved-searches-digest?frequency=daily|weekly` using `env.NEXT_PUBLIC_APP_URL` + `env.CRON_SECRET`. `ctx.waitUntil` keeps the worker alive until the self-fetch completes.
- `wrangler.jsonc` `main` repointed to `cf/worker-entry.mjs`. The NOTE comment that flagged the missing handler is now resolved and replaced with a comment pairing the wrapper with the triggers.

**Why wrap instead of post-build patch:** doesn't touch generated code → robust to future OpenNext output changes; wrapper is human-readable and lives in source.

## Verification

`npm run cf:build && npx wrangler deploy --dry-run --outdir=…` succeeds. Inspecting the bundled output:

```
Bundle exports:
  BucketCachePurge
  DOQueueHandler
  DOShardedTagCache
  worker_entry_default as default
Bundle contains scheduled handler: true
Bundle contains cron mapping: true
```

## Test plan

- [x] `npm run cf:build` produces `.open-next/worker.js` and the wrapper resolves the import
- [x] `npx wrangler deploy --dry-run` validates the bundle (no errors)
- [x] Bundle output contains a top-level `default` with `scheduled(` and the cron→frequency map
- [ ] **Manual after merge**: confirm `CRON_SECRET` and `NEXT_PUBLIC_APP_URL` are set as Worker secrets/vars in the Cloudflare dashboard
- [ ] **Manual after merge**: trigger a test cron (e.g. `npx wrangler triggers deploy` + manual scheduled event) and verify a digest actually sends
- [ ] **Manual after merge**: observe the next 09:00 UTC scheduled run in CF logs and verify success
- [ ] PM review per project SOP

🤖 Generated with [Claude Code](https://claude.com/claude-code)