### PR TITLE
feat(notifications): per-message email digest for landlords

### DIFF
--- a/cf/worker-entry.mjs
+++ b/cf/worker-entry.mjs
@@ -1,10 +1,7 @@
 // Cloudflare Worker entry: wraps the OpenNext-generated worker so we can
 // add a `scheduled` handler. `@opennextjs/cloudflare` v1.x produces a worker
 // that only exports `default { fetch(...) }`, so cron triggers configured in
-// wrangler.jsonc would never invoke the digest API route without this shim.
-//
-// The cron API route lives at `src/app/api/cron/saved-searches-digest/route.js`
-// and accepts POST with `?frequency=daily|weekly` + `x-cron-secret` header.
+// wrangler.jsonc would never invoke the digest API routes without this shim.
 
 import openNextWorker, {
   DOQueueHandler,
@@ -16,16 +13,20 @@ import openNextWorker, {
 // the top level of the deployed module.
 export { DOQueueHandler, DOShardedTagCache, BucketCachePurge };
 
-// Map cron expressions in wrangler.jsonc to the digest frequency the route
-// expects. Keep in sync with the `triggers.crons` array.
-const CRON_TO_FREQUENCY = {
-  "0 9 * * *": "daily",
-  "0 9 * * 1": "weekly",
+// Map cron expressions in wrangler.jsonc to the route to POST. Keep in sync
+// with the `triggers.crons` array. `path` is the API route under
+// NEXT_PUBLIC_APP_URL; `query` is appended verbatim if present. Adding a new
+// scheduled route is a one-line addition here plus the cron pattern in
+// wrangler.jsonc.
+const CRON_ROUTES = {
+  "0 9 * * *":    { name: "saved-searches-daily",   path: "/api/cron/saved-searches-digest",   query: "frequency=daily" },
+  "0 9 * * 1":    { name: "saved-searches-weekly",  path: "/api/cron/saved-searches-digest",   query: "frequency=weekly" },
+  "*/5 * * * *":  { name: "landlord-message-digest", path: "/api/cron/landlord-message-digest", query: null },
 };
 
-async function runCron(event, env, ctx) {
-  const frequency = CRON_TO_FREQUENCY[event.cron];
-  if (!frequency) {
+async function runCron(event, env) {
+  const route = CRON_ROUTES[event.cron];
+  if (!route) {
     console.error(`[cron] unknown cron expression: ${event.cron}`);
     return;
   }
@@ -34,12 +35,14 @@ async function runCron(event, env, ctx) {
   const secret = env.CRON_SECRET;
   if (!appUrl || !secret) {
     console.error(
-      "[cron] missing NEXT_PUBLIC_APP_URL or CRON_SECRET — cannot dispatch digest",
+      `[cron] ${route.name}: missing NEXT_PUBLIC_APP_URL or CRON_SECRET — cannot dispatch`,
     );
     return;
   }
 
-  const url = `${appUrl}/api/cron/saved-searches-digest?frequency=${frequency}`;
+  const url = route.query
+    ? `${appUrl}${route.path}?${route.query}`
+    : `${appUrl}${route.path}`;
   const startedAt = Date.now();
 
   try {
@@ -54,16 +57,16 @@ async function runCron(event, env, ctx) {
     if (!res.ok) {
       const body = await res.text().catch(() => "");
       console.error(
-        `[cron] ${frequency} digest failed: ${res.status} ${res.statusText} (${elapsed}ms) — ${body.slice(0, 200)}`,
+        `[cron] ${route.name} failed: ${res.status} ${res.statusText} (${elapsed}ms) — ${body.slice(0, 200)}`,
       );
       return;
     }
     const result = await res.json().catch(() => ({}));
     console.log(
-      `[cron] ${frequency} digest ok: processed=${result.processed ?? "?"} sent=${result.emailsSent ?? "?"} (${elapsed}ms)`,
+      `[cron] ${route.name} ok: processed=${result.processed ?? "?"} sent=${result.emailsSent ?? "?"} claimed=${result.alreadyClaimed ?? "?"} (${elapsed}ms)`,
     );
   } catch (err) {
-    console.error(`[cron] ${frequency} digest threw:`, err);
+    console.error(`[cron] ${route.name} threw:`, err);
   }
 }
 
@@ -72,6 +75,6 @@ export default {
   async scheduled(event, env, ctx) {
     // ctx.waitUntil keeps the worker alive past the synchronous handler return
     // until the cron POST completes.
-    ctx.waitUntil(runCron(event, env, ctx));
+    ctx.waitUntil(runCron(event, env));
   },
 };

--- a/src/app/api/cron/landlord-message-digest/route.js
+++ b/src/app/api/cron/landlord-message-digest/route.js
@@ -1,0 +1,135 @@
+import { NextResponse } from 'next/server';
+import { getSupabase } from '@/lib/supabase';
+import { getResend } from '@/lib/resend';
+import {
+  landlordMessageDigestHtml,
+  landlordMessageDigestSubject,
+} from '@/templates/email/landlordMessageDigest';
+
+// Debounce window. One email per inquiry per this interval. Slightly
+// tighter than the cron tick (5 min) so a tick that runs a few seconds
+// late doesn't get rejected by its own previous run, but wide enough
+// to absorb a burst of student messages into a single email.
+const MIN_INTERVAL = '4 minutes 30 seconds';
+
+const FROM_ADDRESS = 'StudentX <alerts@studentx.gr>';
+
+function isCronAuthorized(request) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  const headerSecret = request.headers.get('x-cron-secret');
+  if (headerSecret === secret) return true;
+  const { searchParams } = new URL(request.url);
+  return searchParams.get('secret') === secret;
+}
+
+function resolveLocale(landlordLocale) {
+  if (landlordLocale === 'el' || landlordLocale === 'en') return landlordLocale;
+  return 'el';
+}
+
+export async function POST(request) {
+  if (!isCronAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Kill switch: deploy-time disable without removing the cron trigger.
+  if (process.env.LANDLORD_DIGEST_ENABLED === 'false') {
+    return NextResponse.json({ skipped: 'disabled' });
+  }
+
+  const supabase = getSupabase();
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://studentx.gr';
+
+  const { data: pending, error: fetchError } = await supabase.rpc(
+    'get_pending_landlord_notifications',
+    { p_min_interval: MIN_INTERVAL },
+  );
+
+  if (fetchError) {
+    console.error('[landlord-digest] failed to fetch pending notifications:', fetchError);
+    return NextResponse.json({ error: 'Failed to fetch pending notifications' }, { status: 500 });
+  }
+
+  if (!pending || pending.length === 0) {
+    return NextResponse.json({ processed: 0, emailsSent: 0, alreadyClaimed: 0 });
+  }
+
+  const resend = getResend();
+  let emailsSent = 0;
+  let alreadyClaimed = 0;
+  let failures = 0;
+
+  for (const row of pending) {
+    try {
+      // Claim BEFORE Resend send: conditional UPSERT, only one caller
+      // per (inquiry, period) advances last_notified_at. Concurrent /
+      // retried callers get false and skip silently. Mirrors
+      // claim_digest_send (migration 022).
+      const { data: claimed, error: claimError } = await supabase.rpc(
+        'claim_landlord_message_notification',
+        {
+          p_inquiry_id: row.inquiry_id,
+          p_min_interval: MIN_INTERVAL,
+          p_unread_count: row.unread_count,
+        },
+      );
+
+      if (claimError) {
+        console.error(
+          `[landlord-digest] claim_landlord_message_notification failed for ${row.inquiry_id}:`,
+          claimError,
+        );
+        failures++;
+        continue;
+      }
+      if (!claimed) {
+        alreadyClaimed++;
+        continue;
+      }
+
+      // From here on the claim is committed: a Resend failure means
+      // this digest is lost for this period. Same tradeoff as the
+      // saved-searches digest — missing one email beats double-sending.
+      const locale = resolveLocale(row.landlord_locale);
+
+      await resend.emails.send({
+        from: FROM_ADDRESS,
+        to: row.landlord_email,
+        subject: landlordMessageDigestSubject(
+          row.student_display_name,
+          row.unread_count,
+          locale,
+        ),
+        html: landlordMessageDigestHtml({
+          landlordName: row.landlord_name,
+          studentName: row.student_display_name,
+          listing: {
+            listing_id: row.listing_id,
+            address: row.listing_address,
+            neighborhood: row.listing_neighborhood,
+            monthly_price: row.listing_monthly_price,
+          },
+          unreadCount: row.unread_count,
+          snippet: row.latest_message_body,
+          appUrl,
+          inquiryId: row.inquiry_id,
+          locale,
+        }),
+      });
+
+      emailsSent++;
+    } catch (err) {
+      console.error(`[landlord-digest] error processing inquiry ${row?.inquiry_id}:`, err);
+      failures++;
+      // Continue with next inquiry — one bad row must not abort the run.
+    }
+  }
+
+  return NextResponse.json({
+    processed: pending.length,
+    emailsSent,
+    alreadyClaimed,
+    failures,
+  });
+}

--- a/src/templates/email/landlordMessageDigest.js
+++ b/src/templates/email/landlordMessageDigest.js
@@ -1,0 +1,221 @@
+/**
+ * Email sent to a landlord when one or more unread chat messages from
+ * a student have been waiting past the debounce window. One email per
+ * inquiry per N minutes (see /api/cron/landlord-message-digest).
+ *
+ * Mirrors the styling and locale-as-key pattern of inquiry.js. New
+ * strings live under the `student.notifications.*` namespace (the
+ * email goes to the landlord, but the i18n key namespace is owned by
+ * the student-flows feature folder).
+ *
+ * @param {object} params
+ * @param {string} params.landlordName
+ * @param {string} params.studentName
+ * @param {object} params.listing - { listing_id, address?, neighborhood?, monthly_price? }
+ * @param {number} params.unreadCount
+ * @param {string} params.snippet - Most recent unread message body
+ * @param {string} params.appUrl
+ * @param {string} params.inquiryId
+ * @param {'el'|'en'} [params.locale='el']
+ */
+
+const STRINGS = {
+  el: {
+    htmlLang: 'el',
+    'student.notifications.titleTag': 'Νέα μηνύματα στη συνομιλία σου',
+    'student.notifications.headerTagline': 'Φοιτητική στέγαση · Θεσσαλονίκη',
+    'student.notifications.heading': (count, name) =>
+      count === 1
+        ? `Νέο μήνυμα από ${name}`
+        : `${count} νέα μηνύματα από ${name}`,
+    'student.notifications.greetingFallback': 'εσένα',
+    'student.notifications.intro': (greeting, count, name, summary) => {
+      const noun = count === 1 ? 'ένα αδιάβαστο μήνυμα' : `${count} αδιάβαστα μηνύματα`;
+      const tail = summary
+        ? ` σχετικά με την αγγελία σου <strong style="color:#1a2744;">${summary}</strong>`
+        : '';
+      return `Γεια ${greeting}, έχεις ${noun} από τον/την ${name}${tail}.`;
+    },
+    'student.notifications.snippetLabel': 'Πιο πρόσφατο μήνυμα',
+    'student.notifications.cta': 'Άνοιγμα συνομιλίας',
+    'student.notifications.inboxButton': 'Όλα τα μηνύματα',
+    'student.notifications.viewListing': 'Δες την αγγελία →',
+    'student.notifications.footerLine1':
+      'StudentX · Κατάλογος φοιτητικής στέγης για τη Θεσσαλονίκη',
+    'student.notifications.footerLine2':
+      'Λαμβάνεις αυτό το email επειδή ένας φοιτητής σου έγραψε στο StudentX.',
+    'student.notifications.footerLine3':
+      'Ανοίγουμε ένα email κάθε λίγα λεπτά όταν έχεις αδιάβαστα μηνύματα — όχι ένα ανά μήνυμα.',
+    'student.notifications.subjectOne': (name) => `Νέο μήνυμα από ${name} · StudentX`,
+    'student.notifications.subjectMany': (count, name) =>
+      `${count} νέα μηνύματα από ${name} · StudentX`,
+    'student.notifications.subjectFallbackName': 'έναν φοιτητή',
+    'student.notifications.pricePerMonth': (n) => `€${n}/μήνα`,
+  },
+  en: {
+    htmlLang: 'en',
+    'student.notifications.titleTag': 'New messages in your conversation',
+    'student.notifications.headerTagline': 'Student Housing · Thessaloniki',
+    'student.notifications.heading': (count, name) =>
+      count === 1
+        ? `New message from ${name}`
+        : `${count} new messages from ${name}`,
+    'student.notifications.greetingFallback': 'there',
+    'student.notifications.intro': (greeting, count, name, summary) => {
+      const noun = count === 1 ? 'one unread message' : `${count} unread messages`;
+      const tail = summary
+        ? ` about your listing <strong style="color:#1a2744;">${summary}</strong>`
+        : '';
+      return `Hi ${greeting}, you have ${noun} from ${name}${tail}.`;
+    },
+    'student.notifications.snippetLabel': 'Latest message',
+    'student.notifications.cta': 'Open conversation',
+    'student.notifications.inboxButton': 'All inquiries',
+    'student.notifications.viewListing': 'View listing →',
+    'student.notifications.footerLine1':
+      'StudentX · Student housing directory for Thessaloniki, Greece',
+    'student.notifications.footerLine2':
+      "You're receiving this because a student is messaging you on StudentX.",
+    'student.notifications.footerLine3':
+      'We bundle messages into one email every few minutes instead of one per message.',
+    'student.notifications.subjectOne': (name) => `New message from ${name} · StudentX`,
+    'student.notifications.subjectMany': (count, name) =>
+      `${count} new messages from ${name} · StudentX`,
+    'student.notifications.subjectFallbackName': 'a student',
+    'student.notifications.pricePerMonth': (n) => `€${n}/mo`,
+  },
+};
+
+function pickStrings(locale) {
+  return STRINGS[locale] || STRINGS.el;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function landlordMessageDigestSubject(studentName, unreadCount, locale = 'el') {
+  const s = pickStrings(locale);
+  const trimmed = (studentName || '').trim() || s['student.notifications.subjectFallbackName'];
+  return unreadCount === 1
+    ? s['student.notifications.subjectOne'](trimmed)
+    : s['student.notifications.subjectMany'](unreadCount, trimmed);
+}
+
+export function landlordMessageDigestHtml({
+  landlordName,
+  studentName,
+  listing,
+  unreadCount,
+  snippet,
+  appUrl,
+  inquiryId,
+  locale = 'el',
+}) {
+  const s = pickStrings(locale);
+  const safeStudent = escapeHtml(studentName || s['student.notifications.subjectFallbackName']);
+  const safeGreeting = landlordName
+    ? escapeHtml(landlordName)
+    : s['student.notifications.greetingFallback'];
+  const safeAddress = listing?.address ? escapeHtml(listing.address) : '';
+  const safeNeighborhood = listing?.neighborhood ? escapeHtml(listing.neighborhood) : '';
+  const safePrice = listing?.monthly_price
+    ? s['student.notifications.pricePerMonth'](Number(listing.monthly_price))
+    : '';
+  const listingSummary = [safeAddress, safeNeighborhood, safePrice].filter(Boolean).join(' · ');
+  const safeSnippet = snippet ? escapeHtml(snippet).replace(/\n/g, '<br/>') : '';
+
+  const chatUrl = `${appUrl}/landlord/inquiries/${inquiryId}/chat`;
+  const inboxUrl = `${appUrl}/landlord/inquiries`;
+  const listingUrl = listing?.listing_id ? `${appUrl}/listing/${listing.listing_id}` : null;
+
+  const heading = s['student.notifications.heading'](unreadCount, safeStudent);
+  const intro = s['student.notifications.intro'](
+    safeGreeting,
+    unreadCount,
+    safeStudent,
+    listingSummary,
+  );
+
+  return `<!DOCTYPE html>
+<html lang="${s.htmlLang}">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${s['student.notifications.titleTag']}</title>
+</head>
+<body style="margin:0;padding:0;background:#f5f5f0;font-family:Georgia,serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f5f5f0;padding:40px 16px;">
+    <tr>
+      <td align="center">
+        <table width="560" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;border:1px solid #e5e5e0;">
+          <!-- Header -->
+          <tr>
+            <td style="background:#1a2744;padding:24px 32px;">
+              <p style="margin:0;font-family:'Helvetica Neue',sans-serif;font-size:11px;font-weight:700;letter-spacing:0.15em;text-transform:uppercase;color:#c9a84c;">StudentX</p>
+              <p style="margin:4px 0 0;font-family:'Helvetica Neue',sans-serif;font-size:11px;color:#ffffff80;">${s['student.notifications.headerTagline']}</p>
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding:32px;">
+              <h1 style="margin:0 0 8px;font-family:'Helvetica Neue',sans-serif;font-size:22px;font-weight:700;color:#1a2744;">${heading}</h1>
+              <p style="margin:0 0 24px;font-size:15px;color:#555;line-height:1.6;">
+                ${intro}
+              </p>
+
+              ${
+                safeSnippet
+                  ? `
+              <!-- Snippet -->
+              <p style="margin:0 0 6px;font-family:'Helvetica Neue',sans-serif;font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:#888;">${s['student.notifications.snippetLabel']}</p>
+              <div style="font-size:15px;color:#333;line-height:1.6;border-left:3px solid #c9a84c;padding:4px 16px;margin-bottom:24px;">
+                ${safeSnippet}
+              </div>`
+                  : ''
+              }
+
+              <!-- CTAs -->
+              <table cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background:#1a2744;border-radius:8px;padding:0;">
+                    <a href="${chatUrl}" style="display:inline-block;padding:12px 22px;font-family:'Helvetica Neue',sans-serif;font-size:14px;font-weight:700;color:#ffffff;text-decoration:none;">${s['student.notifications.cta']}</a>
+                  </td>
+                  <td style="width:8px;"></td>
+                  <td style="border:1px solid #1a2744;border-radius:8px;padding:0;">
+                    <a href="${inboxUrl}" style="display:inline-block;padding:11px 22px;font-family:'Helvetica Neue',sans-serif;font-size:14px;font-weight:700;color:#1a2744;text-decoration:none;">${s['student.notifications.inboxButton']}</a>
+                  </td>
+                </tr>
+              </table>
+
+              ${
+                listingUrl
+                  ? `<p style="margin:24px 0 0;font-size:13px;color:#888;">
+                <a href="${listingUrl}" style="color:#888;">${s['student.notifications.viewListing']}</a>
+              </p>`
+                  : ''
+              }
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td style="background:#f5f5f0;padding:20px 32px;border-top:1px solid #e5e5e0;">
+              <p style="margin:0;font-size:12px;color:#999;">
+                ${s['student.notifications.footerLine1']}<br/>
+                ${s['student.notifications.footerLine2']}<br/>
+                ${s['student.notifications.footerLine3']}
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}

--- a/supabase/migrations/032_landlord_message_notifications.sql
+++ b/supabase/migrations/032_landlord_message_notifications.sql
@@ -1,0 +1,138 @@
+-- ============================================================
+-- Migration 032: Per-message email digest tracking for landlords.
+-- ============================================================
+--
+-- After PR #38, the chat thread between student and landlord lives
+-- entirely in-app. The legacy first-inquiry email still fires on
+-- inquiry creation (see src/lib/inquiryEmail.js) but every subsequent
+-- student message is in-app only — landlords with no notification
+-- habit miss the conversation.
+--
+-- This migration adds the bookkeeping for a debounced digest. A
+-- scheduled Cloudflare Worker (cf/worker-entry.mjs) ticks every five
+-- minutes and POSTs to /api/cron/landlord-message-digest. That route
+-- finds inquiries with landlord_unread_count > 0 that haven't been
+-- notified within the debounce window, sends one summary email per
+-- inquiry, and stamps last_notified_at here.
+--
+-- The shape mirrors saved_searches + claim_digest_send (migration 022):
+-- a server-side-only table with RLS disabled, mutated only via
+-- SECURITY DEFINER RPCs. Keeping the notification logic separate from
+-- the inquiry_messages triggers (027/028) means we can change the
+-- debounce window or kill the digest without touching message writes.
+
+CREATE TABLE landlord_message_notifications (
+  inquiry_id            UUID PRIMARY KEY REFERENCES inquiries(inquiry_id) ON DELETE CASCADE,
+  last_notified_at      TIMESTAMPTZ,
+  unread_count_snapshot INT NOT NULL DEFAULT 0,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Server-side-only table (mirrors saved_searches): no RLS, accessed
+-- only via the SECURITY DEFINER RPCs below. The cron route uses the
+-- anon Supabase client, so the grants must reach `anon`.
+ALTER TABLE landlord_message_notifications DISABLE ROW LEVEL SECURITY;
+
+-- ---- get_pending_landlord_notifications ----------------------------
+-- Returns one row per inquiry that has unread student messages and
+-- either has never been notified or was last notified longer than
+-- p_min_interval ago. Bundles the student display name, the listing
+-- summary fields, and the latest unread student message body so the
+-- cron route can build the email in a single round trip.
+--
+-- The bundled SELECTs span students + inquiry_messages, both of which
+-- are RLS-restricted to thread participants — the anon cron client
+-- cannot read them directly, so the SECURITY DEFINER context here is
+-- load-bearing.
+CREATE OR REPLACE FUNCTION public.get_pending_landlord_notifications(
+  p_min_interval interval
+) RETURNS TABLE (
+  inquiry_id              UUID,
+  listing_id              UUID,
+  landlord_email          TEXT,
+  landlord_name           TEXT,
+  landlord_locale         TEXT,
+  student_display_name    TEXT,
+  unread_count            INT,
+  last_message_at         TIMESTAMPTZ,
+  latest_message_body     TEXT,
+  listing_address         TEXT,
+  listing_neighborhood    TEXT,
+  listing_monthly_price   NUMERIC
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+  SELECT i.inquiry_id,
+         i.listing_id,
+         ll.email,
+         ll.name,
+         ll.preferred_locale,
+         st.display_name,
+         i.landlord_unread_count,
+         i.last_message_at,
+         (SELECT m.body
+            FROM inquiry_messages m
+           WHERE m.inquiry_id = i.inquiry_id
+             AND m.sender_role = 'student'
+             AND m.read_at IS NULL
+           ORDER BY m.created_at DESC
+           LIMIT 1) AS latest_message_body,
+         loc.address,
+         loc.neighborhood,
+         r.monthly_price
+    FROM inquiries i
+    JOIN listings  l  ON l.listing_id  = i.listing_id
+    JOIN landlords ll ON ll.landlord_id = l.landlord_id
+    LEFT JOIN students st ON st.auth_user_id = i.student_user_id
+    LEFT JOIN location loc ON loc.listing_id = l.listing_id
+    LEFT JOIN rent     r   ON r.listing_id   = l.listing_id
+    LEFT JOIN landlord_message_notifications n
+           ON n.inquiry_id = i.inquiry_id
+   WHERE i.landlord_unread_count > 0
+     AND ll.email IS NOT NULL
+     AND (n.last_notified_at IS NULL
+          OR n.last_notified_at < now() - p_min_interval);
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_pending_landlord_notifications(interval)
+  TO anon, authenticated;
+
+-- ---- claim_landlord_message_notification ---------------------------
+-- Conditional UPSERT mirroring claim_digest_send (022): the cron route
+-- calls this BEFORE dispatching to Resend. First caller advances
+-- last_notified_at and gets true; concurrent or retried callers within
+-- p_min_interval get false and skip silently. This is the debounce.
+--
+-- p_unread_count is the snapshot at claim time, kept for observability
+-- (lets us see how big each digest was without re-querying inquiries).
+CREATE OR REPLACE FUNCTION public.claim_landlord_message_notification(
+  p_inquiry_id   uuid,
+  p_min_interval interval,
+  p_unread_count int
+) RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_updated int;
+BEGIN
+  INSERT INTO landlord_message_notifications
+              (inquiry_id, last_notified_at, unread_count_snapshot)
+       VALUES (p_inquiry_id, now(), p_unread_count)
+  ON CONFLICT (inquiry_id) DO UPDATE
+     SET last_notified_at      = now(),
+         unread_count_snapshot = EXCLUDED.unread_count_snapshot
+   WHERE landlord_message_notifications.last_notified_at IS NULL
+      OR landlord_message_notifications.last_notified_at
+         < now() - p_min_interval;
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated > 0;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.claim_landlord_message_notification(uuid, interval, int)
+  TO anon, authenticated;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -33,14 +33,20 @@
     "NEXT_PUBLIC_SITE_URL": "https://studentx.studentx-gr.workers.dev",
     "NEXT_PUBLIC_APP_URL": "https://studentx.studentx-gr.workers.dev"
   },
-  // Cron triggers: daily at 09:00 UTC and weekly on Mondays at 09:00 UTC.
-  // Dispatched via cf/worker-entry.mjs's `scheduled` handler, which POSTs to
-  // /api/cron/saved-searches-digest using NEXT_PUBLIC_APP_URL + CRON_SECRET.
-  // Keep CRON_TO_FREQUENCY in cf/worker-entry.mjs in sync with these patterns.
+  // Cron triggers. Dispatched via cf/worker-entry.mjs's `scheduled` handler,
+  // which maps each cron expression to a route + payload and POSTs using
+  // NEXT_PUBLIC_APP_URL + CRON_SECRET. Keep cf/worker-entry.mjs's CRON_ROUTES
+  // in sync with these patterns.
+  //
+  //   0 9 * * *      → /api/cron/saved-searches-digest?frequency=daily
+  //   0 9 * * 1      → /api/cron/saved-searches-digest?frequency=weekly
+  //   */5 * * * *    → /api/cron/landlord-message-digest (per-message digest;
+  //                    debounced server-side via claim_landlord_message_notification)
   "triggers": {
     "crons": [
-      "0 9 * * *",   // daily digest
-      "0 9 * * 1"    // weekly digest (Mondays)
+      "0 9 * * *",   // daily saved-searches digest
+      "0 9 * * 1",   // weekly saved-searches digest (Mondays)
+      "*/5 * * * *"  // landlord message digest (every 5 min)
     ]
   }
 }


### PR DESCRIPTION
## Summary

After PR #38, the chat thread between student and landlord lives entirely in-app. The legacy first-inquiry email still fires, but every subsequent student message is in-app only — landlords with no notification habit miss the conversation. Both PM reviewers flagged this as a real UX gap before announcing chat to real landlords.

This PR closes that gap with a **debounced digest**: a 5-minute cron tick collapses any unread student messages into one summary email per inquiry per window. A flurry of student messages produces one email; a quiet inquiry produces nothing.

## What changed

- **`supabase/migrations/032_landlord_message_notifications.sql`** — `landlord_message_notifications` table (PK = `inquiry_id`) plus two RPCs:
  - `get_pending_landlord_notifications(min_interval)` returns inquiries with `landlord_unread_count > 0` past the debounce window, bundling student name, listing summary, and most recent unread message body in one round trip. `SECURITY DEFINER` because `students` and `inquiry_messages` are RLS-restricted to thread participants.
  - `claim_landlord_message_notification(inquiry_id, min_interval, count)` — conditional UPSERT mirroring `claim_digest_send` (022). Called *before* Resend dispatch so retries / overlapping ticks can't double-send.
- **`src/app/api/cron/landlord-message-digest/route.js`** — same shape as the existing saved-searches cron route: `CRON_SECRET` auth, anon `getSupabase()`, claim → send → continue. Returns `{ processed, emailsSent, alreadyClaimed, failures }` for log tailing.
- **`src/templates/email/landlordMessageDigest.js`** — locale-aware (el/en) subject + HTML, mirroring `inquiry.js` styling. New strings under the **`student.notifications.*`** namespace.
- **`wrangler.jsonc` + `cf/worker-entry.mjs`** — adds `*/5 * * * *` to `triggers.crons`. The worker's `scheduled` handler is generalized from the saved-searches-only `CRON_TO_FREQUENCY` to a generic `CRON_ROUTES` map, so adding future scheduled jobs is one line in each file.

Migrations 026/027/028/029 and the `inquiry_messages` triggers are untouched. Migration numbers 030 (SSO) and 031 (chat rate-limit) are reserved and not consumed here.

## Cron schedule

`*/5 * * * *` — every 5 minutes — dispatched by `cf/worker-entry.mjs::scheduled` → POST to `/api/cron/landlord-message-digest` with `x-cron-secret`.

To verify it's firing post-deploy: `wrangler tail` and watch for log lines like
```
[cron] landlord-message-digest ok: processed=2 sent=1 claimed=1 (412ms)
```
at the 5-minute marks. The worker has a 25-second internal abort to keep failures visible rather than silently killed by Cloudflare's ~30s scheduled-handler limit.

## Required env vars

- `RESEND_API_KEY` (existing)
- `CRON_SECRET` (existing)
- `NEXT_PUBLIC_APP_URL` (existing)
- `LANDLORD_DIGEST_ENABLED` — **new, optional**. Set to `false` to disable the digest at deploy time without removing the cron trigger. Default = enabled.

## Test plan

- [ ] `npm run lint` clean (0 errors).
- [ ] `npm run build` succeeds; both `/api/cron/saved-searches-digest` and `/api/cron/landlord-message-digest` appear in the build manifest.
- [ ] Apply migration 032 to a Supabase branch / project; confirm `\d landlord_message_notifications` shows the table and `\df get_pending_landlord_notifications` / `\df claim_landlord_message_notification` show both RPCs.
- [ ] Sign in as a student, open an existing inquiry, and send 3 chat messages within ~30 seconds.
- [ ] Trigger the route manually:
  ```
  curl -X POST -H "x-cron-secret: $CRON_SECRET" "$NEXT_PUBLIC_APP_URL/api/cron/landlord-message-digest"
  ```
  Expect `{ processed: 1, emailsSent: 1, alreadyClaimed: 0, failures: 0 }`. The landlord inbox receives one email summarizing all 3 messages with the most recent body as the snippet.
- [ ] Re-run the curl immediately. Expect `emailsSent: 0, alreadyClaimed: 1`. No second email.
- [ ] As the student, send 2 more messages. Wait 5+ minutes (or temporarily set `MIN_INTERVAL` in the route to `'30 seconds'` for the test). Re-run the curl. Expect a second email covering the new messages only.
- [ ] Set `LANDLORD_DIGEST_ENABLED=false` and re-run the curl. Expect `{ skipped: 'disabled' }`.
- [ ] Tail `wrangler tail` after the next 5-minute cron tick on the deployed Worker; confirm the log line shape above.

## Known limitations

- Activity in the last few seconds before a cron tick may roll into the *next* email by design — the debounce window is the unit of bundling.
- If a landlord opens the in-app chat between two ticks and reads everything, they correctly get no email next tick. But the *previous* tick may have already sent one for messages they then read in-app. Acceptable.
- The digest does not yet cover landlord-side typing or "online now" presence — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)