### PR TITLE
fix(email): send from alerts@updates.studentx.gr (verified Resend subdomain)

### DIFF
--- a/src/app/api/cron/landlord-message-digest/route.js
+++ b/src/app/api/cron/landlord-message-digest/route.js
@@ -23,7 +23,7 @@ function getServiceSupabase() {
 // to absorb a burst of student messages into a single email.
 const MIN_INTERVAL = '4 minutes 30 seconds';
 
-const FROM_ADDRESS = 'StudentX <alerts@studentx.gr>';
+const FROM_ADDRESS = 'StudentX <alerts@updates.studentx.gr>';
 
 function isCronAuthorized(request) {
   const secret = process.env.CRON_SECRET;

--- a/src/app/api/cron/saved-searches-digest/route.js
+++ b/src/app/api/cron/saved-searches-digest/route.js
@@ -134,7 +134,7 @@ export async function POST(request) {
       const manageUrl = `${appUrl}/alerts/manage?token=${search.unsubscribe_token}`;
 
       await resend.emails.send({
-        from: 'StudentX Alerts <alerts@studentx.gr>',
+        from: 'StudentX Alerts <alerts@updates.studentx.gr>',
         to: search.email,
         subject: digestEmailSubject(search.label, matches.length),
         html: digestEmailHtml({

--- a/src/app/api/saved-searches/route.js
+++ b/src/app/api/saved-searches/route.js
@@ -51,7 +51,7 @@ export async function POST(request) {
     try {
       const resend = getResend();
       await resend.emails.send({
-        from: 'StudentX Alerts <alerts@studentx.gr>',
+        from: 'StudentX Alerts <alerts@updates.studentx.gr>',
         to: email.trim().toLowerCase(),
         subject: confirmationEmailSubject(label?.trim()),
         html: confirmationEmailHtml({

--- a/src/lib/inquiryEmail.js
+++ b/src/lib/inquiryEmail.js
@@ -2,7 +2,7 @@ import { getSupabase } from '@/lib/supabase';
 import { getResend } from '@/lib/resend';
 import { inquiryEmailHtml, inquiryEmailSubject } from '@/templates/email/inquiry';
 
-const FROM_ADDRESS = 'StudentX <alerts@studentx.gr>';
+const FROM_ADDRESS = 'StudentX <alerts@updates.studentx.gr>';
 
 function resolveLandlordEmailLocale(request, landlord) {
   if (landlord?.preferred_locale === 'el' || landlord?.preferred_locale === 'en') {


### PR DESCRIPTION
## Why

Resend rejects sends from any domain not verified in their account. We've registered the subdomain ``updates.studentx.gr`` in Resend (best practice for transactional email — isolates sending reputation from the rest of the domain). All outbound code currently sends from ``alerts@studentx.gr`` (the apex), which Resend will refuse.

## What

Swap the from-address in all 4 outbound email paths to ``alerts@updates.studentx.gr``:

| File | Sends |
|---|---|
| [src/lib/inquiryEmail.js:5](src/lib/inquiryEmail.js#L5) | Student inquiry → landlord notification |
| [src/app/api/cron/landlord-message-digest/route.js:26](src/app/api/cron/landlord-message-digest/route.js#L26) | Per-message digest cron (``*/5``) |
| [src/app/api/cron/saved-searches-digest/route.js:137](src/app/api/cron/saved-searches-digest/route.js#L137) | Daily/weekly digest cron |
| [src/app/api/saved-searches/route.js:54](src/app/api/saved-searches/route.js#L54) | Signup confirmation email |

The synthetic-en-listing route from PR #50 already reads from ``RESEND_FROM_EMAIL`` with a fallback; the fallback there is updated separately on that branch.

## Background

This PR pairs with #50 (synthetic uptime check, [#49](https://github.com/MichaelChar/StudentX/issues/49)). Investigating why the existing ``*/5`` landlord-message-digest cron was silently failing surfaced two prerequisites for any email-sending in production:

1. ``CRON_SECRET`` was missing from the Worker (being set manually now).
2. ``RESEND_API_KEY`` was missing — Resend account had to be created (in progress: domain ``updates.studentx.gr`` is being verified in Resend right now).

This PR fixes the from-address mismatch that follows from #2.

## Files changed (4)

4 lines, 1 per file. ``StudentX <alerts@studentx.gr>`` → ``StudentX <alerts@updates.studentx.gr>`` (and ``StudentX Alerts`` variant).

No DB / migration touch. No production data risk.

## Test plan

- [x] ``grep -rn 'alerts@studentx.gr' src/`` returns nothing
- [x] Lint clean (errors in ``.open-next/`` are pre-existing, unrelated)
- [ ] After Resend domain verification + ``RESEND_API_KEY`` set: confirm next ``*/5`` landlord-message-digest cron logs ``ok`` (no longer 500s on email send)
- [ ] After deploy: trigger a synthetic inquiry from a test student account, confirm landlord receives an email from ``alerts@updates.studentx.gr``

🤖 Generated with [Claude Code](https://claude.com/claude-code)