### PR TITLE
fix(i18n): pass explicit locale to AuthGate; tighten student server components

### DIFF
--- a/src/app/[locale]/listing/[id]/page.js
+++ b/src/app/[locale]/listing/[id]/page.js
@@ -38,6 +38,7 @@ export default async function ListingPage({ params, searchParams }) {
     return (
       <AuthGate
         next={nextPath}
+        locale={locale}
         mode={auth?.kind === 'wrong-role' ? 'wrong-role' : 'guest'}
       />
     );

--- a/src/app/[locale]/student/account/page.js
+++ b/src/app/[locale]/student/account/page.js
@@ -33,7 +33,7 @@ export default async function StudentAccountPage({ params }) {
     redirect(`${locale === 'el' ? '' : `/${locale}`}/student/login?next=${encodeURIComponent(next)}`);
   }
 
-  const t = await getTranslations('student.account');
+  const t = await getTranslations({ locale, namespace: 'student.account' });
   const { student, supabase } = auth;
 
   const { data: inquiries, error } = await supabase

--- a/src/app/[locale]/student/inquiries/[inquiry_id]/page.js
+++ b/src/app/[locale]/student/inquiries/[inquiry_id]/page.js
@@ -18,7 +18,7 @@ export default async function StudentInquiryThreadPage({ params }) {
     redirect(`${locale === 'el' ? '' : `/${locale}`}/student/login?next=${encodeURIComponent(next)}`);
   }
 
-  const t = await getTranslations('student.chat');
+  const t = await getTranslations({ locale, namespace: 'student.chat' });
   const { user, supabase } = auth;
 
   // Single round-trip: inquiry + listing summary + initial message page.

--- a/src/components/AuthGate.js
+++ b/src/components/AuthGate.js
@@ -15,9 +15,16 @@ import AuthGateRescue from '@/components/AuthGateRescue';
  *
  * `next` is a path-with-query (e.g. "/listing/3801?from=...") that the
  * sign-in page reads from `?next=` and assigns via window.location.
+ *
+ * `locale` must be passed explicitly by the caller. Bare
+ * `getTranslations('namespace')` reads from next-intl's request scope,
+ * which under OpenNext on Workers can fall through to `defaultLocale`
+ * ('el') for components rendered inside a redirect/guard branch —
+ * producing Greek copy on /en/ routes. The explicit
+ * `{ locale, namespace }` form is authoritative.
  */
-export default async function AuthGate({ next, mode = 'guest' }) {
-  const t = await getTranslations('student.gate');
+export default async function AuthGate({ next, locale, mode = 'guest' }) {
+  const t = await getTranslations({ locale, namespace: 'student.gate' });
   const safeNext = typeof next === 'string' && next.startsWith('/') ? next : '';
   const nextQuery = safeNext ? `?next=${encodeURIComponent(safeNext)}` : '';
 


### PR DESCRIPTION
## Symptom

`/en/listing/<id>` rendered the AuthGate (the gate shown to guests and wrong-role visitors) in **Greek** instead of English.

## Root cause

[`AuthGate.js`](src/components/AuthGate.js) used the bare form `getTranslations('student.gate')`. That form reads the locale from next-intl's request scope. Under OpenNext on Cloudflare Workers, when the gate is rendered inside the listing page's auth guard branch, the request scope is not always populated by the time the server component runs — so the lookup falls through to `defaultLocale: 'el'` and you get Greek copy on the English route.

The explicit `getTranslations({ locale, namespace: 'student.gate' })` form is authoritative and bypasses the request-scope dependency. Sister calls in the same listing page (`getTranslations({ locale, namespace: 'propylaea.listing' })`) already use the explicit form — this PR brings the laggards in line.

## Fix

- [`src/components/AuthGate.js`](src/components/AuthGate.js) — accept `locale` as an explicit prop, use `getTranslations({ locale, namespace: 'student.gate' })`. JSDoc updated with the rationale so future edits don't regress.
- [`src/app/[locale]/listing/[id]/page.js`](src/app/[locale]/listing/[id]/page.js) — pass `locale={locale}` through to `<AuthGate>` (the only call site).

Same tightening applied to two more student-facing server components that share the anti-pattern. They work today only because `setRequestLocale(locale)` runs in the same render frame; one refactor (e.g. extracting a sub-tree) would break them the same way:

- [`src/app/[locale]/student/account/page.js`](src/app/[locale]/student/account/page.js)
- [`src/app/[locale]/student/inquiries/[inquiry_id]/page.js`](src/app/[locale]/student/inquiries/[inquiry_id]/page.js)

## Files changed (4)

- `src/components/AuthGate.js`
- `src/app/[locale]/listing/[id]/page.js`
- `src/app/[locale]/student/account/page.js`
- `src/app/[locale]/student/inquiries/[inquiry_id]/page.js`

No DB / migration touch. No production data risk.

## Why this matters (PM lens)

Visitors hitting `/en/listing/*` right now see a Greek "you must sign up" screen at the moment they're evaluating a listing — a conversion-killer for the English-speaking segment (Erasmus, international AUTH applicants), which is also the segment with no fallback (a Greek student can read either; an exchange student likely cannot). This PR's value is concentrated on the hardest-to-acquire users. Also a quiet WCAG 3.1.1 (Language of Page) win.

## ⚠️ POST-MERGE: Manual CDN cache purge required

[`next.config.mjs:49-55`](next.config.mjs#L49-L55) sets `Cache-Control: public, s-maxage=300, stale-while-revalidate=86400` on listing pages. After this PR merges and the Cloudflare deploy completes, **the wrong-locale Greek HTML for `/en/listing/*` will remain in the CDN edge cache for up to 5 minutes hard + 1 day stale-while-revalidate.**

**Action required after deploy:**

1. Cloudflare dashboard → Caching → Configuration → **Purge cache** → Purge by URL prefix.
2. Purge the prefix `https://<your-domain>/en/listing/` (or use the wrangler equivalent).

This was not automated in the PR because it requires a Cloudflare API token that's not available to the build pipeline.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [ ] After deploy: visit `/en/listing/<id>` while signed out → AuthGate copy is English (title, subtitle, both CTAs, landlord hint).
- [ ] After deploy: visit `/listing/<id>` (default `el`) → Greek copy unchanged.
- [ ] After deploy: visit `/en/listing/<id>` while signed in as a landlord → wrong-role English copy.
- [ ] After deploy + CDN purge: `curl -I https://<domain>/en/listing/<id>` shows fresh response (CF-Cache-Status: MISS or DYNAMIC on first hit).
- [ ] After deploy: visit `/en/student/account` while signed out → English AuthGate copy (same four strings).
- [ ] After deploy: visit `/en/student/inquiries/<inquiry_id>` as a non-owner student → English AuthGate copy.
- [ ] After deploy + purge: hard-reload `/en/listing/<id>` from a second device/incognito (cold edge POP) → English on first paint, no Greek flash.
- [ ] Follow-up filed: synthetic check on `/en/listing/<id>` asserting English marker string in HTML — see #49.

## Follow-ups (post-merge, non-blocking)

- **#49** — synthetic check so this class of bug self-detects next time.
- Submit `/en/listing/` prefix for re-crawl in Google Search Console (the wrong-locale Greek HTML may already be indexed). 30 seconds, can happen any time today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)