### PR TITLE
fix(security,monitoring): cap ?from=, enforce CSP, expand smoke checks

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,10 +2,22 @@ import createNextIntlPlugin from 'next-intl/plugin';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.js');
 
-// Baseline security headers applied to every route. CSP is delivered in
-// Report-Only mode so we observe violations without blocking the live site
-// — flip to enforced once the report endpoint is wired and clean.
-// Allow lists tracked alongside `next.config.mjs#images.remotePatterns`.
+// Baseline security headers applied to every route. CSP was rolled out in
+// Report-Only mode (PR #28); audit before flipping found the only
+// browser-loaded third-party host not yet covered was unpkg.com (Leaflet
+// default marker icons in src/components/ListingsMap.js). Added it to
+// img-src and flipped to enforced. Allow lists tracked alongside
+// `next.config.mjs#images.remotePatterns`.
+//
+// Audit summary (browser-side traffic surface):
+//   - script-src: only inline JSON-LD in src/app/[locale]/listing/[id]/layout.js;
+//     covered by 'unsafe-inline'.
+//   - img-src: static.wixstatic.com (listing photos), Supabase storage
+//     (uploaded photos), *.tile.openstreetmap.org (map tiles), unpkg.com
+//     (Leaflet marker PNGs); all listed below.
+//   - connect-src: only Supabase.
+//   - font-src: next/font/google self-hosts at build time; fonts.gstatic.com
+//     kept defensively in case any subset still pulls there.
 const SECURITY_HEADERS = [
   { key: 'X-Content-Type-Options', value: 'nosniff' },
   { key: 'X-Frame-Options', value: 'DENY' },
@@ -19,12 +31,12 @@ const SECURITY_HEADERS = [
     value: 'max-age=63072000; includeSubDomains; preload',
   },
   {
-    key: 'Content-Security-Policy-Report-Only',
+    key: 'Content-Security-Policy',
     value: [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
       "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: blob: https://static.wixstatic.com https://ecluqurlfbvkxrnoyhaq.supabase.co https://*.tile.openstreetmap.org",
+      "img-src 'self' data: blob: https://static.wixstatic.com https://ecluqurlfbvkxrnoyhaq.supabase.co https://*.tile.openstreetmap.org https://unpkg.com",
       "font-src 'self' data: https://fonts.gstatic.com",
       "connect-src 'self' https://ecluqurlfbvkxrnoyhaq.supabase.co",
       "frame-ancestors 'none'",

--- a/src/app/[locale]/listing/[id]/page.js
+++ b/src/app/[locale]/listing/[id]/page.js
@@ -16,6 +16,11 @@ import Icon from '@/components/ui/Icon';
 import VerifiedSeal from '@/components/ui/VerifiedSeal';
 import OrnamentRule from '@/components/ui/OrnamentRule';
 
+// Cap on the untrusted ?from= URL param. Real /results querystrings are
+// well under this; anything bigger is almost certainly an attempt to
+// stuff oversized payloads into the back-link / AuthGate redirect.
+const MAX_FROM_LENGTH = 512;
+
 export default async function ListingPage({ params, searchParams }) {
   const { locale, id } = await params;
   const sp = (await searchParams) || {};
@@ -24,7 +29,11 @@ export default async function ListingPage({ params, searchParams }) {
   // ?from=<urlencoded querystring> threads the user's prior /results
   // filter state into the back-link so it returns to the same filtered
   // view they came from. Plain ?from= param (or missing) → bare /results.
-  const fromRaw = typeof sp.from === 'string' ? sp.from : '';
+  // Drop oversized values (length cap above) — fall through to bare
+  // /results rather than echoing untrusted bytes into the rendered href.
+  const fromRawInput = typeof sp.from === 'string' ? sp.from : '';
+  const fromRaw =
+    fromRawInput && fromRawInput.length <= MAX_FROM_LENGTH ? fromRawInput : '';
   const backHref = fromRaw ? `/results?${fromRaw}` : '/results';
 
   // Auth gate — only authenticated students view listing detail. The

--- a/src/app/api/cron/synthetic-en-listing/route.js
+++ b/src/app/api/cron/synthetic-en-listing/route.js
@@ -2,12 +2,18 @@ import { NextResponse } from 'next/server';
 import { getResend } from '@/lib/resend';
 
 // Synthetic uptime check guarding against the regression class fixed in PR #48
-// (see issue #49 + docs/runbooks/synthetic-en-listing.md). Fetches the EN listing
-// page and asserts English markers are present + Greek markers absent. Emails
-// SYNTHETIC_ALERT_EMAIL via Resend on any failure.
+// (see issue #49 + docs/runbooks/synthetic-en-listing.md). Originally just
+// asserted that /en/listing/<id> renders English markers + no Greek leakage;
+// now also runs four production-canary checks (listing API distance variety,
+// 404 status on missing listings, og-default.png served as PNG, no
+// MISSING_MESSAGE next-intl placeholders on /en).
 //
-// Triggered by cf/worker-entry.mjs on the */15 * * * * cron. Also callable
-// manually with the CRON_SECRET for local sanity checks.
+// All assertions run independently; one failing does not block the others.
+// On any failure, emails SYNTHETIC_ALERT_EMAIL via Resend (if RESEND_API_KEY
+// configured) and returns 500 with the failure list. On all-pass returns 200
+// with the per-check status. Triggered by cf/worker-entry.mjs on the
+// */15 * * * * cron. Also callable manually with the CRON_SECRET for local
+// sanity checks.
 
 const DEFAULT_LISTING_ID = '0100006';
 const FETCH_TIMEOUT_MS = 10_000;
@@ -30,13 +36,18 @@ function isCronAuthorized(request) {
   return searchParams.get('secret') === secret;
 }
 
-async function fetchListingHtml(url) {
+async function fetchUrl(url, { method = 'GET' } = {}) {
   const res = await fetch(url, {
-    method: 'GET',
+    method,
     headers: { 'user-agent': 'StudentX-synthetic/1.0' },
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     redirect: 'manual',
   });
+  return res;
+}
+
+async function fetchListingHtml(url) {
+  const res = await fetchUrl(url);
   const body = await res.text();
   return { status: res.status, body };
 }
@@ -58,22 +69,103 @@ function evaluateBody({ status, body }) {
   return { ok: true };
 }
 
-async function sendAlert({ to, listingId, url, status, reason, bodyExcerpt }) {
+// --- Additional smoke assertions (all soft-fail: append to `failures`) -----
+
+// Listing API returns ≥2 distinct walk_minutes values across faculty_distances.
+// Guards against transformListing dropping the field or the seed regressing
+// to all-equal distances. We just need diversity, not exact values.
+async function checkListingApiDistanceVariety(appUrl, listingId) {
+  const url = `${appUrl}/api/listings/${listingId}`;
+  try {
+    const res = await fetchUrl(url);
+    if (res.status !== 200) {
+      return { name: 'listing-api-distances', ok: false, reason: `status ${res.status} from ${url}` };
+    }
+    const json = await res.json();
+    const distances = json?.listing?.faculty_distances || [];
+    const walks = new Set(
+      distances
+        .map((d) => d.walk_minutes)
+        .filter((w) => w != null),
+    );
+    if (walks.size < 2) {
+      return {
+        name: 'listing-api-distances',
+        ok: false,
+        reason: `expected ≥2 distinct walk_minutes, got ${walks.size} (${[...walks].join(',')})`,
+      };
+    }
+    return { name: 'listing-api-distances', ok: true };
+  } catch (err) {
+    return { name: 'listing-api-distances', ok: false, reason: `fetch threw: ${err.message || err.name}` };
+  }
+}
+
+// Unknown listing should hit notFound() and serve the locale-aware 404 page
+// with HTTP 404. Greek is the default at root, so we hit `/listing/...`,
+// not `/en/listing/...`.
+async function checkSoft404(appUrl) {
+  const url = `${appUrl}/listing/does-not-exist`;
+  try {
+    const res = await fetchUrl(url);
+    if (res.status !== 404) {
+      return { name: 'soft-404', ok: false, reason: `expected 404, got ${res.status} from ${url}` };
+    }
+    return { name: 'soft-404', ok: true };
+  } catch (err) {
+    return { name: 'soft-404', ok: false, reason: `fetch threw: ${err.message || err.name}` };
+  }
+}
+
+// og-default.png must serve as image/png — broken paths surface as text/html
+// (the Next 404 page) rather than 404, so check the content-type explicitly.
+async function checkOgDefault(appUrl) {
+  const url = `${appUrl}/og-default.png`;
+  try {
+    const res = await fetchUrl(url);
+    if (res.status !== 200) {
+      return { name: 'og-default', ok: false, reason: `expected 200, got ${res.status} from ${url}` };
+    }
+    const ct = (res.headers.get('content-type') || '').toLowerCase();
+    if (!ct.includes('image/png')) {
+      return { name: 'og-default', ok: false, reason: `expected image/png, got "${ct}"` };
+    }
+    return { name: 'og-default', ok: true };
+  } catch (err) {
+    return { name: 'og-default', ok: false, reason: `fetch threw: ${err.message || err.name}` };
+  }
+}
+
+// next-intl renders `MISSING_MESSAGE: ...` placeholders when a key is absent
+// from the locale's messages bundle. Treat any such substring on /en as a
+// regression — it means a translation key was added without a peer in en.json.
+async function checkNoMissingMessage(appUrl) {
+  const url = `${appUrl}/en`;
+  try {
+    const res = await fetchUrl(url);
+    if (res.status !== 200) {
+      return { name: 'missing-message', ok: false, reason: `expected 200, got ${res.status} from ${url}` };
+    }
+    const body = await res.text();
+    if (body.includes('MISSING_MESSAGE:')) {
+      const idx = body.indexOf('MISSING_MESSAGE:');
+      const excerpt = body.slice(idx, idx + 120);
+      return { name: 'missing-message', ok: false, reason: `MISSING_MESSAGE present: ${excerpt}` };
+    }
+    return { name: 'missing-message', ok: true };
+  } catch (err) {
+    return { name: 'missing-message', ok: false, reason: `fetch threw: ${err.message || err.name}` };
+  }
+}
+
+async function sendAlert({ to, subject, lines }) {
   const resend = getResend();
   const from = process.env.RESEND_FROM_EMAIL || 'StudentX Alerts <alerts@studentx.gr>';
   await resend.emails.send({
     from,
     to,
-    subject: `[StudentX synthetic] /en/listing/${listingId} failed: ${reason}`,
-    text: [
-      `Synthetic check failed for ${url}`,
-      ``,
-      `Status: ${status ?? 'no response'}`,
-      `Reason: ${reason}`,
-      ``,
-      `--- HTML excerpt (first 500 chars) ---`,
-      bodyExcerpt || '(no body)',
-    ].join('\n'),
+    subject,
+    text: lines.join('\n'),
   });
 }
 
@@ -85,43 +177,70 @@ export async function POST(request) {
   const listingId = process.env.SYNTHETIC_LISTING_ID || DEFAULT_LISTING_ID;
   const alertEmail = process.env.SYNTHETIC_ALERT_EMAIL;
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-  const url = `${appUrl}/en/listing/${listingId}`;
+  const enListingUrl = `${appUrl}/en/listing/${listingId}`;
 
-  let fetched;
+  const checks = [];
+  const failures = [];
+
+  // --- Original assertion: /en/listing renders without Greek leakage -------
+  let enListingExcerpt = '';
   try {
-    fetched = await fetchListingHtml(url);
+    const fetched = await fetchListingHtml(enListingUrl);
+    const verdict = evaluateBody(fetched);
+    if (verdict.ok) {
+      checks.push({ name: 'en-listing-locale', ok: true });
+    } else {
+      enListingExcerpt = (fetched.body || '').slice(0, 500);
+      const failure = { name: 'en-listing-locale', ok: false, reason: verdict.reason };
+      checks.push(failure);
+      failures.push(failure);
+    }
   } catch (err) {
     const reason = `fetch threw: ${err.name || 'Error'} ${err.message || ''}`.trim();
-    if (alertEmail) {
-      try {
-        await sendAlert({ to: alertEmail, listingId, url, status: null, reason, bodyExcerpt: '' });
-      } catch (mailErr) {
-        console.error('[synthetic-en-listing] alert email failed:', mailErr);
-      }
-    }
-    return NextResponse.json({ ok: false, reason }, { status: 200 });
+    const failure = { name: 'en-listing-locale', ok: false, reason };
+    checks.push(failure);
+    failures.push(failure);
   }
 
-  const verdict = evaluateBody(fetched);
-  if (!verdict.ok) {
-    if (alertEmail) {
+  // --- Additional assertions, run independently ----------------------------
+  const additional = await Promise.all([
+    checkListingApiDistanceVariety(appUrl, listingId),
+    checkSoft404(appUrl),
+    checkOgDefault(appUrl),
+    checkNoMissingMessage(appUrl),
+  ]);
+  for (const r of additional) {
+    checks.push(r);
+    if (!r.ok) failures.push(r);
+  }
+
+  if (failures.length > 0) {
+    if (alertEmail && process.env.RESEND_API_KEY) {
       try {
         await sendAlert({
           to: alertEmail,
-          listingId,
-          url,
-          status: fetched.status,
-          reason: verdict.reason,
-          bodyExcerpt: fetched.body.slice(0, 500),
+          subject: `[StudentX synthetic] ${failures.length} check${failures.length === 1 ? '' : 's'} failed`,
+          lines: [
+            `Synthetic check failed against ${appUrl}`,
+            ``,
+            `Failures (${failures.length}):`,
+            ...failures.map((f) => `  - ${f.name}: ${f.reason}`),
+            ``,
+            `--- /en/listing HTML excerpt (first 500 chars) ---`,
+            enListingExcerpt || '(n/a)',
+          ],
         });
       } catch (mailErr) {
         console.error('[synthetic-en-listing] alert email failed:', mailErr);
       }
     } else {
-      console.error('[synthetic-en-listing] no SYNTHETIC_ALERT_EMAIL configured; failure was:', verdict.reason);
+      console.error(
+        '[synthetic-en-listing] failures (no alert email sent):',
+        failures.map((f) => `${f.name}: ${f.reason}`).join('; '),
+      );
     }
-    return NextResponse.json({ ok: false, reason: verdict.reason, status: fetched.status }, { status: 200 });
+    return NextResponse.json({ ok: false, failures, checks }, { status: 500 });
   }
 
-  return NextResponse.json({ ok: true, status: fetched.status });
+  return NextResponse.json({ ok: true, checks });
 }


### PR DESCRIPTION
## Summary

Three small follow-ups bundled in one PR:

1. Cap the untrusted `?from=` URL param at 512 chars on `/listing/[id]` so oversized payloads can't be reflected into the back-link / AuthGate redirect.
2. Flip CSP from `Content-Security-Policy-Report-Only` to enforced `Content-Security-Policy` after a clean reporting window (PR #28). One host added (`unpkg.com`) — see audit below.
3. Extend `/api/cron/synthetic-en-listing` (already runs every 15 min) with four additional production canaries — distance variety, soft-404 status, OG image content-type, and `MISSING_MESSAGE:` absence on `/en`.

## Changes

### Task 1 — `?from=` length cap
- `src/app/[locale]/listing/[id]/page.js`: introduced `MAX_FROM_LENGTH = 512`. Both the back-link href and the AuthGate redirect path use the capped value (oversized → drop to bare `/results`).

### Task 2 — CSP enforced
- `next.config.mjs`: header renamed to `Content-Security-Policy`. Added `https://unpkg.com` to `img-src`. Updated the leading comment block with the audit summary.

#### CSP audit findings
What the codebase actually loads from the browser:

| Directive | Host | Source | Already in CSP? |
|-----------|------|--------|-----------------|
| `script-src` | inline | `src/app/[locale]/listing/[id]/layout.js` JSON-LD via `dangerouslySetInnerHTML` | yes (`'unsafe-inline'`) |
| `img-src` | `static.wixstatic.com` | listing photos (seed snapshot + import path) | yes |
| `img-src` | `ecluqurlfbvkxrnoyhaq.supabase.co` | uploaded photos via Supabase storage | yes |
| `img-src` | `*.tile.openstreetmap.org` | `src/components/ListingsMap.js` map tiles | yes |
| `img-src` | `unpkg.com` | `src/components/ListingsMap.js` Leaflet default marker icons (`marker-icon.png`, `marker-icon-2x.png`, `marker-shadow.png`) | **NO — added in this PR** |
| `connect-src` | `ecluqurlfbvkxrnoyhaq.supabase.co` | Supabase client (browser + server) | yes |
| `font-src` | `fonts.gstatic.com` | `next/font/google` self-hosts at build time, but kept defensively | yes |
| top-level navigation | `buy.stripe.com`, `www.google.com/maps` | `window.location.assign` and `<a href>` (NOT subresource loads) | n/a — not subject to `connect-src`/`img-src` |
| server-side fetch | `spiti.gr`, `xe.gr` | `/api/landlord/listings/import-url` server-side scrape | n/a — server fetch, no browser CSP |

`unpkg.com` was the only browser-loaded host the Report-Only policy would have blocked; without the addition, marker pins would silently fail on `/results` map view after enforcement.

### Task 3 — Smoke check expansion (Option A — extended existing route)
- `src/app/api/cron/synthetic-en-listing/route.js`: kept the existing locale-regression check (now named `en-listing-locale`) and added four sibling checks running independently in parallel:
  - **`listing-api-distances`**: GETs `/api/listings/<SYNTHETIC_LISTING_ID>` and asserts ≥2 distinct `walk_minutes` values across `faculty_distances`. Guards against `transformListing` regressions and seed flattening.
  - **`soft-404`**: GETs `/listing/does-not-exist` (Greek-default at root, not `/en/...`) and asserts HTTP 404.
  - **`og-default`**: GETs `/og-default.png` and asserts 200 with `content-type: image/png` (catches the case where a broken path silently 200s with `text/html`).
  - **`missing-message`**: GETs `/en` and asserts the body does NOT contain `MISSING_MESSAGE:`, the next-intl placeholder for keys absent from the locale bundle.
- All assertions soft-fail: one bad check does not bail the others. On any failure the route returns 500 with `{ ok: false, failures, checks }` and emails `SYNTHETIC_ALERT_EMAIL` via Resend (only if `RESEND_API_KEY` is set; otherwise just `console.error`s). On all-pass returns 200 with `{ ok: true, checks }`.
- Reuses existing env (`SYNTHETIC_LISTING_ID`, `NEXT_PUBLIC_APP_URL`, `CRON_SECRET`, `SYNTHETIC_ALERT_EMAIL`) and the existing `x-cron-secret` auth pattern. No `wrangler.jsonc` / `cf/worker-entry.mjs` changes.

## Test plan

- [x] `npx eslint` clean on all three touched files
- [x] `node -e "JSON.parse(...)"` on `src/messages/en.json` parses
- [ ] Manual hit after deploy: `curl -X POST -H "x-cron-secret: $CRON_SECRET" $APP_URL/api/cron/synthetic-en-listing` returns `{"ok":true,"checks":[...]}` with all 5 names
- [ ] Watch CSP-enforced traffic for ~24h after deploy — any unexpected violation should be visible in browser console
- [ ] Confirm `/results` map view still shows Leaflet pins (img-src for `unpkg.com` covers it)

## Risks

- **CSP enforcement** is the highest-risk change — Report-Only had been live since #28 with no observed legitimate violations beyond what's enumerated above, but a third-party load that ships only on a low-traffic surface could surface now. Mitigation: violations break image/script loads but not server traffic, and we can roll back the header rename in a one-line revert.
- **Smoke check fan-out**: the route now does 5 outbound fetches per cron tick (every 15 min). Each has `AbortSignal.timeout(10s)` and they run in parallel where possible, well under the 25s scheduled-handler abort in `cf/worker-entry.mjs`.
- **`?from=` cap**: 512 chars is generous (real /results querystrings are ~100-200 chars), so legitimate users see no behaviour change.

## Other observations

While running the CSP audit I noticed `next.config.mjs` keeps `'unsafe-eval'` in `script-src`. Worth investigating whether any current bundle path actually requires it (Next.js modern builds usually don't); could potentially be tightened in a follow-up. Not in scope for this PR.