### PR TITLE
fix: address 5 high-rated findings from PM live-site audit

### DIFF
--- a/src/app/api/inquiries/route.js
+++ b/src/app/api/inquiries/route.js
@@ -74,6 +74,32 @@ export async function POST(request) {
         { status: 400 }
       );
     }
+
+    // Verify the listing exists *before* validating the rest of the body so
+    // a stale URL surfaces as 404 LISTING_NOT_FOUND immediately, rather than
+    // hiding behind "message must be at least 10 characters" or similar
+    // (the audit flagged this exact precedence as confusing UX). The RPC
+    // re-checks existence under a row lock — this is just for error ordering.
+    const supabase = getSupabase();
+    const { data: existingListing, error: existsError } = await supabase
+      .from("listings")
+      .select("listing_id")
+      .eq("listing_id", listing_id.trim())
+      .maybeSingle();
+    if (existsError) {
+      console.error("Inquiry listing-existence check failed:", existsError);
+      return NextResponse.json(
+        { error_code: "INTERNAL", error: "Failed to verify listing" },
+        { status: 500 }
+      );
+    }
+    if (!existingListing) {
+      return NextResponse.json(
+        { error_code: "LISTING_NOT_FOUND", error: "Listing not found" },
+        { status: 404 }
+      );
+    }
+
     if (!student_name || typeof student_name !== "string" || student_name.trim().length === 0) {
       return NextResponse.json(
         { error_code: "INVALID_INPUT", error: "student_name is required" },
@@ -129,7 +155,6 @@ export async function POST(request) {
       );
     }
 
-    const supabase = getSupabase();
     const submitterIp = getClientIp(request);
 
     const cleanName = student_name.trim();

--- a/src/messages/el.json
+++ b/src/messages/el.json
@@ -6,8 +6,6 @@
     "landlords": "Ιδιοκτήτες",
     "listings": "Αγγελίες",
     "takeTheQuiz": "Κάνε το κουίζ",
-    "programme": "Το πρόγραμμα",
-    "faq": "Συχνές ερωτήσεις",
     "signIn": "Σύνδεση ιδιοκτήτη",
     "menu": "Μενού",
     "openMenu": "Άνοιγμα μενού",
@@ -29,9 +27,6 @@
     "schoolOfMedicine": "Ιατρική Σχολή",
     "firstYears": "Πρωτοετείς",
     "landlordVetting": "Έλεγχος ιδιοκτητών",
-    "contact": "Επικοινωνία",
-    "terms": "Όροι",
-    "privacy": "Απόρρητο",
     "officialPartner": "Επίσημος συνεργάτης στέγασης",
     "thessaloniki": "Θεσσαλονίκη"
   },

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -6,8 +6,6 @@
     "landlords": "Landlords",
     "listings": "Listings",
     "takeTheQuiz": "Take the quiz",
-    "programme": "The programme",
-    "faq": "FAQ",
     "signIn": "Landlord login",
     "menu": "Menu",
     "openMenu": "Open menu",
@@ -29,9 +27,6 @@
     "schoolOfMedicine": "School of Medicine",
     "firstYears": "First-years",
     "landlordVetting": "Landlord vetting",
-    "contact": "Contact",
-    "terms": "Terms",
-    "privacy": "Privacy",
     "officialPartner": "Official housing partner",
     "thessaloniki": "Thessaloniki"
   },

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,7 +23,15 @@
   // missing env. Anon key is RLS-protected and intentionally public.
   "vars": {
     "NEXT_PUBLIC_SUPABASE_URL": "https://ecluqurlfbvkxrnoyhaq.supabase.co",
-    "NEXT_PUBLIC_SUPABASE_ANON_KEY": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVjbHVxdXJsZmJ2a3hybm95aGFxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQ3ODQ0MzUsImV4cCI6MjA5MDM2MDQzNX0.XspsrkDjv_AWltPgFqBQSocLXU4tBmq1auu_Zg8qTBE"
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVjbHVxdXJsZmJ2a3hybm95aGFxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQ3ODQ0MzUsImV4cCI6MjA5MDM2MDQzNX0.XspsrkDjv_AWltPgFqBQSocLXU4tBmq1auu_Zg8qTBE",
+    // Canonical/sitemap/og:url + landlord email links all resolve from these.
+    // Code defaults to https://studentx.gr but the live deploy is the
+    // workers.dev host until DNS flips — without these bindings, every
+    // canonical points to a hostname Google can't fetch and every email
+    // button links somewhere broken. Flip back to studentx.gr (or just
+    // remove these lines, since the code falls back to it) once DNS lands.
+    "NEXT_PUBLIC_SITE_URL": "https://studentx.studentx-gr.workers.dev",
+    "NEXT_PUBLIC_APP_URL": "https://studentx.studentx-gr.workers.dev"
   },
   // Cron triggers: daily at 09:00 UTC and weekly on Mondays at 09:00 UTC.
   // Dispatched via cf/worker-entry.mjs's `scheduled` handler, which POSTs to


### PR DESCRIPTION
## Summary
The 2026-04-26 PM audit flagged 7 High items. **5 land here**, **1 was a no-op** (live sitemap is already correct), and **2 are deferred** as data/content work.

## In scope (5)
- **H1 — Canonicals/sitemap point at studentx.gr while live deploy is workers.dev.** Bound `NEXT_PUBLIC_SITE_URL` and `NEXT_PUBLIC_APP_URL` in `wrangler.jsonc` to the workers.dev hostname so canonicals/og:url/email links resolve to a host crawlers can actually fetch. Mirrors the pattern from [studentx#27](https://github.com/MichaelChar/StudentX/pull/27). Flip back to `studentx.gr` (or just remove the lines — code falls back to it) the moment DNS lands.
- **H2 — Audit claimed sitemap had `/el/listing/...` URLs that redirect-chain.** Verified against live: `curl .../sitemap.xml | grep -c '/el/'` → 0. No code change. Audit was wrong on this one.
- **H5 — Dead footer i18n keys.** Removed `footer.contact / .terms / .privacy / .faq` and `nav.faq / nav.programme`. Conservative scope: kept column-header keys (`colCompany`, `colProgramme`) since the Footer.js comment indicates those columns will be reactivated when the underlying pages ship.
- **H6 — Inquiry validation order.** Pre-fix: a stale URL (format-valid listing_id but missing row) + short message returned `400 \"message must be at least 10 characters\"`. Now it returns `404 \"Listing not found\"` first. Added a Supabase listing-existence check between the listing_id format check and the rest of body validation. RPC still re-checks under a row lock — this is purely error-precedence.
- **H7 — Audit suspected form contract drift (name vs student_name).** Verified: `InquiryForm.js:42-50` already posts the correct field names. No code change.

## Out of scope (deferred per agreement with PM)
- **H3 — No Verified/Featured seed data.** Sales/onboarding work, not code. Address when the first paying landlord onboards.
- **H4 — Faculty distances are stub values (walk:5, transit:8 across most rows).** Needs proper Distance Matrix integration. PM flagged this as **more time-sensitive than initially implied given the May 2026 outreach kickoff** — recommend a follow-up to soften copy or hide stub rows as an interim before the full backend lands.

## PM review
Reviewed by an independent PM agent before opening — verdict: **APPROVE** after committing (working tree was unstaged at first review) and excluding `.claude/` dev-env churn from the PR. Both addressed.

## Test plan
- [ ] **H1 (post-deploy):** `curl -s https://studentx.studentx-gr.workers.dev/sitemap.xml | head` — first `<loc>` should be `https://studentx.studentx-gr.workers.dev`, NOT `https://studentx.gr`. `curl https://.../en/listing/0100001 | grep canonical` — canonical href should start with the workers.dev hostname.
- [ ] **H6 (post-deploy):** `curl -X POST .../api/inquiries -d '{\"listing_id\":\"9999999\",\"student_name\":\"Test\",\"student_email\":\"a@b.co\",\"message\":\"short\"}'` → expect `404 LISTING_NOT_FOUND`, not `400 INVALID_INPUT`.
- [ ] **H6 sanity:** same call with a real listing_id (`0100001`) and short message → still expect `400 \"message must be at least 10 characters\"`.
- [ ] **H5 (post-deploy):** view-source on `/en` and `/`. Footer should not contain the strings `Contact`, `Terms`, `Privacy`, or `FAQ` as standalone link text. Locally confirmed in dev preview before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)