### PR TITLE
chore(cf): enable workers_dev for public URL

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,11 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "studentx",
+  // Expose the Worker on Cloudflare's free `*.workers.dev` subdomain so the
+  // deployment has a public URL even before a custom domain is wired up.
+  // The hostname will be `studentx.<account-subdomain>.workers.dev`. Safe
+  // to leave on alongside a future custom domain — both serve the same code.
+  "workers_dev": true,
   // cf/worker-entry.mjs wraps .open-next/worker.js to add a `scheduled` handler
   // (OpenNext v1.x doesn't ship one). The wrapper imports the built worker, so
   // `npm run cf:build` must have run before `wrangler deploy`.


### PR DESCRIPTION
## Why

The Worker has been deploying successfully to Cloudflare since PR #4 (cf:build) but with **no public URL** — `wrangler.jsonc` declares neither `routes` (custom domain) nor `workers_dev: true`. So every deploy lands on the edge unreachable. Today's GlobeLoader merge (PR #25) is live but no one can see it.

`studentx.gr` returns NXDOMAIN — the custom domain isn't set up either.

## What

One line: `"workers_dev": true` in `wrangler.jsonc`.

After this merges and CF Workers Builds redeploys, the site is reachable at:

```
studentx.<account-subdomain>.workers.dev
```

(Account subdomain visible in the CF dashboard once the Worker has been deployed with `workers_dev` enabled.)

Safe to leave on alongside a future custom domain — both targets serve the same Worker code.

## Verification

- [x] `npx wrangler deploy --dry-run` validates the config (no errors, bundle uploads cleanly)
- [ ] **Manual after merge**: visit the dashboard → studentx Worker → "Triggers" / overview to find the activated `*.workers.dev` URL, then load it in a browser
- [ ] **Manual after merge**: take the quiz on that URL, confirm the Globe Loader plays and listings render

🤖 Generated with [Claude Code](https://claude.com/claude-code)