### PR TITLE
chore(ci): add migration apply check

### DIFF
--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -1,0 +1,25 @@
+name: Migration check
+
+on:
+  pull_request:
+    paths:
+      - 'supabase/migrations/**'
+      - 'supabase/config.toml'
+      - 'supabase/seed.sql'
+      - '.github/workflows/migration-check.yml'
+
+jobs:
+  apply-migrations:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Start Supabase local stack (applies all migrations)
+        run: supabase start


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that spins up the Supabase local stack and applies every migration on every PR that touches `supabase/migrations/`. The job fails loudly if any migration fails to apply.

## Why

We've had three migration bugs in a row escape PR review and only surface at apply time on Supabase:

- **#31** — historical apply-time fix
- **#43** — `fix(migration): correct join columns in 032_landlord_message_notifications`
- **#44** — `fix(migration): correct listing_id return type in 032_landlord_message_notifications`

These are all **apply-time** errors — wrong column references, wrong return types, broken triggers. Lint and `next build` can't see them because they're SQL-level errors that only Postgres catches when it tries to execute the DDL. Every one of these cost a fix-PR cycle and a re-merge. A pre-merge check that actually runs `supabase start` against the migrations would have caught all three at PR time.

## What the workflow does

In plain English:

1. **Triggers** only on PRs that touch `supabase/migrations/**`, `supabase/config.toml`, `supabase/seed.sql`, or the workflow file itself. Every other PR stays fast.
2. **Checks out** the PR's code.
3. **Installs** the Supabase CLI via `supabase/setup-cli@v1`.
4. **Runs `supabase start`**, which boots the full local Supabase stack (Postgres + GoTrue + the rest) and **applies every migration in `supabase/migrations/` in order** as part of bootstrap. Then runs `seed.sql`.

If any migration produces a SQL error, `supabase start` exits non-zero and the PR check goes red.

## Why the full Supabase stack and not a vanilla Postgres container

The migrations heavily reference `auth.users` and `auth.uid()` (10+ files), and 029 installs a trigger directly on `auth.users`. The `auth` schema is provisioned by Supabase's `gotrue` service, not by Postgres core, so a plain `postgres:17` container would fail at the first `auth.*` reference with `schema "auth" does not exist`. `supabase start` provides the same environment we run in production.

## Self-test note

The path filter includes `.github/workflows/migration-check.yml` itself, so this PR triggers its own check — proving the workflow is wired up before the next migration PR relies on it.

## Test plan

- [x] YAML parses cleanly (`ruby -ryaml`)
- [x] `npm run lint` clean (only pre-existing unrelated warning in `cf/worker-entry.mjs`)
- [x] `npm run build` succeeds
- [ ] PR's own check runs and goes green (this is the live test, since the workflow file is in the path filter)
- [ ] Auto-merge after green per overnight protocol — pure CI infrastructure addition, no production impact, no source files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)