### PR TITLE
feat(monitoring): synthetic check guards /en/listing locale regression (closes #49)

### DIFF
--- a/cf/worker-entry.mjs
+++ b/cf/worker-entry.mjs
@@ -22,6 +22,7 @@ const CRON_ROUTES = {
   "0 9 * * *":    { name: "saved-searches-daily",   path: "/api/cron/saved-searches-digest",   query: "frequency=daily" },
   "0 9 * * 1":    { name: "saved-searches-weekly",  path: "/api/cron/saved-searches-digest",   query: "frequency=weekly" },
   "*/5 * * * *":  { name: "landlord-message-digest", path: "/api/cron/landlord-message-digest", query: null },
+  "*/15 * * * *": { name: "synthetic-en-listing",   path: "/api/cron/synthetic-en-listing",    query: null },
 };
 
 async function runCron(event, env) {

--- a/docs/runbooks/synthetic-en-listing.md
+++ b/docs/runbooks/synthetic-en-listing.md
@@ -1,0 +1,83 @@
+# Runbook — Synthetic check: `/en/listing/<id>` serves English
+
+**Issue:** [#49](https://github.com/MichaelChar/StudentX/issues/49) · **Guards against:** [#48](https://github.com/MichaelChar/StudentX/pull/48)
+
+## What this guards against
+
+PR #48 fixed a class of bug where `getTranslations('ns')` (the bare form) silently fell back to `defaultLocale: 'el'` under OpenNext on Cloudflare Workers, causing Greek copy to render on `/en/listing/<id>` for English users. The fix was to pass an explicit `locale` to every `getTranslations` call in server components.
+
+The bug can recur whenever a new locale-aware server component is added or a sub-tree is extracted without the explicit `locale` prop. Manual QA won't catch silent regressions weeks later. This synthetic check runs every 15 minutes and emails on regression.
+
+## How it works
+
+| Piece | Location |
+|---|---|
+| Cron trigger (`*/15 * * * *`) | [`wrangler.jsonc`](../../wrangler.jsonc) `triggers.crons` |
+| Cron dispatch (cron expr → route) | [`cf/worker-entry.mjs`](../../cf/worker-entry.mjs) `CRON_ROUTES` |
+| Check logic + alerting | [`src/app/api/cron/synthetic-en-listing/route.js`](../../src/app/api/cron/synthetic-en-listing/route.js) |
+
+Every 15 min, the Worker's `scheduled` handler POSTs to `/api/cron/synthetic-en-listing` with the `x-cron-secret` header. The route fetches `${NEXT_PUBLIC_APP_URL}/en/listing/${SYNTHETIC_LISTING_ID}` and asserts:
+
+**Required (must be present in body):**
+- `<html lang="en"`
+- `Sign in to view this listing` — from `student.gate.title` in [`src/messages/en.json`](../../src/messages/en.json)
+
+**Forbidden (must NOT be present in body):**
+- `lang="el"`
+- `Συνδέσου` — from `student.gate.title` in [`src/messages/el.json`](../../src/messages/el.json)
+
+Any failed assertion (or non-200, or fetch timeout) sends an email via Resend to `SYNTHETIC_ALERT_EMAIL`.
+
+## Configuration
+
+Vars in [`wrangler.jsonc`](../../wrangler.jsonc):
+
+| Var | Default | Purpose |
+|---|---|---|
+| `SYNTHETIC_LISTING_ID` | `0100006` | Listing ID to probe. Must be permanently published. |
+| `SYNTHETIC_ALERT_EMAIL` | `michaeltubehd007@gmail.com` | Where alerts go. |
+
+Secrets (set via `wrangler secret put`, not in `wrangler.jsonc`):
+
+- `CRON_SECRET` — required, same value used by all cron routes.
+- `RESEND_API_KEY` — required for the alert path. Without it the route logs but cannot email.
+
+## When the alert fires
+
+Subject: `[StudentX synthetic] /en/listing/<id> failed: <reason>`
+
+Body includes status code, which assertion failed, and the first 500 chars of the returned HTML. Possible reasons:
+
+- `non-200 status: <code>` — the page errored or redirected. Check the Worker logs.
+- `missing required EN marker: <marker>` — the page returned 200 but the English copy disappeared. Either the gate copy was edited (update marker below) or the i18n regression class is back.
+- `forbidden EL marker present: <marker>` — Greek leaked onto the EN page. **This is the regression we're guarding against** — investigate `getTranslations` calls in any recently-changed server component.
+- `fetch threw: ...` — the Worker couldn't reach the public hostname. Could be a Worker outage or DNS issue.
+
+## Maintenance
+
+**Marker strings change with copy edits.** If you edit `student.gate.title` in either locale's messages file, update the constants at the top of [`src/app/api/cron/synthetic-en-listing/route.js`](../../src/app/api/cron/synthetic-en-listing/route.js):
+
+- `EN_MARKERS_REQUIRED` — must be a unique string from the EN gate copy
+- `EL_MARKERS_FORBIDDEN` — must be a unique string from the EL gate copy that has no English equivalent
+
+**Stable listing ID.** `0100006` is the default. If it ever gets unpublished or removed, swap `SYNTHETIC_LISTING_ID` in `wrangler.jsonc` to another permanently-published listing ID.
+
+**Silence temporarily.** Comment out `"*/15 * * * *"` in `wrangler.jsonc` and the matching entry in `cf/worker-entry.mjs` `CRON_ROUTES`, then `npm run cf:build && wrangler deploy`. Re-enable when ready.
+
+## Manual trigger
+
+Local dev server:
+```bash
+curl -X POST -H "x-cron-secret: $CRON_SECRET" \
+  http://localhost:3000/api/cron/synthetic-en-listing
+# Expect: {"ok":true,"status":200}
+```
+
+Production (manual run, doesn't wait for the next 15-min tick):
+- Cloudflare dashboard → Workers → `studentx` → Triggers → "Trigger Cron" on `*/15 * * * *`, OR
+- `curl -X POST -H "x-cron-secret: <secret>" https://studentx.studentx-gr.workers.dev/api/cron/synthetic-en-listing`
+
+## Known limitations
+
+- **Same-network probe.** The cron runs inside the same Cloudflare Worker that serves the page. Doesn't simulate a US user's edge cache. Acceptable because the listing page currently sets `Cache-Control: private, no-cache, no-store, must-revalidate` — there is no edge cache to test from a different POP.
+- **No alert dedupe.** A sustained outage emails every 15 min. If this becomes annoying, add a `synthetic_alert_state(check_name, last_alert_at)` Supabase row and gate the email on `now() - last_alert_at > 1 hour`.

--- a/docs/runbooks/synthetic-en-listing.md
+++ b/docs/runbooks/synthetic-en-listing.md
@@ -26,7 +26,9 @@ Every 15 min, the Worker's `scheduled` handler POSTs to `/api/cron/synthetic-en-
 - `lang="el"`
 - `Συνδέσου` — from `student.gate.title` in [`src/messages/el.json`](../../src/messages/el.json)
 
-Any failed assertion (or non-200, or fetch timeout) sends an email via Resend to `SYNTHETIC_ALERT_EMAIL`.
+Any failed assertion (or non-200, or fetch timeout) attempts to send an email via Resend to `SYNTHETIC_ALERT_EMAIL`.
+
+> **Status as of merge:** the email alert path is configured in code but **logs-only in production** because Resend isn't set up yet (`studentx.gr` isn't a registered domain — see [the domain context note](#domain-context) below). Failures surface in `wrangler tail` logs only. To enable email alerts later: register the domain, verify it in Resend, set `RESEND_API_KEY` as a Worker secret. The route's email send is wrapped in try/catch so a missing `RESEND_API_KEY` doesn't break the check itself.
 
 ## Configuration
 
@@ -77,7 +79,24 @@ Production (manual run, doesn't wait for the next 15-min tick):
 - Cloudflare dashboard → Workers → `studentx` → Triggers → "Trigger Cron" on `*/15 * * * *`, OR
 - `curl -X POST -H "x-cron-secret: <secret>" https://studentx.studentx-gr.workers.dev/api/cron/synthetic-en-listing`
 
+## Domain context
+
+The codebase fallback addresses (`alerts@studentx.gr`) and the `NEXT_PUBLIC_SITE_URL` default (`https://studentx.gr`) reference a domain that is not yet registered. The live deploy runs on `studentx.studentx-gr.workers.dev` (a `*.workers.dev` subdomain) until DNS is sorted. This is why the email alert path is currently logs-only:
+
+1. Resend rejects sends from unverified domains.
+2. `studentx.gr` can't be verified because it doesn't exist.
+3. Until the domain is registered + verified, all email-sending paths in the codebase (this synthetic, saved-searches digest, landlord message digest, inquiry email) silently fail at the Resend send step.
+
+To enable email here:
+
+1. Register `studentx.gr` (or pick a different domain and update `NEXT_PUBLIC_SITE_URL` + the from-addresses in code).
+2. Add the domain to Cloudflare (or whatever DNS host you'll use).
+3. In Resend, add a sending subdomain (e.g. `updates.studentx.gr`) and follow the DNS verification flow.
+4. `npx wrangler secret put RESEND_API_KEY --name studentx`
+5. Update `RESEND_FROM_EMAIL` in `wrangler.jsonc` (or each route's hardcoded from-address) to match the verified subdomain.
+
 ## Known limitations
 
 - **Same-network probe.** The cron runs inside the same Cloudflare Worker that serves the page. Doesn't simulate a US user's edge cache. Acceptable because the listing page currently sets `Cache-Control: private, no-cache, no-store, must-revalidate` — there is no edge cache to test from a different POP.
-- **No alert dedupe.** A sustained outage emails every 15 min. If this becomes annoying, add a `synthetic_alert_state(check_name, last_alert_at)` Supabase row and gate the email on `now() - last_alert_at > 1 hour`.
+- **No alert dedupe.** A sustained outage would email every 15 min once email is wired up. If this becomes annoying, add a `synthetic_alert_state(check_name, last_alert_at)` Supabase row and gate the email on `now() - last_alert_at > 1 hour`.
+- **Logs-only until email is configured.** See [Domain context](#domain-context) above.

--- a/src/app/api/cron/synthetic-en-listing/route.js
+++ b/src/app/api/cron/synthetic-en-listing/route.js
@@ -60,7 +60,7 @@ function evaluateBody({ status, body }) {
 
 async function sendAlert({ to, listingId, url, status, reason, bodyExcerpt }) {
   const resend = getResend();
-  const from = process.env.RESEND_FROM_EMAIL || 'alerts@studentx.gr';
+  const from = process.env.RESEND_FROM_EMAIL || 'StudentX Alerts <alerts@updates.studentx.gr>';
   await resend.emails.send({
     from,
     to,

--- a/src/app/api/cron/synthetic-en-listing/route.js
+++ b/src/app/api/cron/synthetic-en-listing/route.js
@@ -60,7 +60,7 @@ function evaluateBody({ status, body }) {
 
 async function sendAlert({ to, listingId, url, status, reason, bodyExcerpt }) {
   const resend = getResend();
-  const from = process.env.RESEND_FROM_EMAIL || 'StudentX Alerts <alerts@updates.studentx.gr>';
+  const from = process.env.RESEND_FROM_EMAIL || 'StudentX Alerts <alerts@studentx.gr>';
   await resend.emails.send({
     from,
     to,

--- a/src/app/api/cron/synthetic-en-listing/route.js
+++ b/src/app/api/cron/synthetic-en-listing/route.js
@@ -1,0 +1,127 @@
+import { NextResponse } from 'next/server';
+import { getResend } from '@/lib/resend';
+
+// Synthetic uptime check guarding against the regression class fixed in PR #48
+// (see issue #49 + docs/runbooks/synthetic-en-listing.md). Fetches the EN listing
+// page and asserts English markers are present + Greek markers absent. Emails
+// SYNTHETIC_ALERT_EMAIL via Resend on any failure.
+//
+// Triggered by cf/worker-entry.mjs on the */15 * * * * cron. Also callable
+// manually with the CRON_SECRET for local sanity checks.
+
+const DEFAULT_LISTING_ID = '0100006';
+const FETCH_TIMEOUT_MS = 10_000;
+
+const EN_MARKERS_REQUIRED = [
+  '<html lang="en"',
+  'Sign in to view this listing',
+];
+const EL_MARKERS_FORBIDDEN = [
+  'lang="el"',
+  'Συνδέσου',
+];
+
+function isCronAuthorized(request) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  const headerSecret = request.headers.get('x-cron-secret');
+  if (headerSecret === secret) return true;
+  const { searchParams } = new URL(request.url);
+  return searchParams.get('secret') === secret;
+}
+
+async function fetchListingHtml(url) {
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: { 'user-agent': 'StudentX-synthetic/1.0' },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    redirect: 'manual',
+  });
+  const body = await res.text();
+  return { status: res.status, body };
+}
+
+function evaluateBody({ status, body }) {
+  if (status !== 200) {
+    return { ok: false, reason: `non-200 status: ${status}` };
+  }
+  for (const marker of EN_MARKERS_REQUIRED) {
+    if (!body.includes(marker)) {
+      return { ok: false, reason: `missing required EN marker: ${marker}` };
+    }
+  }
+  for (const marker of EL_MARKERS_FORBIDDEN) {
+    if (body.includes(marker)) {
+      return { ok: false, reason: `forbidden EL marker present: ${marker}` };
+    }
+  }
+  return { ok: true };
+}
+
+async function sendAlert({ to, listingId, url, status, reason, bodyExcerpt }) {
+  const resend = getResend();
+  const from = process.env.RESEND_FROM_EMAIL || 'alerts@studentx.gr';
+  await resend.emails.send({
+    from,
+    to,
+    subject: `[StudentX synthetic] /en/listing/${listingId} failed: ${reason}`,
+    text: [
+      `Synthetic check failed for ${url}`,
+      ``,
+      `Status: ${status ?? 'no response'}`,
+      `Reason: ${reason}`,
+      ``,
+      `--- HTML excerpt (first 500 chars) ---`,
+      bodyExcerpt || '(no body)',
+    ].join('\n'),
+  });
+}
+
+export async function POST(request) {
+  if (!isCronAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const listingId = process.env.SYNTHETIC_LISTING_ID || DEFAULT_LISTING_ID;
+  const alertEmail = process.env.SYNTHETIC_ALERT_EMAIL;
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  const url = `${appUrl}/en/listing/${listingId}`;
+
+  let fetched;
+  try {
+    fetched = await fetchListingHtml(url);
+  } catch (err) {
+    const reason = `fetch threw: ${err.name || 'Error'} ${err.message || ''}`.trim();
+    if (alertEmail) {
+      try {
+        await sendAlert({ to: alertEmail, listingId, url, status: null, reason, bodyExcerpt: '' });
+      } catch (mailErr) {
+        console.error('[synthetic-en-listing] alert email failed:', mailErr);
+      }
+    }
+    return NextResponse.json({ ok: false, reason }, { status: 200 });
+  }
+
+  const verdict = evaluateBody(fetched);
+  if (!verdict.ok) {
+    if (alertEmail) {
+      try {
+        await sendAlert({
+          to: alertEmail,
+          listingId,
+          url,
+          status: fetched.status,
+          reason: verdict.reason,
+          bodyExcerpt: fetched.body.slice(0, 500),
+        });
+      } catch (mailErr) {
+        console.error('[synthetic-en-listing] alert email failed:', mailErr);
+      }
+    } else {
+      console.error('[synthetic-en-listing] no SYNTHETIC_ALERT_EMAIL configured; failure was:', verdict.reason);
+    }
+    return NextResponse.json({ ok: false, reason: verdict.reason, status: fetched.status }, { status: 200 });
+  }
+
+  return NextResponse.json({ ok: true, status: fetched.status });
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -31,7 +31,13 @@
     // button links somewhere broken. Flip back to studentx.gr (or just
     // remove these lines, since the code falls back to it) once DNS lands.
     "NEXT_PUBLIC_SITE_URL": "https://studentx.studentx-gr.workers.dev",
-    "NEXT_PUBLIC_APP_URL": "https://studentx.studentx-gr.workers.dev"
+    "NEXT_PUBLIC_APP_URL": "https://studentx.studentx-gr.workers.dev",
+    // Synthetic uptime check — guards against the i18n regression class fixed
+    // in PR #48 (Greek copy leaking onto /en/listing/<id>). The */15 cron POSTs
+    // to /api/cron/synthetic-en-listing, which fetches /en/listing/<id> and
+    // emails alerts on locale-marker mismatches. See docs/runbooks/synthetic-en-listing.md.
+    "SYNTHETIC_LISTING_ID": "0100006",
+    "SYNTHETIC_ALERT_EMAIL": "michaeltubehd007@gmail.com"
   },
   // Cron triggers. Dispatched via cf/worker-entry.mjs's `scheduled` handler,
   // which maps each cron expression to a route + payload and POSTs using
@@ -42,11 +48,13 @@
   //   0 9 * * 1      → /api/cron/saved-searches-digest?frequency=weekly
   //   */5 * * * *    → /api/cron/landlord-message-digest (per-message digest;
   //                    debounced server-side via claim_landlord_message_notification)
+  //   */15 * * * *   → /api/cron/synthetic-en-listing (i18n regression guard, #49)
   "triggers": {
     "crons": [
-      "0 9 * * *",   // daily saved-searches digest
-      "0 9 * * 1",   // weekly saved-searches digest (Mondays)
-      "*/5 * * * *"  // landlord message digest (every 5 min)
+      "0 9 * * *",    // daily saved-searches digest
+      "0 9 * * 1",    // weekly saved-searches digest (Mondays)
+      "*/5 * * * *",  // landlord message digest (every 5 min)
+      "*/15 * * * *"  // synthetic /en/listing locale check (#49)
     ]
   }
 }


### PR DESCRIPTION
## Why

PR #48 fixed a class of bug where bare ``getTranslations('ns')`` silently fell back to ``defaultLocale: 'el'`` under OpenNext on Cloudflare Workers, causing Greek copy on ``/en/listing/<id>``. The trap can recur whenever a new locale-aware server component is added without the explicit ``locale`` prop. Manual QA caught it once but won't reliably catch silent regressions weeks later.

Issue #49 asks for a synthetic check that pages on regression. This PR ships it as a **logs-only regression detector**.

## What

A new Cloudflare Worker cron at ``*/15 * * * *`` POSTs to ``/api/cron/synthetic-en-listing``. The route fetches ``${NEXT_PUBLIC_APP_URL}/en/listing/${SYNTHETIC_LISTING_ID}`` and asserts:

**Required (must be present):**
- ``<html lang=\"en\"``
- ``Sign in to view this listing`` — from ``student.gate.title`` in [src/messages/en.json](src/messages/en.json)

**Forbidden (must NOT be present):**
- ``lang=\"el\"``
- ``Συνδέσου`` — from ``student.gate.title`` in [src/messages/el.json](src/messages/el.json)

On any failure (assertion, non-200, fetch timeout) the route attempts an email via Resend to ``SYNTHETIC_ALERT_EMAIL`` AND logs via ``console.error`` for ``wrangler tail``.

## ⚠️ Logs-only at merge time

The email alert path is wired in code but **non-functional in production right now**. ``studentx.gr`` is not a registered domain (NXDOMAIN), so Resend can't verify any subdomain of it, and ``RESEND_API_KEY`` isn't set on the Worker. **All email-sending paths in the codebase are currently broken** — this isn't a regression from this PR, it predates it.

The synthetic check still works as designed: assertion failures appear in ``wrangler tail`` immediately. To upgrade to push email alerts later: register ``studentx.gr`` (or pick a different domain), verify it in Resend, set ``RESEND_API_KEY``. See [docs/runbooks/synthetic-en-listing.md#domain-context](docs/runbooks/synthetic-en-listing.md) for the full setup path.

## Files changed

| File | Change |
|---|---|
| [src/app/api/cron/synthetic-en-listing/route.js](src/app/api/cron/synthetic-en-listing/route.js) | New cron route. Mirrors auth + structure of [saved-searches-digest/route.js](src/app/api/cron/saved-searches-digest/route.js). Email send is wrapped in try/catch so a missing ``RESEND_API_KEY`` doesn't break the assertion check. |
| [cf/worker-entry.mjs](cf/worker-entry.mjs#L25) | One-line addition to ``CRON_ROUTES`` (the dispatch map was already generalized in PR #40 — no refactor needed) |
| [wrangler.jsonc](wrangler.jsonc) | Added ``*/15 * * * *`` cron + ``SYNTHETIC_LISTING_ID`` + ``SYNTHETIC_ALERT_EMAIL`` vars |
| [docs/runbooks/synthetic-en-listing.md](docs/runbooks/synthetic-en-listing.md) | Runbook covering markers, alert format, maintenance, manual trigger, domain context, known limitations |

No DB / migration touch.

## Decisions called out

- **Cadence: 15 min** (issue's max acceptable). Faster wastes Worker requests; the regression class is rare and not user-reportable in seconds.
- **No alert dedupe in v1.** When email is eventually wired up, a sustained outage would email every 15 min. Trivial follow-up if it bites.
- **Stable listing ID = ``0100006``.** Lowest sequential ID, oldest publish, presumed most stable. Runbook explains how to swap.
- **PR #48's \"manual CDN purge required\" warning is moot.** The listing page now responds with ``cache-control: private, no-cache, no-store, must-revalidate`` — no edge cache to purge.

## Verified locally

- ``npm run lint`` → 0 errors (15 pre-existing warnings, none from this PR)
- ``npm run build`` → clean, ``/api/cron/synthetic-en-listing`` registered
- ``POST`` no secret → ``401 {\"error\":\"Unauthorized\"}`` ✅
- ``POST`` with correct ``x-cron-secret`` against live prod ``/en/listing/0100006`` → ``200 {\"ok\":true,\"status\":200}`` ✅
- ``POST`` with ``SYNTHETIC_LISTING_ID=9999999`` (forces 404 from prod) → ``200 {\"ok\":false,\"reason\":\"non-200 status: 404\",\"status\":404}`` ✅

Verified in production after deploy (commit ``8db1b5a7``):

- Cron tick at 08:00:29 UTC fired and reached the route. (Currently logs ``missing CRON_SECRET — cannot dispatch`` because that secret was never set on the Worker — pre-existing issue, also affects the landlord-message-digest cron. Setting ``CRON_SECRET`` is on the post-merge checklist.)

## Post-merge checklist

1. **Set ``CRON_SECRET`` on the Worker** (also unblocks the existing landlord-message-digest cron that's been silently no-op'ing):
   ``\`\`bash
   openssl rand -hex 32
   npx wrangler secret put CRON_SECRET --name studentx
   ``\`\`
2. **Confirm:** ``npx wrangler secret list --name studentx`` shows ``CRON_SECRET``
3. **Watch first ticks** (within 15 min): ``npx wrangler tail studentx --format pretty``
   - Expected: ``[cron] synthetic-en-listing ok: {\"ok\":true,\"status\":200} ...``
4. **Close [#49](https://github.com/MichaelChar/StudentX/issues/49)** once the synthetic has run a successful round.

## Out of scope (parking lot)

- **Email alerts.** Blocked on ``studentx.gr`` registration. Tracked in the runbook's [Domain context](docs/runbooks/synthetic-en-listing.md) section.
- **Multi-POP coverage.** Cron runs inside CF's network — doesn't simulate a US user's edge cache. Acceptable because the listing page is now uncached at the edge.
- **Pre-existing bug noticed during prod check:** ``<title>`` is in English on both ``/en/listing/<id>`` and ``/listing/<id>`` (\"Sign in to view listing — StudentX — StudentX\") — EL page has English title plus a doubled brand suffix. Not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)