### PR TITLE
fix(i18n): localize auth-gate page title on /listing/<id>; remove doubled "— StudentX" suffix

### DIFF
--- a/src/app/[locale]/listing/[id]/layout.js
+++ b/src/app/[locale]/listing/[id]/layout.js
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
 import { getListingForRender } from "@/lib/listingForRender";
 import { requireStudent } from "@/lib/requireStudent";
 
@@ -26,11 +27,17 @@ export async function generateMetadata({ params }) {
   // page-level call below shares this round-trip.
   // Wrong-role auth (e.g. landlord) is treated the same as a guest:
   // they'll see the gate, so the rich metadata must be stripped too.
+  //
+  // The bare string form gets templated by the parent locale layout
+  // ('%s — StudentX' in src/app/[locale]/layout.js), so the title here
+  // must NOT include '— StudentX' itself or it doubles. Use the same
+  // student.gate.* translations that AuthGate renders in the body so
+  // the meta title and the visible heading stay in lockstep.
   if (!auth || auth.kind === 'wrong-role') {
+    const t = await getTranslations({ locale, namespace: 'student.gate' });
     return {
-      title: "Sign in to view listing — StudentX",
-      description:
-        "StudentX listings are visible to verified student accounts. Create a free account to view this listing.",
+      title: t('title'),
+      description: t('subtitle'),
       robots: { index: false, follow: false },
       alternates: undefined,
     };


### PR DESCRIPTION
## Symptom

The ``<title>`` on the listing detail page rendered as ``"Sign in to view listing — StudentX — StudentX"`` for guests and wrong-role visitors, on **both** EN and EL routes:

| Route | Before | After |
|---|---|---|
| ``/en/listing/<id>`` | ``Sign in to view listing — StudentX — StudentX`` | ``Sign in to view this listing — StudentX`` |
| ``/listing/<id>`` (EL default) | ``Sign in to view listing — StudentX — StudentX`` | ``Συνδέσου για να δεις την αγγελία — StudentX`` |

## Root cause

Two distinct bugs in a single string in [src/app/[locale]/listing/[id]/layout.js:29-37](src/app/[locale]/listing/[id]/layout.js#L29):

1. **Locale ignored.** The auth-gate metadata branch hardcoded English regardless of the ``locale`` route param. Same regression class as [#48](https://github.com/MichaelChar/StudentX/pull/48) — a server-rendered piece that didn't thread ``locale`` to its translations.
2. **Doubled brand suffix.** The string included ``"— StudentX"`` inline, then the parent locale layout's [``title.template: '%s — StudentX'``](src/app/[locale]/layout.js#L42) templated it again, producing ``— StudentX — StudentX``.

I noticed this during the prod check that informed [#50](https://github.com/MichaelChar/StudentX/pull/50) and parked it as out-of-scope there. Picking it up now.

## Fix

Thread ``locale`` into the metadata via ``getTranslations({ locale, namespace: 'student.gate' })`` and return bare title strings (no inline brand). The parent template suffixes ``— StudentX`` exactly once.

The ``student.gate.title`` and ``student.gate.subtitle`` keys are the same translations [``AuthGate``](src/components/AuthGate.js) renders for the visible heading + body, so the meta title and the rendered heading now stay in lockstep — if copy edits are made, both update together.

## Files changed (1)

- [src/app/[locale]/listing/[id]/layout.js](src/app/[locale]/listing/[id]/layout.js) — 10 lines added, 3 removed

No DB / migration touch. Pure metadata fix.

## Verified locally

Dev server with ``.env.production`` copied to ``.env.local`` for DB access:

```
/listing/0100006    → <title>Συνδέσου για να δεις την αγγελία — StudentX</title>  ✅
/en/listing/0100006 → <title>Sign in to view this listing — StudentX</title>     ✅
```

Both ``<h1>`` headings match their respective titles. Neither has a doubled brand suffix. ``robots: { index: false, follow: false }`` still applied (SEO cloaking guard preserved).

- [x] ``npm run build`` succeeds (99/99 static pages generated, ``Compiled successfully in 2.5s``)
- [x] Lint clean for changed file (54 unrelated pre-existing errors all in ``.open-next/`` build artifacts)

## Why this matters

For ``/en/listing/<id>`` specifically:

- Browser tab shows the doubled-brand title — looks unprofessional, especially in tab-overflow scenarios
- Search engines that crawl the page (despite ``noindex``, some crawlers index temporarily before respecting the directive) see the malformed title
- Social-media unfurls (when someone pastes a listing link in Slack/Twitter/Facebook) use the ``<title>`` as part of the preview — first-impression damage for the exact funnel that PR #48 was trying to protect

For ``/listing/<id>`` (EL default), the bigger win is that the title is now actually Greek — matching the rest of the page.

## Out of scope (parking lot)

Same dev-mode quirk surfaced in my testing but **not** introduced here:

- In dev mode, ``<html lang>`` on ``/en/`` pages renders as ``"el"`` because the root layout's [``getLocale().catch(() => 'el')``](src/app/layout.js#L35) falls back when next-intl's request scope isn't populated. The PR #50 synthetic check confirms **production** correctly emits ``<html lang=\"en\">`` on ``/en/``, so this is a dev-only artifact of the same regression class as PR #48. Worth a separate look if it ever bites prod.
- The (effectively dead-code) ``"Listing not found — StudentX"`` branch in the same file ([line 16](src/app/[locale]/listing/[id]/layout.js#L16)) is also hardcoded English. The page-level ``notFound()`` in the layout's render path means this metadata is overridden by Next.js's not-found handling before users see it. Still strictly wrong but no user impact — leaving for now.

## Test plan after merge

- [ ] Deploy: ``npm run cf:build && npx wrangler deploy``
- [ ] Curl prod: ``curl -s https://studentx.studentx-gr.workers.dev/en/listing/0100006 | grep -oE '<title[^>]*>[^<]+'`` → ``Sign in to view this listing — StudentX``
- [ ] Curl prod: ``curl -s https://studentx.studentx-gr.workers.dev/listing/0100006 | grep -oE '<title[^>]*>[^<]+'`` → ``Συνδέσου για να δεις την αγγελία — StudentX``
- [ ] PR #50 synthetic check continues to log ``ok`` on ``/en/`` (the new EN title still contains \"Sign in to view this listing\" — the synthetic's required marker — so this PR is compatible with that check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)