### PR TITLE
fix(migration): correct join columns in 032_landlord_message_notifications

### DIFF
--- a/supabase/migrations/032_landlord_message_notifications.sql
+++ b/supabase/migrations/032_landlord_message_notifications.sql
@@ -86,8 +86,8 @@ AS $function$
     JOIN listings  l  ON l.listing_id  = i.listing_id
     JOIN landlords ll ON ll.landlord_id = l.landlord_id
     LEFT JOIN students st ON st.auth_user_id = i.student_user_id
-    LEFT JOIN location loc ON loc.listing_id = l.listing_id
-    LEFT JOIN rent     r   ON r.listing_id   = l.listing_id
+    LEFT JOIN location loc ON loc.location_id = l.location_id
+    LEFT JOIN rent     r   ON r.rent_id       = l.rent_id
     LEFT JOIN landlord_message_notifications n
            ON n.inquiry_id = i.inquiry_id
    WHERE i.landlord_unread_count > 0


### PR DESCRIPTION
## Summary

Forward-fix for migration 032 (PR #40, commit `2d4bbac`), which failed atomically when applied to production:

```
ERROR: 42703: column loc.listing_id does not exist
HINT: Perhaps you meant to reference the column "l.listing_id".
```

The `get_pending_landlord_notifications` RPC joined `location` and `rent` on `listing_id`, but neither dimension has that column. `listings` is the fact table holding the FKs — `location_id` and `rent_id` — and 032's preceding `JOIN listings l` already binds `l`, so the fix is two lines:

```diff
-    LEFT JOIN location loc ON loc.listing_id = l.listing_id
-    LEFT JOIN rent     r   ON r.listing_id   = l.listing_id
+    LEFT JOIN location loc ON loc.location_id = l.location_id
+    LEFT JOIN rent     r   ON r.rent_id       = l.rent_id
```

## Why edit 032 in place (not add 033)

The original transaction rolled back atomically, so 032's table + both RPCs exist in **no** environment. Adding a `033_fix_landlord_notifications_joins.sql` would either need to recreate everything 032 was supposed to ship (defeats the point of the fix) or leave a known-broken historical migration on disk for fresh `supabase db push` runs to trip over. Editing 032 directly is safe because no environment has it.

Same precedent: PR #31 / commit `c28b558` fixed migration 024 in place after the identical bug class (`location.listing_id` does not exist).

## Adjacent code reviewed

- [`src/app/api/cron/landlord-message-digest/route.js`](src/app/api/cron/landlord-message-digest/route.js) calls the RPC and reads only its returned fields. No direct SELECT of `location`/`rent`. **Untouched.**
- [`src/templates/email/landlordMessageDigest.js`](src/templates/email/landlordMessageDigest.js) consumes `{listing_id, address, neighborhood, monthly_price}` — exact match for the corrected RPC's columns (`listing_id`, `listing_address`, `listing_neighborhood`, `listing_monthly_price`). **Untouched.**
- `claim_landlord_message_notification` only touches the new notifications table. No broken joins. **Untouched.**

## Files changed

- `supabase/migrations/032_landlord_message_notifications.sql` (2-line diff inside `get_pending_landlord_notifications`)

## Test plan

- [x] `npm run lint` clean (one pre-existing warning in `cf/worker-entry.mjs`, unrelated)
- [x] `npm run build` succeeds
- [ ] Post-merge: apply migration 032 to production via Supabase MCP `apply_migration`
- [ ] Post-merge: `SELECT to_regclass('public.landlord_message_notifications')` returns the OID, and both `get_pending_landlord_notifications` / `claim_landlord_message_notification` show in `pg_proc`
- [ ] Post-merge: smoke `SELECT * FROM get_pending_landlord_notifications('5 minutes'::interval)` runs without error
- [ ] Post-merge: flip `LANDLORD_DIGEST_ENABLED` (kill switch from the rollback) back to `true` (or unset) on the CF Worker env, redeploy
- [ ] Post-merge: tick the cron route manually with `x-cron-secret` and confirm a real email lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)