### PR TITLE
fix(migration): correct listing_id return type in 032_landlord_message_notifications

### DIFF
--- a/supabase/migrations/032_landlord_message_notifications.sql
+++ b/supabase/migrations/032_landlord_message_notifications.sql
@@ -48,7 +48,7 @@ CREATE OR REPLACE FUNCTION public.get_pending_landlord_notifications(
   p_min_interval interval
 ) RETURNS TABLE (
   inquiry_id              UUID,
-  listing_id              UUID,
+  listing_id              TEXT,
   landlord_email          TEXT,
   landlord_name           TEXT,
   landlord_locale         TEXT,


### PR DESCRIPTION
## Summary

Second forward-fix for migration 032. After PR #43 corrected the join columns, applying 032 to production failed again with a different bug:

```
ERROR: 42P13: return type mismatch in function declared to return record
DETAIL: Final statement returns text instead of uuid at column 2.
```

`get_pending_landlord_notifications` declared `listing_id UUID` in its `RETURNS TABLE` clause, but `inquiries.listing_id` and `listings.listing_id` are both `TEXT` (StudentX listing IDs are 7-digit codes, not UUIDs — see the `CHECK` constraint at `supabase/migrations/001_create_schema.sql:54`). One-character fix: `UUID → TEXT` on column 2.

Atomic rollback from the failed PR #43 apply left production with no `landlord_message_notifications` table or RPCs, so the migration was pending again from a clean slate.

## Verification — applied to production BEFORE this PR

The migration was applied to production via `mcp__supabase__apply_migration` and **succeeded on the first attempt**. Sanity SQL outputs:

```sql
-- Both functions exist:
SELECT proname FROM pg_proc WHERE proname IN
  ('get_pending_landlord_notifications','claim_landlord_message_notification');
-- → claim_landlord_message_notification, get_pending_landlord_notifications

-- Table exists:
SELECT tablename FROM pg_tables WHERE schemaname='public'
  AND tablename = 'landlord_message_notifications';
-- → landlord_message_notifications

-- Function runs without error:
SELECT * FROM get_pending_landlord_notifications('5 minutes'::interval) LIMIT 1;
-- → []   (no pending rows in production yet, but the function executes cleanly)
```

## Type audits performed

Cross-referenced every `RETURNS TABLE` column against its source column in `inquiries`, `listings`, `landlords`, `students`, `location`, `rent`, `inquiry_messages`. **`listing_id` was the only mismatch.** The other 11 columns all match:

| Column | Declared | Source | Actual |
|---|---|---|---|
| `inquiry_id` | UUID | `inquiries.inquiry_id` | UUID ✓ |
| `listing_id` | ~~UUID~~ → **TEXT** | `inquiries.listing_id` | TEXT |
| `landlord_email` | TEXT | `landlords.email` | TEXT ✓ |
| `landlord_name` | TEXT | `landlords.name` | TEXT ✓ |
| `landlord_locale` | TEXT | `landlords.preferred_locale` | TEXT ✓ |
| `student_display_name` | TEXT | `students.display_name` | TEXT ✓ |
| `unread_count` | INT | `inquiries.landlord_unread_count` | INTEGER ✓ |
| `last_message_at` | TIMESTAMPTZ | `inquiries.last_message_at` | TIMESTAMPTZ ✓ |
| `latest_message_body` | TEXT | `inquiry_messages.body` | TEXT ✓ |
| `listing_address` | TEXT | `location.address` | TEXT ✓ |
| `listing_neighborhood` | TEXT | `location.neighborhood` | TEXT ✓ |
| `listing_monthly_price` | NUMERIC | `rent.monthly_price` | NUMERIC ✓ |

Also audited:

- **`claim_landlord_message_notification`** — params and return type all match the table (`uuid` inquiry_id, `int` unread_count, `boolean` return). No issues.
- **`src/app/api/cron/landlord-message-digest/route.js`** — passes `row.listing_id` straight into `landlordMessageDigestHtml({ listing: { listing_id, ... } })`. No UUID regex/length/cast assumptions.
- **`src/templates/email/landlordMessageDigest.js`** — uses `listing.listing_id` only to interpolate into a URL (`${appUrl}/listing/${listing.listing_id}`). No UUID-specific handling.

## Broader pattern — third migration-bug-escaping-review in a row

Migration bugs that PMs/reviewers can't catch from the diff alone (only Postgres can, at apply time):

- #31 — migration 024 referenced nonexistent `location.listing_id`
- #43 — migration 032 had wrong join columns (this same migration)
- this PR — migration 032 had wrong return type (same migration)

**Recommendation:** add a CI step that actually applies the migrations against a fresh Postgres before merge, e.g. `supabase db reset` against a Supabase preview branch (or local CLI in CI). This class of bug is invisible to lint/build and to human review of the SQL diff, but takes seconds to catch by actually running it.

## Test plan

- [x] `npm run lint` — clean (1 pre-existing warning in `cf/worker-entry.mjs`, unrelated)
- [x] `npm run build` — compiles successfully, all 98 static pages generated
- [x] Migration applied to production via Supabase MCP — succeeded on first attempt
- [x] All three sanity SQL queries returned expected results
- [x] Type audit of all 12 RETURNS TABLE columns vs source schema
- [x] Cron route + email template scanned for UUID assumptions on `listing_id` (none found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)