### PR TITLE
fix(results): drop sort_by tautology + capture API error details

### DIFF
--- a/src/app/[locale]/results/page.js
+++ b/src/app/[locale]/results/page.js
@@ -111,14 +111,21 @@ function ResultsContent() {
       if (filters.selectedNeighborhoods.length > 0)
         params.set('neighborhoods', filters.selectedNeighborhoods.join(','));
       if (filters.verifiedOnly) params.set('verified_only', 'true');
-      params.set('sort_by', sortBy === 'price' ? 'price' : 'price');
+      // 'match' is the UI default; the API enforces verified/featured tier
+      // priority in route.js regardless of sort_by, so 'match' collapses to
+      // 'price' asc.
+      params.set('sort_by', 'price');
       params.set('sort_order', sortBy === 'priceDesc' ? 'desc' : 'asc');
 
       const res = await fetch(`/api/listings?${params.toString()}`);
-      if (!res.ok) throw new Error('API error');
+      if (!res.ok) {
+        const detail = await res.text().catch(() => '');
+        throw new Error(`API ${res.status}: ${detail}`);
+      }
       const data = await res.json();
       setListings(data.listings || []);
-    } catch {
+    } catch (err) {
+      console.error('fetchListings failed:', err);
       setError(true);
       setListings([]);
     } finally {


### PR DESCRIPTION
## What

Two small improvements to `src/app/[locale]/results/page.js`'s `fetchListings`, found dirty in the parent worktree at the start of today's multi-instance cleanup and parked. Independent of any other in-flight work.

1. **Drop the `sort_by` tautology.** `params.set('sort_by', sortBy === 'price' ? 'price' : 'price')` was redundant — both branches set the same value. Replaced with a plain `params.set('sort_by', 'price')` plus a comment explaining why: the UI's 'match' default collapses to 'price' asc because the API enforces verified/featured tier priority server-side regardless of `sort_by`.

2. **Capture API error details.** The fetch error path was previously a bare `if (!res.ok) throw new Error('API error')` with `} catch {}` — the actual status and response body were thrown away. Now the catch captures status, body, and `console.error`s the real error before flipping to the error UI state. Better triage when something breaks in prod.

## Why now

Parked since this morning during the multi-instance git cleanup (these edits had ended up on the parent worktree on the `feat/i18n-inquiry-errors-email` branch by mistake). Tying off the loose end.

## Test plan

- [x] `npm run build` succeeds
- [ ] **Manual**: hit `/results` with valid filters — should render normally, no behaviour change
- [ ] **Manual**: simulate an API error (kill the API or hit with malformed params) — should still flip to error UI, but now with a meaningful console.error
- [ ] PM review per project SOP

🤖 Generated with [Claude Code](https://claude.com/claude-code)