### PR TITLE
fix: ContactRail Send hang + auth-gated route caching

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -34,12 +34,12 @@ const SECURITY_HEADERS = [
   },
 ];
 
-// Marketing/listing HTML routes should be CDN-cacheable. OpenNext (and the
+// Marketing HTML routes should be CDN-cacheable. OpenNext (and the
 // dynamic-page default) serves `private, no-cache, no-store, must-revalidate`
 // for any page that touches request-scoped APIs (next-intl reads headers),
 // which kills shared caching for a public catalog. Override here. Excludes
-// /api/* (per-route control already set), /landlord/* (auth, must stay
-// private), and _next/static/.
+// /api/* (per-route control already set), auth-gated surfaces (/landlord/*,
+// /listing/*, /student/*), and _next/static/.
 //   public               — any cache (browser + CDN) may store the response
 //   s-maxage=300         — CDN holds for 5 min
 //   stale-while-revalidate=86400 — serve stale up to 1 day while refetching
@@ -70,7 +70,10 @@ const nextConfig = {
         source: '/:path*',
         headers: SECURITY_HEADERS,
       },
-      // Auth-bound landlord surfaces stay private.
+      // Auth-bound surfaces stay private. /listing/[id] is gated by
+      // requireStudent and renders an AuthGate body to anonymous users —
+      // CDN-caching it would serve one viewer's gated/non-gated body to
+      // another. /student/* (account, inquiries) is per-session.
       {
         source: '/landlord/:path*',
         headers: PRIVATE_CACHE_HEADERS,
@@ -79,11 +82,28 @@ const nextConfig = {
         source: '/:locale(en)/landlord/:path*',
         headers: PRIVATE_CACHE_HEADERS,
       },
+      {
+        source: '/listing/:path*',
+        headers: PRIVATE_CACHE_HEADERS,
+      },
+      {
+        source: '/:locale(en)/listing/:path*',
+        headers: PRIVATE_CACHE_HEADERS,
+      },
+      {
+        source: '/student/:path*',
+        headers: PRIVATE_CACHE_HEADERS,
+      },
+      {
+        source: '/:locale(en)/student/:path*',
+        headers: PRIVATE_CACHE_HEADERS,
+      },
       // All other HTML routes are public-cacheable. The negative lookahead
-      // skips api / _next / landlord / files with extensions (favicon etc.).
+      // skips api / _next / auth-gated surfaces / files with extensions
+      // (favicon etc.).
       {
         source:
-          '/((?!api|_next|landlord|en/landlord|.*\\..*).*)',
+          '/((?!api|_next|landlord|en/landlord|listing|en/listing|student|en/student|.*\\..*).*)',
         headers: PUBLIC_CACHE_HEADERS,
       },
     ];

--- a/src/app/[locale]/landlord/listings/[id]/edit/page.js
+++ b/src/app/[locale]/landlord/listings/[id]/edit/page.js
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { useRouter } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { useAccessToken } from '@/lib/useAccessToken';
 import ListingForm from '@/components/ListingForm';
 import { useTranslations } from 'next-intl';
 
@@ -13,6 +14,7 @@ import Button from '@/components/ui/Button';
 export default function EditListingPage() {
   const t = useTranslations('landlord.editListing');
   const router = useRouter();
+  const accessToken = useAccessToken();
   const { id } = useParams();
   const [initialValues, setInitialValues] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -58,9 +60,6 @@ export default function EditListingPage() {
   }, [id, t]);
 
   async function handleSubmit(formData) {
-    const supabase = getSupabaseBrowser();
-    const { data: { session } } = await supabase.auth.getSession();
-
     const payload = {
       ...formData,
       monthly_price: formData.monthly_price !== '' ? parseFloat(formData.monthly_price) : null,
@@ -73,7 +72,7 @@ export default function EditListingPage() {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${session.access_token}`,
+        Authorization: `Bearer ${accessToken}`,
       },
       body: JSON.stringify(payload),
     });

--- a/src/app/[locale]/landlord/listings/new/page.js
+++ b/src/app/[locale]/landlord/listings/new/page.js
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from '@/i18n/navigation';
-import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { useAccessToken } from '@/lib/useAccessToken';
 import ListingForm from '@/components/ListingForm';
 import { useTranslations } from 'next-intl';
 
@@ -17,6 +17,7 @@ import Button from '@/components/ui/Button';
 export default function NewListingPage() {
   const t = useTranslations('landlord.newListing');
   const router = useRouter();
+  const accessToken = useAccessToken();
 
   const [importUrl, setImportUrl] = useState('');
   const [importState, setImportState] = useState('idle');
@@ -30,10 +31,6 @@ export default function NewListingPage() {
     setImportError('');
 
     try {
-      const supabase = getSupabaseBrowser();
-      const { data: { session } } = await supabase.auth.getSession();
-      const accessToken = session?.access_token;
-
       const res = await fetch('/api/landlord/listings/import-url', {
         method: 'POST',
         headers: {
@@ -65,17 +62,14 @@ export default function NewListingPage() {
       }
 
       setImportState('success');
-    } catch {
+    } catch (err) {
+      console.error('[NewListing] import_url failed:', err);
       setImportState('error');
       setImportError('Something went wrong. Please try again.');
     }
   }
 
   async function handleSubmit(formData) {
-    const supabase = getSupabaseBrowser();
-    const { data: { session } } = await supabase.auth.getSession();
-    const accessToken = session?.access_token;
-
     const payload = {
       ...formData,
       monthly_price: formData.monthly_price ? parseFloat(formData.monthly_price) : null,

--- a/src/app/[locale]/landlord/listings/page.js
+++ b/src/app/[locale]/landlord/listings/page.js
@@ -5,6 +5,7 @@ import { useRouter, Link } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { useAccessToken } from '@/lib/useAccessToken';
 
 import LandlordShell from '@/components/landlord/LandlordShell';
 import Button from '@/components/ui/Button';
@@ -19,6 +20,7 @@ import Icon from '@/components/ui/Icon';
 export default function LandlordListingsPage() {
   const t = useTranslations('landlord.dashboard');
   const router = useRouter();
+  const accessToken = useAccessToken();
   const [listings, setListings] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -51,45 +53,61 @@ export default function LandlordListingsPage() {
   async function handleDelete(listingId) {
     if (!confirm(t('deleteConfirm'))) return;
     setDeleting(listingId);
-    const supabase = getSupabaseBrowser();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) { router.replace('/landlord/login'); return; }
-    const res = await fetch(`/api/landlord/listings/${listingId}`, {
-      method: 'DELETE',
-      headers: { Authorization: `Bearer ${session.access_token}` },
-    });
-    if (res.ok) {
-      setListings((prev) => prev.filter((l) => l.listing_id !== listingId));
-    } else {
+    try {
+      if (!accessToken) {
+        setDeleting(null);
+        router.replace('/landlord/login');
+        return;
+      }
+      const res = await fetch(`/api/landlord/listings/${listingId}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      if (res.ok) {
+        setListings((prev) => prev.filter((l) => l.listing_id !== listingId));
+      } else {
+        alert(t('deleteError'));
+      }
+    } catch (err) {
+      console.error('[LandlordListings] delete failed:', err);
       alert(t('deleteError'));
+    } finally {
+      setDeleting(null);
     }
-    setDeleting(null);
   }
 
   async function handleToggleFeatured(listingId, currentlyFeatured) {
     setTogglingFeatured(listingId);
-    const supabase = getSupabaseBrowser();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) { router.replace('/landlord/login'); return; }
-    const res = await fetch(`/api/landlord/listings/${listingId}`, {
-      method: 'PATCH',
-      headers: {
-        Authorization: `Bearer ${session.access_token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ is_featured: !currentlyFeatured }),
-    });
-    if (res.ok) {
-      setListings((prev) =>
-        prev.map((l) =>
-          l.listing_id === listingId ? { ...l, is_featured: !currentlyFeatured } : l
-        )
-      );
-    } else {
-      const data = await res.json().catch(() => ({}));
-      alert(data.error || t('featuredError'));
+    try {
+      if (!accessToken) {
+        setTogglingFeatured(null);
+        router.replace('/landlord/login');
+        return;
+      }
+      const res = await fetch(`/api/landlord/listings/${listingId}`, {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ is_featured: !currentlyFeatured }),
+      });
+      if (res.ok) {
+        setListings((prev) =>
+          prev.map((l) =>
+            l.listing_id === listingId ? { ...l, is_featured: !currentlyFeatured } : l
+          )
+        );
+      } else {
+        const data = await res.json().catch(() => ({}));
+        alert(data.error || t('featuredError'));
+      }
+    } catch (err) {
+      console.error('[LandlordListings] toggle_featured failed:', err);
+      alert(t('featuredError'));
+    } finally {
+      setTogglingFeatured(null);
     }
-    setTogglingFeatured(null);
   }
 
   return (

--- a/src/app/[locale]/landlord/settings/page.js
+++ b/src/app/[locale]/landlord/settings/page.js
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { useAccessToken } from '@/lib/useAccessToken';
 
 import LandlordShell from '@/components/landlord/LandlordShell';
 import Button from '@/components/ui/Button';
@@ -18,6 +19,7 @@ import Icon from '@/components/ui/Icon';
 */
 export default function LandlordSettingsPage() {
   const t = useTranslations('propylaea.landlord.settings');
+  const accessToken = useAccessToken();
 
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
@@ -77,19 +79,15 @@ export default function LandlordSettingsPage() {
     setError('');
     setSavedTick(false);
 
-    const supabase = getSupabaseBrowser();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) {
-      setError(t('error'));
-      setSubmitting(false);
-      return;
-    }
-
     try {
+      if (!accessToken) {
+        setError(t('error'));
+        return;
+      }
       const res = await fetch('/api/landlord/profile', {
         method: 'PATCH',
         headers: {
-          Authorization: `Bearer ${session.access_token}`,
+          Authorization: `Bearer ${accessToken}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ preferred_locale: preferredLocale }),
@@ -107,7 +105,8 @@ export default function LandlordSettingsPage() {
       // unmount effect can cancel it.
       if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
       savedTimerRef.current = setTimeout(() => setSavedTick(false), 2500);
-    } catch {
+    } catch (err) {
+      console.error('[LandlordSettings] save_profile failed:', err);
       setError(t('error'));
     } finally {
       setSubmitting(false);

--- a/src/app/[locale]/landlord/verification/page.js
+++ b/src/app/[locale]/landlord/verification/page.js
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useRef } from 'react';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { useAccessToken } from '@/lib/useAccessToken';
 
 import LandlordShell from '@/components/landlord/LandlordShell';
 import Button from '@/components/ui/Button';
@@ -9,6 +10,7 @@ import Card from '@/components/ui/Card';
 import Icon from '@/components/ui/Icon';
 
 export default function LandlordVerificationPage() {
+  const accessToken = useAccessToken();
   const [loading, setLoading] = useState(true);
   const [verifiedTier, setVerifiedTier] = useState(null);
   const [latestRequest, setLatestRequest] = useState(null);
@@ -52,21 +54,17 @@ export default function LandlordVerificationPage() {
     setSubmitting(true);
     setSubmitError('');
 
-    const supabase = getSupabaseBrowser();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) {
-      setSubmitError('Session expired. Please sign in again.');
-      setSubmitting(false);
-      return;
-    }
-
-    const formData = new FormData();
-    formData.append('id_document', file);
-
     try {
+      if (!accessToken) {
+        setSubmitError('Session expired. Please sign in again.');
+        return;
+      }
+      const formData = new FormData();
+      formData.append('id_document', file);
+
       const res = await fetch('/api/landlord/verification', {
         method: 'POST',
-        headers: { Authorization: `Bearer ${session.access_token}` },
+        headers: { Authorization: `Bearer ${accessToken}` },
         body: formData,
       });
       const data = await res.json();
@@ -76,7 +74,8 @@ export default function LandlordVerificationPage() {
         setSubmitSuccess(true);
         setLatestRequest({ status: 'pending', submitted_at: new Date().toISOString() });
       }
-    } catch {
+    } catch (err) {
+      console.error('[LandlordVerification] submit failed:', err);
       setSubmitError('Failed to submit. Please try again.');
     } finally {
       setSubmitting(false);

--- a/src/components/BillingSection.js
+++ b/src/components/BillingSection.js
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { useAccessToken } from '@/lib/useAccessToken';
 
 const TIER_STYLES = {
   none: 'bg-gray-100 text-gray-700',
@@ -12,20 +12,14 @@ const TIER_STYLES = {
 
 export default function BillingSection() {
   const t = useTranslations('landlord.billing');
+  const accessToken = useAccessToken();
   const [billing, setBilling] = useState(null);
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState(false);
 
-  async function getToken() {
-    const supabase = getSupabaseBrowser();
-    const { data: { session } } = await supabase.auth.getSession();
-    return session?.access_token;
-  }
-
-  const loadBilling = useCallback(async () => {
+  const loadBilling = useCallback(async (token) => {
     setLoading(true);
     try {
-      const token = await getToken();
       if (!token) return;
 
       const res = await fetch('/api/landlord/billing/subscription', {
@@ -33,25 +27,25 @@ export default function BillingSection() {
       });
 
       if (res.ok) setBilling(await res.json());
-    } catch {
-      // Billing info unavailable
+    } catch (err) {
+      console.error('[BillingSection] load_billing failed:', err);
     } finally {
       setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    loadBilling();
-  }, [loadBilling]);
+    if (accessToken === null) return; // wait for first session resolution
+    loadBilling(accessToken);
+  }, [accessToken, loadBilling]);
 
   async function handleCheckout(tier) {
     setActionLoading(true);
     try {
-      const token = await getToken();
       const res = await fetch('/api/landlord/billing/checkout', {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${accessToken}`,
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ tier }),
@@ -64,6 +58,9 @@ export default function BillingSection() {
         const { error } = await res.json();
         alert(error || t('checkoutError'));
       }
+    } catch (err) {
+      console.error('[BillingSection] checkout failed:', err);
+      alert(t('checkoutError'));
     } finally {
       setActionLoading(false);
     }
@@ -72,10 +69,9 @@ export default function BillingSection() {
   async function handleManageBilling() {
     setActionLoading(true);
     try {
-      const token = await getToken();
       const res = await fetch('/api/landlord/billing/portal', {
         method: 'POST',
-        headers: { Authorization: `Bearer ${token}` },
+        headers: { Authorization: `Bearer ${accessToken}` },
       });
 
       if (res.ok) {
@@ -85,6 +81,9 @@ export default function BillingSection() {
         const { error } = await res.json();
         alert(error || t('portalError'));
       }
+    } catch (err) {
+      console.error('[BillingSection] manage_billing failed:', err);
+      alert(t('portalError'));
     } finally {
       setActionLoading(false);
     }

--- a/src/components/ListingForm.js
+++ b/src/components/ListingForm.js
@@ -17,6 +17,7 @@ const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 export default function ListingForm({ initialValues = {}, onSubmit, submitLabel }) {
   const t = useTranslations('landlord.listingForm');
   const fileInputRef = useRef(null);
+  const [userId, setUserId] = useState('anon');
   const [form, setForm] = useState({
     address: '',
     neighborhood: '',
@@ -49,6 +50,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
     async function loadOptions() {
       const supabase = getSupabaseBrowser();
       const { data: { session } } = await supabase.auth.getSession();
+      if (session?.user?.id) setUserId(session.user.id);
 
       const fetches = [fetch('/api/property-types'), fetch('/api/amenities')];
       if (session?.access_token) {
@@ -117,8 +119,6 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
     setUploading(true);
     try {
       const supabase = getSupabaseBrowser();
-      const { data: { session } } = await supabase.auth.getSession();
-      const userId = session?.user?.id || 'anon';
 
       const uploaded = [];
       for (const file of toUpload) {
@@ -140,6 +140,9 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
       if (uploaded.length > 0) {
         setForm((prev) => ({ ...prev, photos: [...(prev.photos || []), ...uploaded] }));
       }
+    } catch (err) {
+      console.error('[ListingForm] photo_upload failed:', err);
+      setPhotoError(t('photosError'));
     } finally {
       setUploading(false);
       if (fileInputRef.current) fileInputRef.current.value = '';

--- a/src/components/listing/ContactRail.js
+++ b/src/components/listing/ContactRail.js
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRouter } from '@/i18n/navigation';
-import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { useAccessToken } from '@/lib/useAccessToken';
 
 import Button from '@/components/ui/Button';
 import Card from '@/components/ui/Card';
@@ -29,6 +29,7 @@ export default function ContactRail({ listing }) {
   const tListing = useTranslations('listing');
   const tContact = useTranslations('student.contact');
   const router = useRouter();
+  const accessToken = useAccessToken();
   const [open, setOpen] = useState(false);
   const [message, setMessage] = useState('');
   const [sending, setSending] = useState(false);
@@ -45,10 +46,11 @@ export default function ContactRail({ listing }) {
     setSending(true);
 
     try {
-      const supabase = getSupabaseBrowser();
-      const { data: { session } } = await supabase.auth.getSession();
-      if (!session?.access_token) {
+      if (!accessToken) {
         // Shouldn't happen — page is gated — but recover gracefully.
+        // Reset sending before navigating so a slow/aborted route change
+        // doesn't strand the modal in "SENDING…".
+        setSending(false);
         router.push('/student/login');
         return;
       }
@@ -57,7 +59,7 @@ export default function ContactRail({ listing }) {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${session.access_token}`,
+          Authorization: `Bearer ${accessToken}`,
         },
         body: JSON.stringify({
           listing_id: listing.listing_id,
@@ -68,13 +70,14 @@ export default function ContactRail({ listing }) {
       if (!res.ok || !data.inquiry_id) {
         const key = ERROR_TO_KEY[data.error_code] || 'errorGeneric';
         setError(tContact(key));
-        setSending(false);
         return;
       }
 
       router.push(`/student/inquiries/${data.inquiry_id}`);
-    } catch {
+    } catch (err) {
+      console.error('[ContactRail] start_inquiry failed:', err);
       setError(tContact('errorGeneric'));
+    } finally {
       setSending(false);
     }
   }

--- a/src/lib/useAccessToken.js
+++ b/src/lib/useAccessToken.js
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+
+/**
+ * Resolve the current access token at mount and keep it fresh via
+ * onAuthStateChange. Use this in client components instead of calling
+ * supabase.auth.getSession() inside a click/submit handler — that
+ * pattern can deadlock on the navigator.locks-backed auth storage if
+ * a prior auth op didn't release.
+ *
+ * Returns null until the first session load resolves, then the token
+ * (string) or '' if signed out.
+ */
+export function useAccessToken() {
+  const [token, setToken] = useState(null);
+
+  useEffect(() => {
+    const supabase = getSupabaseBrowser();
+    let cancelled = false;
+
+    (async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!cancelled) setToken(session?.access_token ?? '');
+    })();
+
+    const { data: sub } = supabase.auth.onAuthStateChange((_evt, session) => {
+      if (!cancelled) setToken(session?.access_token ?? '');
+    });
+
+    return () => {
+      cancelled = true;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  return token;
+}


### PR DESCRIPTION
## Symptom

A logged-in student opens a listing detail page, clicks **Contact landlord**, types a message, clicks **Send**. The button transitions to "SENDING…" and stays stuck forever — **zero network requests fire**, console clean.

## Root cause

Execution stalls at `await supabase.auth.getSession()` in `src/components/listing/ContactRail.js:49` — the only `await` between `setSending(true)` and the fetch.

Supabase auth-js v2.10.x serializes auth-storage access via `navigator.locks`. If any prior auth op (a stranded `getSession`, an `onAuthStateChange` callback, a token refresh) didn't release the lock, every subsequent `getSession` queues forever. The browser singleton in `src/lib/supabaseBrowser.js` is shared across `Navbar.js`, `SessionSync.js`, `ChatThread.js`, `AuthGateRescue.js`, `LandlordShell.js`, and the landlord pages — the failure mode is real.

## Fix (3 commits)

### 1. `fix(contact-rail): resolve auth token at mount, not per-click`
- New `src/lib/useAccessToken` hook resolves the access token at mount via `getSession` + `onAuthStateChange` and caches it in component state.
- `ContactRail.handleStart` consumes the cached token and never calls `getSession` per click — sidesteps the lock-contention class entirely.
- Wrap the flow in `try/finally` so `setSending(false)` runs on every exit path.
- Reset `sending` *before* `router.push('/student/login')` so a slow/aborted navigation can't strand the modal.
- `console.error` the catch so future failures surface in DevTools.

### 2. `fix(landlord): cache access token at mount in submit handlers (same hang class)`

Audit of all `supabase.auth.getSession()` callsites surfaced **8 more hot-path uses** with the same latent hang. Patched the same way (cached token via `useAccessToken`, `try/finally`, error logging):
- `landlord/settings` profile-save handler
- `landlord/listings` delete + toggle-featured handlers
- `landlord/listings/new` import-url + create handlers
- `landlord/listings/[id]/edit` update handler
- `landlord/verification` ID-document submit handler
- `ListingForm` photo-upload handler (now reads `user_id` from the mount-time session)
- `BillingSection` checkout + portal + load handlers (drop the per-click `getToken()` helper)

Mount-time `getSession()` calls inside `useEffect` are left as-is — they can't strand a user-visible action.

### 3. `fix(cdn): stop public-caching auth-gated /listing/* and /student/* routes`

`next.config.mjs` was marking everything except `/api`, `/_next`, and `/landlord` as `public, s-maxage=300, stale-while-revalidate=86400`. That bucket included:
- `/listing/[id]` — gated by `requireStudent()`; renders an `<AuthGate>` body to anonymous viewers. Public-caching means one viewer's gated/non-gated body could be served to any other user via the CDN.
- `/student/account`, `/student/inquiries/[id]` — per-session.

Added explicit `PRIVATE_CACHE_HEADERS` rules for `/listing/*` and `/student/*` (both locale variants) and updated the catch-all negative lookahead to match.

## Verification

`npm run lint` — clean (pre-existing warning in `cf/worker-entry.mjs` only).
`npm run build` — succeeds.

The original bug is non-deterministic (depends on a stranded auth-lock from prior usage), so a preview-server smoke test can't deterministically prove the fix. The structural change is what makes the bug class impossible.

## Test plan (post-merge, in production)

- [ ] Hard reload `/listing/<id>` while signed in as a student
- [ ] Click "Contact landlord", type a 10+ char message, click Send
- [ ] DevTools Network tab shows `POST /api/inquiries/start` within ~1s
- [ ] Either lands on `/student/inquiries/<id>` chat thread OR surfaces an error in the modal — never stuck on "SENDING…"
- [ ] `/listing/<id>` and `/student/account` responses carry `Cache-Control: private, no-cache, no-store, must-revalidate`
- [ ] Spot-check landlord publish/edit/delete/feature/verify/billing flows still work post-cached-token refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)