### PR TITLE
data(photos): one-off migration script Wix CDN -> Supabase Storage

### DIFF
--- a/docs/runbooks/listing-photos-migration.md
+++ b/docs/runbooks/listing-photos-migration.md
@@ -1,0 +1,169 @@
+# Runbook: Migrate listing photos from Wix CDN to Supabase Storage
+
+## Why
+
+12 of 13 production listings hotlink their photos from `static.wixstatic.com`.
+That's a single point of failure outside our control:
+
+- If Wix goes down, every listing's gallery breaks.
+- If Wix revokes hotlinking from third-party origins (their TOS technically
+  forbids it), the same thing happens with no warning.
+- og:image previews on Slack / Messenger / WhatsApp / Twitter all break too,
+  which kills sharing — our top organic channel.
+
+Migrating the bytes into our own Supabase Storage bucket removes Wix as a
+dependency. PR-B (#37) already added the Supabase Storage host to
+`next.config.mjs#images.remotePatterns`, so once `listings.photos[]` URLs are
+flipped to point at our bucket the gallery and og:image just work — no other
+code change needed.
+
+## Pre-flight (one-time): create the Storage bucket
+
+The script does NOT create the bucket — bucket creation needs Dashboard
+access and is a one-off. Do it before the first apply run.
+
+1. Open the Supabase Dashboard -> **Storage** -> **New bucket**.
+2. Name: `listing-photos`
+3. Public bucket: **Yes** (toggle on). Photos are public anyway — we render
+   them in `<img>` tags with no auth.
+4. File size limit: leave at default (50 MiB is plenty; listing photos are
+   typically 50-500 KiB).
+5. Allowed MIME types (optional, recommended): `image/jpeg, image/png,
+   image/webp, image/avif, image/gif`.
+6. Click **Save**.
+
+### Bucket access policy (storage.objects)
+
+The bucket must allow public reads. If you used the Dashboard "Public
+bucket" toggle, this is already set. To verify or apply via SQL:
+
+```sql
+-- Allow anyone to read objects in listing-photos
+CREATE POLICY "Public read on listing-photos"
+  ON storage.objects FOR SELECT
+  TO public
+  USING (bucket_id = 'listing-photos');
+```
+
+Writes are performed by the script using the service role key, which
+bypasses RLS. No write policy is needed for anon/authenticated users — we
+do not want users uploading directly.
+
+## Dry run (always do this first)
+
+```bash
+export SUPABASE_URL="https://YOUR-REF.supabase.co"
+export SUPABASE_KEY="YOUR-SERVICE-ROLE-KEY"   # NOT the anon key
+python3 scripts/migrate_listing_photos.py --dry-run
+```
+
+Output you should see:
+
+- `Mode: DRY-RUN (no writes will occur).`
+- A line per listing with at least one wixstatic URL.
+- For each Wix photo: a `DRY: would upload -> listing-photos/<id>/<n>.<ext>`
+  line and a `DRY: would rewrite photos[<n>] -> https://...supabase.co/...`
+  line.
+- A summary block at the end.
+
+If the dry run fails (network, missing bucket, bad credentials) **stop**
+and resolve before applying.
+
+## Apply (live writes)
+
+```bash
+export SUPABASE_URL="https://YOUR-REF.supabase.co"
+export SUPABASE_KEY="YOUR-SERVICE-ROLE-KEY"
+python3 scripts/migrate_listing_photos.py --apply
+```
+
+What this does, per Wix photo, in order:
+
+1. Fetches the image (15s timeout, 3 retries with backoff).
+2. Determines extension from `Content-Type` (jpg/png/webp/avif/gif; falls
+   back to jpg).
+3. Uploads to `listing-photos/<listing_id>/<NNN>.<ext>` (NNN = zero-padded
+   index in the source `photos[]`).
+4. After all photos in a listing succeed, captures the original `photos`
+   array to `scripts/migrate_listing_photos.rollback.sql`, then UPDATEs
+   `listings.photos` to the new array.
+
+Per-listing atomicity: if any photo within a listing fails, that listing's
+DB row is left untouched (you'll see the partial uploads in Storage but
+the public URLs still point at Wix until a re-run succeeds).
+
+### Single-listing scope (for testing or fixups)
+
+```bash
+python3 scripts/migrate_listing_photos.py --apply --listing 0100001
+```
+
+### Override bucket (rare)
+
+```bash
+python3 scripts/migrate_listing_photos.py --apply --bucket listing-photos-staging
+```
+
+## Verify
+
+After the apply completes, run this against the production database:
+
+```sql
+SELECT listing_id, photos
+FROM listings
+WHERE EXISTS (
+  SELECT 1
+  FROM unnest(photos) AS u(url)
+  WHERE u.url LIKE '%wixstatic.com%'
+);
+```
+
+Expected: zero rows. If any rows come back, those listings have at least
+one photo that failed to migrate — re-run `--apply` (the script is
+idempotent and will retry only the unmigrated URLs).
+
+Smoke test the site:
+
+- Open `/listing/0100001` (or any listing) and confirm the gallery loads.
+- Use the OpenGraph debugger
+  (https://www.opengraph.xyz/url/https%3A%2F%2Fstudentx.gr%2Flisting%2F0100001)
+  to confirm og:image points at `*.supabase.co/storage/...` and renders.
+
+## Rollback
+
+The script writes `scripts/migrate_listing_photos.rollback.sql` during
+the apply run, with one `UPDATE listings SET photos = ARRAY[...]`
+statement per listing it modified, wrapped in a `BEGIN; ... COMMIT;`.
+
+To roll back:
+
+```bash
+psql "$DATABASE_URL" -f scripts/migrate_listing_photos.rollback.sql
+```
+
+The Storage objects are left in place after rollback — they're orphaned
+but harmless and let us re-apply quickly if needed. Delete via the
+Dashboard if storage cost matters.
+
+## Idempotency
+
+Re-running `--apply` is safe:
+
+- Photos whose URL is already a `*.supabase.co/storage/...` URL pointing at
+  the expected destination are skipped.
+- If the destination object exists in Storage with matching byte size, the
+  upload is skipped (but the DB row is still rewritten — covers the case
+  where a previous run uploaded but crashed before the DB UPDATE).
+- The rollback file is regenerated from scratch on each `--apply` run.
+
+## Known limitations / future work
+
+- **New photos added after this migration** that are still hotlinked from
+  Wix won't be caught until someone re-runs the script. Future work: add a
+  Supabase trigger (or a CI cron) that flags any `listings.photos` value
+  containing `wixstatic.com` and either auto-migrates or alerts.
+- **The script doesn't delete the Wix source images** — we don't own them
+  and can't anyway. They remain on Wix until the original Wix site owner
+  removes them.
+- **Image dimensions / quality are preserved as-served by Wix.** If we
+  later want to thumbnail or re-encode, that's a separate pass.

--- a/scripts/migrate_listing_photos.py
+++ b/scripts/migrate_listing_photos.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env python3
+"""
+One-off migration script: Wix CDN -> Supabase Storage for listing photos.
+
+Production listings hotlink photos from static.wixstatic.com (12 of 13 listings
+at time of writing). If Wix goes down or revokes hotlinking, the gallery and
+og:image break sitewide. This script copies every Wix-hosted photo into our
+own Supabase Storage bucket (`listing-photos`) and rewrites
+`listings.photos[]` to point at the new URLs.
+
+Usage:
+    # Dry run (default — prints what would happen, mutates nothing)
+    python3 scripts/migrate_listing_photos.py --dry-run
+
+    # Apply (actually fetch, upload, and update DB)
+    python3 scripts/migrate_listing_photos.py --apply
+
+    # Restrict to one listing
+    python3 scripts/migrate_listing_photos.py --apply --listing 0100001
+
+    # Override bucket (rare)
+    python3 scripts/migrate_listing_photos.py --apply --bucket listing-photos
+
+Idempotency:
+    - Skips photos whose URL is already a Supabase Storage URL pointing at the
+      expected destination.
+    - If the destination object already exists in Storage with matching size,
+      skips the upload but still rewrites the DB row (covers the case where a
+      previous run uploaded but failed before the DB update).
+
+Safety:
+    - --dry-run is the default. --apply is required for any side effect.
+    - On any photo failure within a listing, the listing's photos array is
+      NOT updated (all-or-nothing per listing).
+    - Before any DB write, captures rollback SQL to
+      scripts/migrate_listing_photos.rollback.sql so a previous-state restore
+      is one psql invocation away.
+
+Pre-flight (one-time):
+    The `listing-photos` Supabase Storage bucket must exist and be public.
+    Create it via the Supabase Dashboard. See
+    docs/runbooks/listing-photos-migration.md for the bucket policy snippet.
+
+Environment variables required:
+    SUPABASE_URL  - Supabase project URL (e.g. https://abc.supabase.co)
+    SUPABASE_KEY  - Supabase service role key (anon won't have write access
+                    to Storage or the listings table for this script's needs)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from urllib.parse import urlparse
+
+try:
+    import requests
+except ImportError:
+    print("Error: requests library is not installed.")
+    print("  Fix: pip install -r scripts/requirements.txt")
+    sys.exit(1)
+
+try:
+    from supabase import create_client, Client
+except ImportError:
+    print("Error: supabase-py is not installed.")
+    print("  Fix: pip install -r scripts/requirements.txt")
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+WIX_HOST = "static.wixstatic.com"
+DEFAULT_BUCKET = "listing-photos"
+FETCH_TIMEOUT = 15  # seconds per image fetch
+MAX_RETRIES = 3
+ROLLBACK_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "migrate_listing_photos.rollback.sql",
+)
+
+# Map of common Content-Type values to file extensions. Anything not in this
+# map falls back to "jpg" (the most common case in production data) so we
+# always end up with *some* extension on disk.
+CONTENT_TYPE_EXT = {
+    "image/jpeg": "jpg",
+    "image/jpg": "jpg",
+    "image/pjpeg": "jpg",
+    "image/png": "png",
+    "image/webp": "webp",
+    "image/gif": "gif",
+    "image/avif": "avif",
+}
+DEFAULT_EXT = "jpg"
+
+
+# ---------------------------------------------------------------------------
+# Supabase
+# ---------------------------------------------------------------------------
+
+def init_supabase() -> tuple[Client, str]:
+    """Connect to Supabase. Returns (client, project_url). Exits on failure."""
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_KEY")
+    if not url or not key:
+        print("=" * 60)
+        print("ERROR: Supabase credentials not set.")
+        print()
+        print("Set these environment variables before running:")
+        print()
+        print('  export SUPABASE_URL="https://YOUR-REF.supabase.co"')
+        print('  export SUPABASE_KEY="your-service-role-key"')
+        print()
+        print("Find them in: Supabase Dashboard -> Project Settings -> API")
+        print("(Service role key required — anon key won't work for Storage")
+        print(" uploads + listings updates.)")
+        print("=" * 60)
+        sys.exit(1)
+
+    try:
+        client = create_client(url, key)
+        client.table("listings").select("listing_id").limit(1).execute()
+        return client, url.rstrip("/")
+    except Exception as e:
+        error_str = str(e)
+        print("=" * 60)
+        print("ERROR: Could not connect to Supabase.")
+        print()
+        if "PGRST" in error_str and "schema cache" in error_str:
+            print("Tables don't exist yet. Run the migrations first.")
+        elif "Invalid API key" in error_str:
+            print("Invalid API key. Check SUPABASE_KEY.")
+        else:
+            print(f"Details: {e}")
+        print("=" * 60)
+        sys.exit(1)
+
+
+def fetch_listings(supabase: Client, listing_filter: str | None) -> list[dict]:
+    """Fetch all listings with photos arrays. Optionally filter to one id."""
+    try:
+        query = supabase.table("listings").select("listing_id, photos")
+        if listing_filter:
+            query = query.eq("listing_id", listing_filter)
+        result = query.execute()
+    except Exception as e:
+        print(f"Error fetching listings: {e}")
+        sys.exit(1)
+
+    if listing_filter and not result.data:
+        print(f"Error: Listing '{listing_filter}' not found.")
+        sys.exit(1)
+
+    return result.data or []
+
+
+# ---------------------------------------------------------------------------
+# URL classification
+# ---------------------------------------------------------------------------
+
+def is_wix_url(url: str) -> bool:
+    """True iff url is hosted on static.wixstatic.com."""
+    try:
+        return urlparse(url).hostname == WIX_HOST
+    except Exception:
+        return False
+
+
+def is_storage_url(url: str, project_url: str, bucket: str) -> bool:
+    """True iff url already points at our Supabase Storage bucket."""
+    expected_prefix = f"{project_url}/storage/v1/object/public/{bucket}/"
+    return isinstance(url, str) and url.startswith(expected_prefix)
+
+
+def storage_path_for(listing_id: str, index: int, ext: str) -> str:
+    """Compute the in-bucket object path: <listing_id>/<NNN>.<ext>."""
+    return f"{listing_id}/{index:03d}.{ext}"
+
+
+def public_url_for(project_url: str, bucket: str, path: str) -> str:
+    """Compute the public Storage URL for an in-bucket path."""
+    return f"{project_url}/storage/v1/object/public/{bucket}/{path}"
+
+
+# ---------------------------------------------------------------------------
+# Fetch + upload
+# ---------------------------------------------------------------------------
+
+def fetch_image(url: str) -> tuple[bytes, str] | tuple[None, None]:
+    """
+    Fetch an image with retry-on-timeout. Returns (bytes, content_type).
+    Returns (None, None) on permanent failure.
+    """
+    last_error = None
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            resp = requests.get(url, timeout=FETCH_TIMEOUT)
+            resp.raise_for_status()
+            content_type = (resp.headers.get("Content-Type") or "").split(";")[0].strip().lower()
+            return resp.content, content_type
+        except requests.exceptions.Timeout:
+            last_error = f"Timeout after {FETCH_TIMEOUT}s"
+            if attempt < MAX_RETRIES:
+                wait = 2 * attempt
+                print(f"      Fetch timeout, retry {attempt}/{MAX_RETRIES} in {wait}s...")
+                time.sleep(wait)
+            continue
+        except requests.exceptions.ConnectionError as e:
+            last_error = f"Connection error: {e}"
+            if attempt < MAX_RETRIES:
+                wait = 2 * attempt
+                print(f"      Connection error, retry {attempt}/{MAX_RETRIES} in {wait}s...")
+                time.sleep(wait)
+            continue
+        except requests.exceptions.HTTPError as e:
+            status = e.response.status_code if e.response else "unknown"
+            last_error = f"HTTP {status}"
+            # 4xx is permanent; 5xx may benefit from retry
+            if isinstance(status, int) and 500 <= status < 600 and attempt < MAX_RETRIES:
+                wait = 2 * attempt
+                print(f"      HTTP {status}, retry {attempt}/{MAX_RETRIES} in {wait}s...")
+                time.sleep(wait)
+                continue
+            break
+
+    print(f"      Fetch failed after {MAX_RETRIES} attempts: {last_error}")
+    return None, None
+
+
+def ext_from_content_type(content_type: str) -> str:
+    """Map a Content-Type to a filename extension; falls back to jpg."""
+    return CONTENT_TYPE_EXT.get(content_type, DEFAULT_EXT)
+
+
+def storage_object_size(supabase: Client, bucket: str, path: str) -> int | None:
+    """
+    Returns the size in bytes of an existing object, or None if missing.
+    Uses Storage list() under the prefix because the supabase-py client
+    doesn't expose a direct stat() — list() returns objects with metadata.
+    """
+    parent = path.rsplit("/", 1)[0] if "/" in path else ""
+    target_name = path.rsplit("/", 1)[-1]
+    try:
+        items = supabase.storage.from_(bucket).list(parent)
+    except Exception:
+        return None
+    for item in items or []:
+        if item.get("name") == target_name:
+            metadata = item.get("metadata") or {}
+            size = metadata.get("size")
+            if isinstance(size, (int, float)):
+                return int(size)
+            return None
+    return None
+
+
+def upload_to_storage(
+    supabase: Client,
+    bucket: str,
+    path: str,
+    data: bytes,
+    content_type: str,
+) -> str | None:
+    """Upload bytes to Storage. Returns an error string, or None on success."""
+    try:
+        supabase.storage.from_(bucket).upload(
+            path=path,
+            file=data,
+            file_options={
+                # cache_control: a year is fine — content-addressed by index
+                "cache-control": "31536000",
+                "content-type": content_type or "application/octet-stream",
+                # upsert=true so re-runs overwrite on byte-mismatch
+                "upsert": "true",
+            },
+        )
+        return None
+    except Exception as e:
+        return str(e)
+
+
+# ---------------------------------------------------------------------------
+# Per-listing migration
+# ---------------------------------------------------------------------------
+
+def migrate_listing(
+    supabase: Client,
+    listing: dict,
+    project_url: str,
+    bucket: str,
+    apply: bool,
+) -> dict:
+    """
+    Process one listing. Returns a result dict:
+        {
+            "listing_id": str,
+            "new_photos": list[str] | None,    # only if all photos succeeded
+            "migrated": int,
+            "skipped": int,
+            "failed": int,
+            "errors": list[str],
+        }
+    Caller decides whether to UPDATE the DB based on whether failed == 0.
+    """
+    listing_id = listing["listing_id"]
+    photos = listing.get("photos") or []
+    result = {
+        "listing_id": listing_id,
+        "new_photos": None,
+        "migrated": 0,
+        "skipped": 0,
+        "failed": 0,
+        "errors": [],
+    }
+
+    new_photos: list[str] = []
+    for idx, src_url in enumerate(photos):
+        # Non-Wix and non-storage URLs (e.g. a host we don't manage): keep as-is.
+        if not isinstance(src_url, str) or not src_url:
+            new_photos.append(src_url)
+            result["skipped"] += 1
+            continue
+
+        if is_storage_url(src_url, project_url, bucket):
+            # Already migrated — keep as is.
+            new_photos.append(src_url)
+            result["skipped"] += 1
+            continue
+
+        if not is_wix_url(src_url):
+            # Some other host, leave it alone.
+            new_photos.append(src_url)
+            result["skipped"] += 1
+            continue
+
+        # --- Wix URL: needs migration ---
+        print(f"    [{idx:03d}] {src_url}")
+
+        data, content_type = fetch_image(src_url)
+        if data is None:
+            err = f"fetch failed for index {idx}: {src_url}"
+            print(f"      FAILED: {err}")
+            result["failed"] += 1
+            result["errors"].append(err)
+            new_photos.append(src_url)  # keep original on failure
+            continue
+
+        ext = ext_from_content_type(content_type)
+        path = storage_path_for(listing_id, idx, ext)
+        dest_url = public_url_for(project_url, bucket, path)
+
+        # Idempotency: if the destination object already exists with matching
+        # size, skip the upload but still rewrite the DB row.
+        existing_size = storage_object_size(supabase, bucket, path)
+        size_match = existing_size is not None and existing_size == len(data)
+
+        if not apply:
+            action = "would skip upload (size match)" if size_match else "would upload"
+            print(f"      DRY: {action} -> {bucket}/{path} ({len(data)} bytes, {content_type or 'unknown'})")
+            print(f"      DRY: would rewrite photos[{idx}] -> {dest_url}")
+            new_photos.append(dest_url)
+            result["migrated"] += 1
+            continue
+
+        if size_match:
+            print(f"      SKIP upload: object exists with matching size ({existing_size} bytes)")
+        else:
+            print(f"      UPLOAD -> {bucket}/{path} ({len(data)} bytes, {content_type or 'unknown'})")
+            err = upload_to_storage(supabase, bucket, path, data, content_type)
+            if err:
+                msg = f"upload failed for index {idx}: {err}"
+                print(f"      FAILED: {msg}")
+                result["failed"] += 1
+                result["errors"].append(msg)
+                new_photos.append(src_url)  # keep original on failure
+                continue
+
+        new_photos.append(dest_url)
+        result["migrated"] += 1
+
+    # Only return new_photos if every photo either migrated or was safely
+    # skipped. If anything failed, the caller must NOT update the DB row.
+    if result["failed"] == 0:
+        result["new_photos"] = new_photos
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Rollback SQL capture
+# ---------------------------------------------------------------------------
+
+def append_rollback_sql(listing_id: str, original_photos: list[str]) -> None:
+    """
+    Append a SQL UPDATE statement that restores this listing's photos to the
+    pre-migration state. Written incrementally so a crash mid-run still
+    leaves a valid rollback for whatever rows were touched.
+    """
+    # Build a Postgres array literal with safe escaping.
+    parts = []
+    for url in original_photos:
+        if url is None:
+            parts.append("NULL")
+            continue
+        # Escape single quotes by doubling them; Postgres array literal syntax.
+        escaped = str(url).replace("'", "''")
+        parts.append(f"'{escaped}'")
+    array_literal = "ARRAY[" + ", ".join(parts) + "]::text[]"
+
+    line = (
+        f"UPDATE listings SET photos = {array_literal} "
+        f"WHERE listing_id = '{listing_id}';\n"
+    )
+
+    # Create the file with a header on first write.
+    new_file = not os.path.exists(ROLLBACK_PATH)
+    with open(ROLLBACK_PATH, "a", encoding="utf-8") as f:
+        if new_file:
+            f.write("-- Rollback for migrate_listing_photos.py\n")
+            f.write("-- Generated automatically before each --apply DB write.\n")
+            f.write("-- Apply via: psql $DATABASE_URL -f scripts/migrate_listing_photos.rollback.sql\n")
+            f.write("BEGIN;\n")
+        f.write(line)
+
+
+def finalize_rollback_sql() -> None:
+    """Append COMMIT to the rollback file if it was opened."""
+    if os.path.exists(ROLLBACK_PATH):
+        with open(ROLLBACK_PATH, "a", encoding="utf-8") as f:
+            f.write("COMMIT;\n")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Migrate Wix-hotlinked listing photos into Supabase Storage.",
+        epilog="Default mode is --dry-run. Use --apply to actually mutate.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually perform fetches, uploads, and DB updates. Required for any side effect.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print every action that would be taken; mutate nothing. Default if --apply is absent.",
+    )
+    parser.add_argument(
+        "--listing",
+        type=str,
+        default=None,
+        help="Restrict to a single listing_id.",
+    )
+    parser.add_argument(
+        "--only-wix",
+        action="store_true",
+        help="(Default behavior) Only touch listings with at least one wixstatic URL. "
+             "Flag is explicit for forward-compat.",
+    )
+    parser.add_argument(
+        "--bucket",
+        type=str,
+        default=DEFAULT_BUCKET,
+        help=f"Supabase Storage bucket name (default: {DEFAULT_BUCKET})",
+    )
+    args = parser.parse_args()
+
+    # Resolve effective mode. --apply wins; otherwise dry-run.
+    apply = bool(args.apply)
+    if apply and args.dry_run:
+        print("Both --apply and --dry-run passed; --apply wins.")
+    if not apply:
+        print("Mode: DRY-RUN (no writes will occur). Pass --apply to mutate.")
+    else:
+        print("Mode: APPLY (will fetch, upload, and update DB).")
+    print(f"Bucket: {args.bucket}")
+    print()
+
+    print("Connecting to Supabase...")
+    supabase, project_url = init_supabase()
+    print(f"Connected to {project_url}\n")
+
+    print("Fetching listings...")
+    all_listings = fetch_listings(supabase, args.listing)
+    print(f"  Found {len(all_listings)} listing(s) total")
+
+    # Filter to listings that have at least one wixstatic URL. Both default
+    # behavior and explicit --only-wix produce the same result; the flag
+    # exists so a future reader can tell that this script is wix-scoped.
+    affected = [
+        l for l in all_listings
+        if any(is_wix_url(u) for u in (l.get("photos") or []) if isinstance(u, str))
+    ]
+    print(f"  {len(affected)} listing(s) have at least one wixstatic.com URL")
+
+    if not affected:
+        print("\nNothing to do.")
+        return 0
+
+    # If we're applying, wipe any stale rollback file so each run starts fresh.
+    if apply and os.path.exists(ROLLBACK_PATH):
+        os.remove(ROLLBACK_PATH)
+
+    totals = {"migrated": 0, "skipped": 0, "failed": 0, "listings_updated": 0, "listings_failed": 0}
+    print()
+
+    for listing in affected:
+        listing_id = listing["listing_id"]
+        original_photos = list(listing.get("photos") or [])
+        print(f"Listing {listing_id} ({len(original_photos)} photo(s)):")
+        result = migrate_listing(supabase, listing, project_url, args.bucket, apply)
+
+        totals["migrated"] += result["migrated"]
+        totals["skipped"] += result["skipped"]
+        totals["failed"] += result["failed"]
+
+        if result["failed"] > 0:
+            print(f"  -> {result['failed']} failure(s); NOT updating photos array for this listing.")
+            for err in result["errors"]:
+                print(f"     - {err}")
+            totals["listings_failed"] += 1
+            print()
+            continue
+
+        new_photos = result["new_photos"]
+        if new_photos == original_photos:
+            print("  -> no changes (all photos already migrated or non-Wix)")
+            print()
+            continue
+
+        if not apply:
+            print(f"  -> DRY: would UPDATE listings SET photos=<{len(new_photos)} urls> "
+                  f"WHERE listing_id='{listing_id}'")
+            print()
+            continue
+
+        # Capture rollback BEFORE issuing the UPDATE so a crash here still
+        # leaves a recoverable trail.
+        append_rollback_sql(listing_id, original_photos)
+        try:
+            supabase.table("listings").update({"photos": new_photos}).eq("listing_id", listing_id).execute()
+            print(f"  -> UPDATED listings.photos for {listing_id}")
+            totals["listings_updated"] += 1
+        except Exception as e:
+            print(f"  -> DB UPDATE failed: {e}")
+            totals["listings_failed"] += 1
+        print()
+
+    if apply:
+        finalize_rollback_sql()
+
+    print("=" * 60)
+    print("Summary")
+    print("=" * 60)
+    print(f"  Photos migrated:   {totals['migrated']}")
+    print(f"  Photos skipped:    {totals['skipped']}")
+    print(f"  Photos failed:     {totals['failed']}")
+    if apply:
+        print(f"  Listings updated:  {totals['listings_updated']}")
+        print(f"  Listings failed:   {totals['listings_failed']}")
+        if totals["listings_updated"] > 0:
+            print(f"  Rollback SQL:      {ROLLBACK_PATH}")
+    else:
+        print("  (dry-run: no writes performed)")
+    print("=" * 60)
+
+    return 1 if totals["failed"] > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

12 of 13 production listings hotlink photos from `static.wixstatic.com`. That's a single point of failure outside our control — if Wix goes down or revokes hotlinking, every listing's gallery and og:image breaks sitewide. This PR adds a one-off migration script (no runtime code changes) that copies every Wix-hosted photo into our own Supabase Storage bucket and rewrites `listings.photos[]` to point at the new URLs.

`next.config.mjs` already lists `ecluqurlfbvkxrnoyhaq.supabase.co` in `images.remotePatterns` (from PR-B / #37), so once URLs are flipped the gallery and og:image just work — no other code change needed.

## How it works

For each listing whose `photos[]` contains at least one `static.wixstatic.com` URL:

1. Fetch the image (15s timeout, 3 retries with backoff).
2. Determine extension from `Content-Type` (`jpg`/`png`/`webp`/`avif`/`gif`; falls back to `jpg`).
3. Upload to `listing-photos/<listing_id>/<NNN>.<ext>` (NNN = zero-padded index).
4. After all photos in the listing succeed, capture rollback SQL, then `UPDATE listings SET photos = <new array>`.

Per-listing atomicity: if any photo within a listing fails, that listing's DB row is left untouched and the failure is reported.

## Pre-flight (one-time)

The `listing-photos` Supabase Storage bucket must exist and be public **before** running `--apply`. The script does NOT create it (Dashboard-only operation). Steps and the public-read policy SQL are in `docs/runbooks/listing-photos-migration.md`.

## Apply steps

```bash
# 1. Always dry-run first
export SUPABASE_URL="https://YOUR-REF.supabase.co"
export SUPABASE_KEY="YOUR-SERVICE-ROLE-KEY"
python3 scripts/migrate_listing_photos.py --dry-run

# 2. Apply
python3 scripts/migrate_listing_photos.py --apply

# 3. Verify: this query should return zero rows
psql "$DATABASE_URL" -c "
  SELECT listing_id FROM listings
  WHERE EXISTS (SELECT 1 FROM unnest(photos) u(url) WHERE u.url LIKE '%wixstatic.com%');
"
```

`--dry-run` is the default safe mode. `--apply` is required for any side effect. `--listing <id>` scopes to one listing for testing or fixups. Re-running `--apply` is safe — already-migrated URLs are skipped, and Storage objects with matching size are skipped at the upload step but still trigger a DB rewrite.

## Rollback

The script writes `scripts/migrate_listing_photos.rollback.sql` during `--apply`, with one `UPDATE listings SET photos = ARRAY[...]` per modified listing wrapped in `BEGIN; ... COMMIT;`. To roll back:

```bash
psql "$DATABASE_URL" -f scripts/migrate_listing_photos.rollback.sql
```

Storage objects are left in place after rollback — orphaned but harmless, and lets us re-apply without re-uploading.

## Risks

- **Wix throttling/blocking the bulk fetch.** Mitigated by 15s timeout + retries; if a fetch fails the script reports it and skips updating that listing's row.
- **Bucket not created before `--apply`.** Upload calls will fail; per-listing atomicity means no listings get half-updated. Documented prominently in the runbook.
- **Service role key leak.** Standard hygiene — pass via env var, never commit. Same posture as `compute_distances.py`.
- **Bytes mismatch on idempotent re-run.** Size check in `storage_object_size` decides skip vs. re-upload. Re-uploads use `upsert=true`.

## Out of scope

- Running the script against production. The user runs it post-merge, dry-run first.
- Changes to `listings` table or `next.config.mjs` (already correct from PR-B).
- A trigger / cron to catch *future* Wix-hotlinked photos added after this migration. Called out as future work in the runbook.
- Image re-encoding / thumbnailing. Bytes are preserved as-served by Wix.

## Test plan

- [ ] Verify script parses: `python3 -c "import ast; ast.parse(open('scripts/migrate_listing_photos.py').read())"`
- [ ] Verify CLI help: `python3 scripts/migrate_listing_photos.py --help`
- [ ] (Post-merge, by user) Create the `listing-photos` bucket in the Dashboard.
- [ ] (Post-merge, by user) Run `--dry-run` against production; confirm summary lists ~12 affected listings and no errors.
- [ ] (Post-merge, by user) Run `--apply`; confirm the verification SQL returns zero rows.
- [ ] (Post-merge, by user) Spot-check 2-3 listing pages render with Storage URLs and og:image previews resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)