### PR TITLE
fix(results,inquiry): URL state + one-click inquiry modal (PR-A)

### DIFF
--- a/src/app/[locale]/results/page.js
+++ b/src/app/[locale]/results/page.js
@@ -24,6 +24,7 @@ import GlobeLoader from '@/components/GlobeLoader';
 const PROPERTY_TYPES = ['Studio', '1-Bedroom', '2-Bedroom', 'Room in shared apartment'];
 const BUDGET_MIN = 150;
 const BUDGET_MAX = 1200;
+const DEFAULT_BUDGET = 900;
 
 function MapLoadingFallback() {
   return (
@@ -84,7 +85,10 @@ function ResultsContent() {
       usp.has('budget') || usp.has('types') || usp.has('neighborhoods');
     if (cameFromQuiz) setShowLoader(true);
   }, []);
-  const [sortBy, setSortBy] = useState('match');
+  const [sortBy, setSortBy] = useState(() => {
+    const s = searchParams.get('sort_by');
+    return s === 'price' || s === 'priceDesc' ? s : 'match';
+  });
   const [viewMode, setViewMode] = useState(
     searchParams.get('view') === 'map' ? 'map' : 'list'
   );
@@ -92,11 +96,16 @@ function ResultsContent() {
   const [saveSearchOpen, setSaveSearchOpen] = useState(false);
   const [filtersMobileOpen, setFiltersMobileOpen] = useState(false);
 
-  const [filters, setFilters] = useState({
-    maxBudget: 900,
-    selectedTypes: [],
-    selectedNeighborhoods: [],
-    verifiedOnly: false,
+  const [filters, setFilters] = useState(() => {
+    const budget = Number(searchParams.get('budget'));
+    const types = searchParams.get('types');
+    const neighborhoods = searchParams.get('neighborhoods');
+    return {
+      maxBudget: Number.isFinite(budget) && budget > 0 ? budget : DEFAULT_BUDGET,
+      selectedTypes: types ? types.split(',').filter(Boolean) : [],
+      selectedNeighborhoods: neighborhoods ? neighborhoods.split(',').filter(Boolean) : [],
+      verifiedOnly: searchParams.get('verified_only') === 'true',
+    };
   });
 
   useEffect(() => {
@@ -106,21 +115,31 @@ function ResultsContent() {
       .catch(() => {});
   }, []);
 
-  // Seed filters from URL params on mount
-  const seededRef = useRef(false);
+  // Sync filter/sort/view state INTO the URL so refresh + share + back
+  // preserve what the user picked. The initial state is seeded from the
+  // URL above, so this effect is a no-op on first render and writes only
+  // on actual user changes. Uses replaceState (not router.replace) so we
+  // don't trigger an unnecessary RSC re-render — the listing fetch reads
+  // from local state, not useSearchParams. Note: the URL params here are
+  // the user-facing names (budget/types/neighborhoods), not the API names
+  // (max_budget); fetchListings translates between them.
   useEffect(() => {
-    if (seededRef.current) return;
-    seededRef.current = true;
-    const budget = searchParams.get('budget');
-    const types = searchParams.get('types');
-    const neighborhoods = searchParams.get('neighborhoods');
-    setFilters((prev) => ({
-      ...prev,
-      maxBudget: budget ? Number(budget) : prev.maxBudget,
-      selectedTypes: types ? types.split(',') : [],
-      selectedNeighborhoods: neighborhoods ? neighborhoods.split(',') : [],
-    }));
-  }, [searchParams]);
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams();
+    if (filters.maxBudget !== DEFAULT_BUDGET) params.set('budget', String(filters.maxBudget));
+    if (filters.selectedTypes.length > 0)
+      params.set('types', filters.selectedTypes.join(','));
+    if (filters.selectedNeighborhoods.length > 0)
+      params.set('neighborhoods', filters.selectedNeighborhoods.join(','));
+    if (filters.verifiedOnly) params.set('verified_only', 'true');
+    if (sortBy !== 'match') params.set('sort_by', sortBy);
+    if (viewMode === 'map') params.set('view', 'map');
+    const next = params.toString();
+    const current = window.location.search.replace(/^\?/, '');
+    if (next === current) return;
+    const url = next ? `${window.location.pathname}?${next}` : window.location.pathname;
+    window.history.replaceState(null, '', url);
+  }, [filters, sortBy, viewMode]);
 
   const fetchListings = useCallback(async () => {
     setLoading(true);

--- a/src/components/InquiryForm.js
+++ b/src/components/InquiryForm.js
@@ -11,10 +11,14 @@ const ERROR_CODES = new Set([
   'INTERNAL',
 ]);
 
-export default function InquiryForm({ listingId, facultyId }) {
+export default function InquiryForm({ listingId, facultyId, defaultOpen = false }) {
   const t = useTranslations('inquiry');
   const tErrors = useTranslations('inquiry.errors');
-  const [open, setOpen] = useState(false);
+  // Standalone use renders a "Contact landlord" trigger first; when the
+  // form is mounted inside an explicit modal/dialog the parent is already
+  // a "send inquiry" affordance, so callers pass defaultOpen to skip the
+  // doubled click.
+  const [open, setOpen] = useState(defaultOpen);
   const [form, setForm] = useState({
     student_name: '',
     student_email: '',

--- a/src/components/listing/ContactRail.js
+++ b/src/components/listing/ContactRail.js
@@ -81,7 +81,7 @@ export default function ContactRail({ listing }) {
                 <Icon name="x" className="w-5 h-5" />
               </button>
             </div>
-            <InquiryForm listingId={listing.listing_id} />
+            <InquiryForm listingId={listing.listing_id} defaultOpen />
           </Card>
         </div>
       )}


### PR DESCRIPTION
## Summary
The original 2026-04-26 PM audit's "what's still missing" list was the interactive layer (filters / map / inquiry form / language toggle / mobile drawer / console errors / hydration). This session ran a live-browser pass against the dev preview and surfaced **four real UX bugs**. This PR fixes the two that are real visible regressions; the other two are dev-only quirks already confirmed clean in production.

## Fixed

| | Bug | Fix |
|---|---|---|
| 1 | Filter clicks on /results don't update the URL | Lazy-init filter state from URL + write-back \`replaceState\` |
| 2 | Sort dropdown changes don't update the URL | Same write-back |
| 3 | Map ↔ List toggle doesn't update the URL | Same write-back |
| 4 | Inquiry modal needs **two clicks** before form fields appear | Add \`defaultOpen\` prop on \`InquiryForm\`; \`ContactRail\` passes it |

## Out of scope (verified harmless or already noted)

- \`/el → /\` redirect chain on locale toggle — audit already documented; one extra hop in production
- Greek strings on \`/en/results\` H1 in **dev mode** — confirmed dev-only quirk; production resolves EN locale correctly per #28 verification
- \`MISSING_MESSAGE: about.ctaQuiz\` errors in **dev console** — confirmed stale dev bytecode from before the M5 PM iteration that removed that key; production renders \`/en/about\` and \`/about\` cleanly

## Implementation

\`src/app/[locale]/results/page.js\`
- Replaced on-mount seed-from-URL \`useEffect\` with a lazy \`useState\` initializer; now seeds \`budget\`, \`types\`, \`neighborhoods\` plus previously-unsupported \`verified_only\`, \`sort_by\`, \`view\`.
- Added write-back \`useEffect\` keyed on \`[filters, sortBy, viewMode]\` that no-ops when the constructed querystring matches the current URL, otherwise calls \`window.history.replaceState\`. \`replaceState\` (not \`router.replace\`) is intentional — the listing fetch reads from local state, not \`useSearchParams\`, so we avoid an unnecessary RSC re-render.
- Extracted \`DEFAULT_BUDGET = 900\` so the initializer fallback and the write-back guard can't drift.
- Removed the now-unused \`seededRef\`.

\`src/components/InquiryForm.js\`
- Added \`defaultOpen = false\` prop. Standalone callers keep the button-then-form pattern; modal callers can skip the inner button.

\`src/components/listing/ContactRail.js\`
- Passes \`defaultOpen\` when mounting \`<InquiryForm>\` in the modal.

## PM review

Reviewed before opening — verdict: **APPROVE** with two non-blocking suggestions, both addressed in this commit:
- Extract \`DEFAULT_BUDGET\` constant (the hardcoded 900 was in two places)
- Add a comment noting page URL params (\`budget\`) differ from API params (\`max_budget\`) intentionally

## Test plan (post-deploy)

- [ ] On \`/en/results\`, click "Ano Poli" neighborhood. URL becomes \`?neighborhoods=Ano%20Poli\`. Refresh — filter still applied.
- [ ] Change sort to "Price — high to low". URL adds \`&sort_by=priceDesc\`.
- [ ] Click Map view toggle. URL adds \`&view=map\`. Click List. URL drops \`view\`.
- [ ] On \`/en/listing/0100001\` click "Send inquiry". Modal opens with **the form fields immediately visible** (was: an inner "Contact landlord" button, two clicks).
- [ ] Standalone \`<InquiryForm>\` use case still shows the "Contact landlord" trigger button first (backward-compatible default).

Note: dev preview verification was inconclusive after a mid-session Next dev-server restart that got stuck in loading state. Lint is clean; logic is small and direct; production is the better verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)