### PR TITLE
chore: gitignore .claude/worktrees/ (sub-agent ephemeral checkouts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Claude Code (sub-agent worktrees)
+.claude/worktrees/


### PR DESCRIPTION
## Why
Claude Code spawns sub-agents in temporary git worktrees under `.claude/worktrees/`. Those checkouts are per-session, machine-local artifacts that show up as untracked noise in `git status` after every session and should never be committed.

## What
One-line addition to `.gitignore`, grouped under a new `# Claude Code (sub-agent worktrees)` comment near the bottom of the file.

Verified locally:
- `git check-ignore .claude/worktrees/` returns the path (ignored)
- `git status` no longer lists `.claude/worktrees/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)