### PR TITLE
fix(ci): grant claude-code-review.yml write scopes so it can post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # Write scopes are required for the action to actually post inline review
+      # comments and a top-level conversation comment. With read-only the
+      # Claude SDK still runs (logs show clean success), but the post-comment
+      # step is a silent no-op — the review is generated, then dropped.
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Symptom

The Claude Code Review workflow has been running on every PR since it was added (commit ``748c144``) and completing successfully — but no review or comment ever appears. PRs #48, #50, #52 all show zero formal reviews and only the Cloudflare deploy bot comment.

## Root cause (diagnosed via workflow run logs)

The job-level ``permissions`` block grants read-only scopes:

```yaml
permissions:
  contents: read
  pull-requests: read   # ← needs write
  issues: read          # ← needs write
  id-token: write
```

The Claude SDK itself runs cleanly — logs from run ``24981094817`` (PR #52) show ~16 turns, ~$0.70/run, ``is_error: false`` — but the immediately following post-step prints ``"No buffered inline comments"`` and the job ends. With ``pull-requests: read``, the workflow's ``GITHUB_TOKEN`` cannot create inline review comments or top-level PR conversation comments via the GitHub API. **The review is generated, then silently dropped.**

## Fix

Bump ``pull-requests`` and ``issues`` to ``write``. ``CLAUDE_CODE_OAUTH_TOKEN`` is already set as a repo secret (verified via ``gh secret list``) so no further config is needed.

## Files changed

- [.github/workflows/claude-code-review.yml](.github/workflows/claude-code-review.yml) — 6 lines added, 2 removed (just the permissions block + a brief comment explaining why write is required)

## Test plan

- [ ] Merge this PR
- [ ] Open another small PR (or push a commit to an open one) and confirm a Claude review comment appears within ~5 minutes
- [ ] If after the permission fix the action still posts ``"No buffered inline comments"``, the secondary fix is to either toggle ``use_sticky_comment: true`` (top-level summary instead of inline) or change the prompt to explicitly emit a comment via ``gh`` CLI. Diagnosed by Agent B's investigation, flagged as a possible follow-up.

## Why now

Realised during today's session — PR #50, #52 merged without any actual review despite the workflow running. The "PM agent review" reference in issue #49's body was almost certainly a local CLI invocation by the user, not this workflow (issue was authored a minute before PR #48 merged). So the workflow has *never* posted on any PR — this isn't a regression, it was misconfigured from the start.

## Confidence

**High.** The result-then-no-comment pattern is the textbook symptom of insufficient ``GITHUB_TOKEN`` scope on a workflow that uses an action with a "buffered comment poster" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)