### PR TITLE
data(faculties): backfill 9 AUTH rows + add library/AHEPA landmarks

### DIFF
--- a/docs/runbooks/035-faculty-backfill.md
+++ b/docs/runbooks/035-faculty-backfill.md
@@ -1,0 +1,98 @@
+# Runbook — Migration 035: AUTH faculty backfill + landmark reference points
+
+**Migration:** [`supabase/migrations/035_seed_remaining_auth_faculties_and_landmarks.sql`](../../supabase/migrations/035_seed_remaining_auth_faculties_and_landmarks.sql)
+
+## What this migration adds
+
+Source-control drift fix plus two new dedicated landmark rows for the listing detail page distance table. Every insert is `ON CONFLICT (faculty_id) DO NOTHING`, so this is safe to re-run.
+
+| `faculty_id` | `name` | Coords (lat, lng) | New on prod? |
+|---|---|---|---|
+| `auth-economics` | Faculty of Social & Economic Sciences | 40.6301, 22.9563 | No (already in prod) |
+| `auth-education` | Faculty of Education | 40.6301, 22.9563 | No |
+| `auth-engineering` | Faculty of Engineering | 40.6310, 22.9590 | No |
+| `auth-fine-arts` | Faculty of Fine Arts | 40.5584, 23.0093 | No |
+| `auth-law` | Faculty of Law | 40.6301, 22.9563 | No |
+| `auth-pe` | Faculty of Physical Education & Sport Sci | 40.5584, 23.0093 | No |
+| `auth-philosophy` | Faculty of Philosophy | 40.6301, 22.9563 | No |
+| `auth-sciences` | Faculty of Sciences | 40.6301, 22.9563 | No |
+| `auth-theology` | Faculty of Theology | 40.6301, 22.9563 | No |
+| `auth-library` | AUTH Central Library | 40.6299, 22.9590 | **Yes** |
+| `ahepa-hospital` | AHEPA University Hospital | 40.6258, 22.9555 | **Yes** |
+
+The 9 AUTH-faculty rows already exist in production; the migration is a strict no-op for them. Only the 2 landmarks insert net-new rows. On a fresh dev clone (or any partial env) every missing row inserts.
+
+`auth-medical` is **not** touched by this migration. It already exists in production with the name `Faculty of Health Sciences` (per the H4 fuzzy-name fix). Renaming or re-inserting it is out of scope.
+
+`auth-main` (in `002_seed_faculties.sql` but not in production) is also left alone — it's a working local fixture; removing it would only diverge dev tooling without prod benefit.
+
+## How to apply
+
+The parent agent applies the migration to production via Supabase MCP `apply_migration` after the PR merges. No manual psql/CLI step required.
+
+```
+mcp__supabase__apply_migration
+  name: "035_seed_remaining_auth_faculties_and_landmarks"
+  query: <contents of supabase/migrations/035_seed_remaining_auth_faculties_and_landmarks.sql>
+```
+
+CI's `migration-check.yml` runs `supabase start` on the PR, which applies all migrations 001 → 035 against a clean local stack. A green check means 035 is valid SQL and idempotent against the local seed.
+
+## Populating `faculty_distances` for the new landmarks
+
+Adding faculty rows does not auto-create distance rows. After the migration applies, run the precomputation script with `--only-missing`. It will fetch every existing listing and every faculty (including the 2 new landmarks), compute walk/transit minutes for each pair via OSRM, and insert the missing rows. Existing pairs are skipped.
+
+```bash
+export SUPABASE_URL="https://YOUR-REF.supabase.co"
+export SUPABASE_KEY="<service-role-key>"
+
+python3 scripts/compute_distances.py --only-missing
+```
+
+The script is rate-limited (~1 OSRM request/second). With N listings in production, it makes 2 × N OSRM calls for the new landmark pairs. At ~50 listings that's ~100 calls → roughly 2 minutes wall time. Output prints per-pair walk/transit minutes; failures are logged and can be retried by re-running the same command.
+
+Once distances exist for both new landmark ids on every listing, the listing detail page distance table can be updated to show three honest rows (Library, AHEPA Hospital, plus the listing's nearest AUTH faculty) instead of the current proxy-via-`auth-main`/`auth-medical` hack. That UI change is a follow-up — out of scope for this migration.
+
+## Verification
+
+After `apply_migration` succeeds, run these in Supabase MCP `execute_sql` (or psql):
+
+```sql
+-- Expect: 13 (11 pre-existing AUTH + auth-library + ahepa-hospital)
+SELECT COUNT(*) FROM faculties WHERE university = 'AUTH';
+
+-- Expect: rows present for both new landmarks
+SELECT faculty_id, name, lat, lng
+  FROM faculties
+ WHERE faculty_id IN ('auth-library', 'ahepa-hospital');
+```
+
+After `compute_distances.py --only-missing` finishes:
+
+```sql
+-- Expect: count equals number of listings (1 row per listing per new landmark)
+SELECT faculty_id, COUNT(*) AS listings_with_distance
+  FROM faculty_distances
+ WHERE faculty_id IN ('auth-library', 'ahepa-hospital')
+ GROUP BY faculty_id;
+```
+
+If a row count is short, re-run `python3 scripts/compute_distances.py --only-missing` to retry the failures. OSRM occasionally returns transient errors that resolve on retry.
+
+## Rollback
+
+To remove the 2 landmarks (the only inserts that actually change production):
+
+```sql
+DELETE FROM faculty_distances WHERE faculty_id IN ('auth-library', 'ahepa-hospital');
+DELETE FROM faculties         WHERE faculty_id IN ('auth-library', 'ahepa-hospital');
+```
+
+`faculty_distances` rows must be deleted first — `faculties.faculty_id` is referenced by `faculty_distances.faculty_id` with `ON DELETE CASCADE`, so a single `DELETE FROM faculties` would also work, but doing distances first makes the impact explicit.
+
+The 9 AUTH backfill rows already existed pre-035, so they have no rollback — leave them alone.
+
+## Notes
+
+- The migration's coordinates for the 9 backfilled AUTH rows match production exactly. They look heavily duplicated (many rows share `40.6301, 22.9563` for the main quadrangle and `40.5584, 23.0093` for the Thermi-area satellite faculties), but that is the live data, not a typo.
+- The two landmark coordinates were chosen to match the real geographic features: AUTH Central Library on the main campus quadrangle, AHEPA University Hospital adjacent to the medical campus on Stilponos Kyriakidi.

--- a/supabase/migrations/035_seed_remaining_auth_faculties_and_landmarks.sql
+++ b/supabase/migrations/035_seed_remaining_auth_faculties_and_landmarks.sql
@@ -61,7 +61,7 @@ INSERT INTO faculties (faculty_id, name, university, lat, lng) VALUES
   ('auth-engineering', 'Faculty of Engineering',                    'AUTH', 40.6310, 22.9590),
   ('auth-fine-arts',   'Faculty of Fine Arts',                      'AUTH', 40.5584, 23.0093),
   ('auth-law',         'Faculty of Law',                            'AUTH', 40.6301, 22.9563),
-  ('auth-pe',          'Faculty of Physical Education & Sport Sci', 'AUTH', 40.5584, 23.0093),
+  ('auth-pe',          'Faculty of Physical Education & Sport Sciences', 'AUTH', 40.5584, 23.0093),
   ('auth-philosophy',  'Faculty of Philosophy',                     'AUTH', 40.6301, 22.9563),
   ('auth-sciences',    'Faculty of Sciences',                       'AUTH', 40.6301, 22.9563),
   ('auth-theology',    'Faculty of Theology',                       'AUTH', 40.6301, 22.9563),

--- a/supabase/migrations/035_seed_remaining_auth_faculties_and_landmarks.sql
+++ b/supabase/migrations/035_seed_remaining_auth_faculties_and_landmarks.sql
@@ -1,0 +1,72 @@
+-- ============================================================
+-- Migration 035: Backfill missing AUTH faculties + add two
+-- dedicated landmark reference points (library, AHEPA hospital).
+-- ============================================================
+--
+-- Why this exists
+-- ---------------
+-- Source-control drift. Production has 11 AUTH faculty rows but the
+-- committed seed (002_seed_faculties.sql) only inserts 3 of them
+-- (auth-main, auth-medical, auth-agriculture). A fresh dev clone
+-- therefore can't reproduce production — multiple PMs have flagged
+-- this. This migration brings the SQL truth in line with the live
+-- truth so every new env starts with the full faculty set.
+--
+-- Production state at write time (11 AUTH rows; no auth-main):
+--   auth-agriculture, auth-economics, auth-education, auth-engineering,
+--   auth-fine-arts, auth-law, auth-medical, auth-pe, auth-philosophy,
+--   auth-sciences, auth-theology
+--
+-- 002 already covers auth-medical and auth-agriculture. The 9 inserts
+-- below cover the remainder. Coordinates are taken from the live row
+-- values (fetched via Supabase MCP, treated as source of truth) so
+-- re-running 002 + 035 on a fresh stack reproduces production for
+-- every faculty id that production has. Note: auth-medical maps to
+-- 'Faculty of Health Sciences' in production (the pre-existing fix
+-- from the H4 fuzzy-name mismatch); we do NOT rename it here.
+--
+-- auth-main (in 002 but not in production) is left alone. Production
+-- never had a generic main-campus row — the specific faculties cover
+-- the same campus area — and removing it from local would diverge a
+-- working dev fixture from no real benefit. Out of scope for 035.
+--
+-- Idempotency
+-- -----------
+-- Every insert is `ON CONFLICT (faculty_id) DO NOTHING`. On
+-- production this migration is therefore a strict no-op for the 9
+-- AUTH rows (they already exist) — it only inserts the 2 new
+-- landmarks. On a fresh dev clone all 11 rows insert. On a partial
+-- environment the migration heals whatever's missing without
+-- erroring on rows that exist.
+--
+-- New landmarks
+-- -------------
+-- The listing detail page's distance table currently fakes 'Central
+-- Library' by proxying to auth-main and 'AHEPA Hospital' by proxying
+-- to auth-medical. We add two real reference points so the table can
+-- show three honest rows. These ARE new on production and will
+-- insert. faculty_distances rows for the new ids are populated
+-- post-merge via scripts/compute_distances.py --only-missing
+-- (covered in docs/runbooks/035-faculty-backfill.md).
+--
+-- Coordinates: AHEPA University Hospital is the AUTH-affiliated
+-- teaching hospital adjacent to the medical campus; AUTH Central
+-- Library sits on the main-campus quadrangle.
+-- ============================================================
+
+INSERT INTO faculties (faculty_id, name, university, lat, lng) VALUES
+  -- AUTH faculties missing from 002 (9 rows; coords from prod)
+  ('auth-economics',   'Faculty of Social & Economic Sciences',     'AUTH', 40.6301, 22.9563),
+  ('auth-education',   'Faculty of Education',                      'AUTH', 40.6301, 22.9563),
+  ('auth-engineering', 'Faculty of Engineering',                    'AUTH', 40.6310, 22.9590),
+  ('auth-fine-arts',   'Faculty of Fine Arts',                      'AUTH', 40.5584, 23.0093),
+  ('auth-law',         'Faculty of Law',                            'AUTH', 40.6301, 22.9563),
+  ('auth-pe',          'Faculty of Physical Education & Sport Sci', 'AUTH', 40.5584, 23.0093),
+  ('auth-philosophy',  'Faculty of Philosophy',                     'AUTH', 40.6301, 22.9563),
+  ('auth-sciences',    'Faculty of Sciences',                       'AUTH', 40.6301, 22.9563),
+  ('auth-theology',    'Faculty of Theology',                       'AUTH', 40.6301, 22.9563),
+
+  -- New landmark reference points (2 rows; net-new on production)
+  ('auth-library',     'AUTH Central Library',                      'AUTH', 40.6299, 22.9590),
+  ('ahepa-hospital',   'AHEPA University Hospital',                 'AUTH', 40.6258, 22.9555)
+ON CONFLICT (faculty_id) DO NOTHING;


### PR DESCRIPTION
## Summary

- Closes the source-control drift on `faculties`: production has 11 AUTH rows but `002_seed_faculties.sql` only inserts 3, so a fresh dev clone can't reproduce production. Multiple PMs flagged. Migration 035 backfills the 9 missing AUTH rows.
- Adds 2 new dedicated landmark reference points so the listing detail distance table can stop faking "Central Library" via `auth-main` and "AHEPA Hospital" via `auth-medical`: `auth-library` (AUTH Central Library) and `ahepa-hospital` (AHEPA University Hospital).
- All inserts are `ON CONFLICT (faculty_id) DO NOTHING`, so the migration is a strict no-op on production for the 9 AUTH rows (they already exist) and only inserts the 2 new landmark rows. On a fresh clone the full diff applies.

> Note: the task brief said "8 AUTH rows missing" but the explicit row list it provided contained 9 (`auth-economics, auth-education, auth-engineering, auth-fine-arts, auth-law, auth-pe, auth-philosophy, auth-sciences, auth-theology`). I trusted the data over the prose. 11 prod AUTH − 2 in 002 (`auth-medical`, `auth-agriculture`) = 9. Updated commit/runbook to match.

## Files

- `supabase/migrations/035_seed_remaining_auth_faculties_and_landmarks.sql` — 11 idempotent inserts (9 AUTH backfill + 2 new landmarks).
- `docs/runbooks/035-faculty-backfill.md` — apply + verify + recompute steps for the parent agent.

## Apply steps (post-merge, parent handles)

1. `mcp__supabase__apply_migration` with the file contents (no-op for the 9 AUTH rows; inserts `auth-library` + `ahepa-hospital`).
2. `python3 scripts/compute_distances.py --only-missing` against production (Supabase service-role key required) to populate `faculty_distances` rows for every existing listing × the 2 new landmark ids. Rate-limited at ~1 OSRM req/sec; ~2 min wall time per ~50 listings.
3. Verify with the SQL in the runbook: `SELECT COUNT(*) FROM faculties WHERE university = 'AUTH'` should return 13 (was 11), and `faculty_distances` should have one row per listing for each of the 2 new landmarks.

## Test plan

- [ ] CI `migration-check.yml` passes — `supabase start` runs migrations 001 → 035 against a clean local stack and the inserts apply cleanly.
- [ ] On a local stack, after the migration, `SELECT faculty_id FROM faculties WHERE faculty_id IN ('auth-library', 'ahepa-hospital')` returns both rows.
- [ ] Re-applying the migration locally is a no-op (no error, no duplicate inserts).
- [ ] After merge, parent applies via Supabase MCP and runs `compute_distances.py --only-missing`; verifies row counts match expectations from the runbook.
- [ ] Follow-up (out of scope here): listing detail distance table updated to render `auth-library` + `ahepa-hospital` rows directly instead of proxying through `auth-main` / `auth-medical`.

## Notes

- `auth-medical` is **not** renamed. It already lives in production as `Faculty of Health Sciences` (the H4 fuzzy-name fix); the `ON CONFLICT DO NOTHING` clause guarantees we don't disturb it.
- `auth-main` (in `002` but not in production) is left alone — it's a working local fixture and removing it would diverge dev tooling without a prod-side benefit. Out of scope for this migration.
- The 9 backfilled AUTH coordinates look heavily duplicated (most share `40.6301, 22.9563` for the main quadrangle; `auth-fine-arts` and `auth-pe` share `40.5584, 23.0093` for the Thermi-area satellite). That's the live data, not a copy-paste error.
- The 2 landmark coordinates are real: AUTH Central Library on the main-campus quadrangle, AHEPA University Hospital adjacent to the medical campus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)