### PR TITLE
fix(cron): make saved-searches digest idempotent (claim-before-send)

### DIFF
--- a/src/app/api/cron/saved-searches-digest/route.js
+++ b/src/app/api/cron/saved-searches-digest/route.js
@@ -96,7 +96,11 @@ export async function POST(request) {
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://studentx.gr';
   const resend = getResend();
   let emailsSent = 0;
-  const now = new Date().toISOString();
+  let alreadyClaimed = 0;
+  // Min interval per frequency. Slightly tighter than the full period so a
+  // cron that runs a few minutes late never gets blocked by its own previous
+  // run, but still wide enough that a retry within seconds/minutes is rejected.
+  const minInterval = frequency === 'weekly' ? '6 days' : '20 hours';
 
   for (const search of searches) {
     try {
@@ -105,6 +109,28 @@ export async function POST(request) {
 
       if (matches.length === 0) continue;
 
+      // Claim the send BEFORE calling Resend. The RPC's conditional UPDATE
+      // ensures only one caller per (saved_search, period) advances
+      // last_notified_at; concurrent or retried callers get false and skip.
+      // See supabase/migrations/022_claim_digest_send.sql.
+      const { data: claimed, error: claimError } = await supabase.rpc('claim_digest_send', {
+        p_saved_search_id: search.id,
+        p_min_interval: minInterval,
+      });
+
+      if (claimError) {
+        console.error(`claim_digest_send failed for ${search.id}:`, claimError);
+        continue;
+      }
+      if (!claimed) {
+        // Another invocation already claimed this period — skip silently.
+        alreadyClaimed++;
+        continue;
+      }
+
+      // From here on: the claim is committed. If Resend throws, this digest
+      // is lost for this period (no resend on retry). For digests this is
+      // the right tradeoff: missing one digest beats double-sending.
       const manageUrl = `${appUrl}/alerts/manage?token=${search.unsubscribe_token}`;
 
       await resend.emails.send({
@@ -120,17 +146,11 @@ export async function POST(request) {
       });
 
       emailsSent++;
-
-      // Update last_notified_at
-      await supabase
-        .from('saved_searches')
-        .update({ last_notified_at: now })
-        .eq('id', search.id);
     } catch (err) {
       console.error(`Error processing saved search ${search.id}:`, err);
       // Continue with next search
     }
   }
 
-  return NextResponse.json({ processed: searches.length, emailsSent });
+  return NextResponse.json({ processed: searches.length, emailsSent, alreadyClaimed });
 }

--- a/supabase/migrations/022_claim_digest_send.sql
+++ b/supabase/migrations/022_claim_digest_send.sql
@@ -1,0 +1,45 @@
+-- ============================================================
+-- Migration 022: Add claim_digest_send() for idempotent digests.
+-- ============================================================
+-- The cron route /api/cron/saved-searches-digest sends a digest
+-- email per active saved_search and then UPDATEs last_notified_at.
+-- If the email send succeeds but the UPDATE fails (network blip,
+-- transient connection issue) — or if Cloudflare retries the
+-- scheduled handler — the next run resends the same digest to the
+-- same recipient.
+--
+-- claim_digest_send() flips the order: the route calls this RPC
+-- BEFORE dispatching to Resend. The conditional UPDATE only succeeds
+-- if last_notified_at is older than p_min_interval (or null). First
+-- caller wins; concurrent / retried callers get false and skip.
+--
+-- Pattern mirrors mark_inquiry_email_sent (021): SECURITY DEFINER
+-- with a narrow conditional UPDATE, callable by anon because the
+-- cron route uses the anon Supabase client (saved_searches has RLS
+-- disabled per its 015 migration — server-side-only table).
+
+CREATE OR REPLACE FUNCTION public.claim_digest_send(
+  p_saved_search_id uuid,
+  p_min_interval    interval
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_updated int;
+BEGIN
+  UPDATE saved_searches
+     SET last_notified_at = now()
+   WHERE id = p_saved_search_id
+     AND is_active = true
+     AND (last_notified_at IS NULL OR last_notified_at < now() - p_min_interval);
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated > 0;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.claim_digest_send(uuid, interval)
+  TO anon, authenticated;


### PR DESCRIPTION
Closes #21.

## Problem

The cron route at `src/app/api/cron/saved-searches-digest/route.js` had a classic "send-then-mark" idempotency hole:

1. Send digest via Resend.
2. UPDATE `saved_searches.last_notified_at = now()`.

If step 1 succeeds but step 2 fails (network blip, transient connection), or if Cloudflare retries the scheduled handler after a partial failure, the next cron run resends the same digest. At peak nurture cadence in Jul–Sep (when send volume scales) this is a real spam risk for both students and landlords.

PM review of PR #20 flagged this and tracked it in #21.

## Fix

Flip the order: **claim before send.**

- New RPC `claim_digest_send(p_saved_search_id, p_min_interval)` — `SECURITY DEFINER`, conditional UPDATE that returns `true` only if `last_notified_at` is null or older than the interval. Concurrent / retried callers get `false`. Pattern mirrors PR #14's `mark_inquiry_email_sent`.
- Route calls `claim_digest_send` **before** `resend.emails.send()`. If `false`, skip silently (counted as `alreadyClaimed` in the response for observability).
- Removed the post-send UPDATE — the RPC already advanced the timestamp.

Min interval: `'20 hours'` for daily, `'6 days'` for weekly. Slightly tighter than the full period so a cron that runs a few minutes late doesn't get blocked by its own previous run, wide enough that retries within seconds/minutes are rejected.

## Trade-off (intentional)

If Resend throws **after** a successful claim, that digest is lost for this period — no resend. **For digests, this is the correct trade-off**: missing one digest is better than double-sending. Inquiry emails (direct user requests) keep their stronger guarantees from PR #14.

## Test plan

- [x] Migration `022_claim_digest_send.sql` written following the project's migration conventions
- [x] Route calls the RPC before send, skips on false
- [x] `npm run build` succeeds
- [ ] **Manual after merge**: apply migration 022 to the Supabase project (`supabase db push` or dashboard SQL editor)
- [ ] **Manual after merge**: in staging, invoke the cron handler twice within 20 hours — verify only one email send per saved_search; second invocation returns `alreadyClaimed > 0`
- [ ] **Manual after merge**: observe the next 09:00 UTC scheduled run in CF logs and verify normal sends complete; check that retries (if any) are rejected
- [ ] PM review per project SOP

🤖 Generated with [Claude Code](https://claude.com/claude-code)