### PR TITLE
fix(cf): bind NEXT_PUBLIC_SUPABASE_* in wrangler vars

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,6 +16,15 @@
     "directory": ".open-next/assets",
     "binding": "ASSETS"
   },
+  // Public Supabase config — these are also inlined into the client bundle
+  // via NEXT_PUBLIC_*, but server-side route handlers (e.g. /api/listings)
+  // read them from process.env at runtime in the Worker. Without these,
+  // every Supabase-backed API route 500s because getSupabase() throws on
+  // missing env. Anon key is RLS-protected and intentionally public.
+  "vars": {
+    "NEXT_PUBLIC_SUPABASE_URL": "https://ecluqurlfbvkxrnoyhaq.supabase.co",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVjbHVxdXJsZmJ2a3hybm95aGFxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQ3ODQ0MzUsImV4cCI6MjA5MDM2MDQzNX0.XspsrkDjv_AWltPgFqBQSocLXU4tBmq1auu_Zg8qTBE"
+  },
   // Cron triggers: daily at 09:00 UTC and weekly on Mondays at 09:00 UTC.
   // Dispatched via cf/worker-entry.mjs's `scheduled` handler, which POSTs to
   // /api/cron/saved-searches-digest using NEXT_PUBLIC_APP_URL + CRON_SECRET.


### PR DESCRIPTION
## Summary
- Adds `vars` block to `wrangler.jsonc` with `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` so server-side route handlers can read them at runtime in the Worker.
- Without this, every Supabase-backed API route on `studentx.studentx-gr.workers.dev` was returning 500 (`getSupabase()` throws on missing env), so `/en/results` rendered empty. Vercel deploy was unaffected.

## Why this is safe
Both values are public by design — anon key is RLS-protected and already shipped in the client bundle. Sensitive keys (`SUPABASE_SERVICE_ROLE_KEY`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `CRON_SECRET`, `ADMIN_EMAILS`) are intentionally **not** in `vars` and remain proper CF secrets.

## PM review
Routed through PM per board directive (STU-94). PM approved: surgical fix, correct scope, public values only, comment explains the why for future maintainers.

## Test plan
- [x] PostgREST direct query returns 4 listings under €550 → DB/RLS healthy
- [x] Vercel `/api/listings?max_budget=550` returns 200 with 4 listings
- [x] Repro: CF `/api/listings` and `/api/neighborhoods` both return 500 pre-fix
- [ ] Post-merge: `Workers Builds: studentx` succeeds and `/en/results?budget=550` renders 4 listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)