### PR TITLE
feat(listing): dedicated landmark destinations + reviews SSR

### DIFF
--- a/src/app/[locale]/listing/[id]/page.js
+++ b/src/app/[locale]/listing/[id]/page.js
@@ -4,6 +4,7 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { Link } from '@/i18n/navigation';
 
 import { getListingForRender } from '@/lib/listingForRender';
+import { getListingReviews } from '@/lib/listingReviews';
 import { requireStudent } from '@/lib/requireStudent';
 
 import AuthGate from '@/components/AuthGate';
@@ -68,6 +69,12 @@ export default async function ListingPage({ params, searchParams }) {
     listing.verified_tier && listing.verified_tier !== 'none';
 
   const distances = deriveDestinations(listing.faculty_distances || [], t);
+
+  // Fetch reviews server-side so they ship in the SSR HTML (gated behind
+  // requireStudent above — only authenticated students see the body).
+  const { reviews, avg_rating, review_count } = await getListingReviews(
+    listing.listing_id,
+  );
 
   return (
     <div className="mx-auto max-w-6xl px-5 py-8 md:py-12">
@@ -242,7 +249,12 @@ export default async function ListingPage({ params, searchParams }) {
 
       {/* Reviews */}
       <div className="mt-16 pt-10 border-t border-night/10">
-        <ReviewList listingId={listing.listing_id} />
+        <ReviewList
+          listingId={listing.listing_id}
+          reviews={reviews}
+          avgRating={avg_rating}
+          reviewCount={review_count}
+        />
       </div>
     </div>
   );
@@ -284,71 +296,32 @@ function BilingualField({ greek, english, value }) {
   );
 }
 
-// Pick up to 3 destination rows for the listing detail's distance table.
-// Match by faculty_id (stable across locales / display-name drift) — the
-// original fuzzy 'medic'/'ιατρ' match silently missed once AUTH Medical
-// School was seeded as "Faculty of Health Sciences".
-//
-// The committed seed (migrations/002_seed_faculties.sql) ships
-// auth-main / auth-medical / auth-agriculture. Production has been
-// extended via MCP with auth-philosophy / auth-engineering / etc. We
-// chain fallbacks so this works in both environments. Dedicated AHEPA
-// hospital / Central Library reference points don't exist yet, so we
-// drop the abstract "destHospital" row when its data would just be a
-// dupe of School of Medicine, and fall back to surfacing the next-
-// nearest unique faculty by its real name. That avoids the duplicate-
-// row UX the previous fuzzy-match approach was hiding.
+// Pick the three destination rows for the listing detail's distance
+// table. Each row maps to a dedicated reference point seeded in
+// migration 035: auth-medical (School of Medicine), ahepa-hospital
+// (AHEPA University Hospital), auth-library (AUTH Central Library).
+// compute_distances.py populates faculty_distances rows for every
+// listing × faculty pair, so a simple by-id lookup is sufficient.
 function deriveDestinations(facultyDistances, t) {
   const byId = (id) => facultyDistances.find((f) => f.faculty_id === id);
-
   const medicine = byId('auth-medical');
-  // Main campus row stands in for "Central Library"; prefer auth-main
-  // (committed seed), fall back to a representative main-campus AUTH
-  // row in production envs that don't have auth-main.
-  const mainCampus =
-    byId('auth-main') ||
-    byId('auth-philosophy') ||
-    byId('auth-engineering') ||
-    byId('auth-law');
-
-  const seen = new Set();
-  const picks = [];
-
-  if (medicine) {
-    picks.push({
+  const ahepa = byId('ahepa-hospital');
+  const library = byId('auth-library');
+  return [
+    {
       name: t('destSchool'),
-      walk: medicine.walk_minutes,
-      transit: medicine.transit_minutes,
-    });
-    seen.add(medicine.faculty_id);
-  }
-  if (mainCampus && !seen.has(mainCampus.faculty_id)) {
-    picks.push({
+      walk: medicine?.walk_minutes,
+      transit: medicine?.transit_minutes,
+    },
+    {
+      name: t('destHospital'),
+      walk: ahepa?.walk_minutes,
+      transit: ahepa?.transit_minutes,
+    },
+    {
       name: t('destLibrary'),
-      walk: mainCampus.walk_minutes,
-      transit: mainCampus.transit_minutes,
-    });
-    seen.add(mainCampus.faculty_id);
-  }
-
-  // Pad to 3 rows with the next-nearest unique faculty under its real
-  // (localised) name. Sorted by walk time; ties broken by transit.
-  const remaining = [...facultyDistances]
-    .filter((f) => !seen.has(f.faculty_id))
-    .sort(
-      (a, b) =>
-        (a.walk_minutes ?? Infinity) - (b.walk_minutes ?? Infinity) ||
-        (a.transit_minutes ?? Infinity) - (b.transit_minutes ?? Infinity)
-    );
-  for (const f of remaining) {
-    if (picks.length >= 3) break;
-    picks.push({
-      name: f.faculty_name,
-      walk: f.walk_minutes,
-      transit: f.transit_minutes,
-    });
-    seen.add(f.faculty_id);
-  }
-
-  return picks;
+      walk: library?.walk_minutes,
+      transit: library?.transit_minutes,
+    },
+  ];
 }

--- a/src/components/ReportReviewButton.js
+++ b/src/components/ReportReviewButton.js
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+/**
+ * ReportReviewButton — small client island for reporting an abusive
+ * review. Posts to /api/reviews/[id]/report and locally marks itself
+ * "reported" so the user gets immediate feedback. Extracted out of
+ * ReviewList so the surrounding list can render on the server.
+ */
+export default function ReportReviewButton({ reviewId }) {
+  const t = useTranslations('reviews');
+  const [reported, setReported] = useState(false);
+  const [pending, setPending] = useState(false);
+
+  async function handleClick() {
+    if (reported || pending) return;
+    setPending(true);
+    try {
+      await fetch(`/api/reviews/${reviewId}/report`, { method: 'POST' });
+      setReported(true);
+    } catch {
+      // silent — non-critical
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={reported || pending}
+      className="text-xs text-gray-dark/30 hover:text-red-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+    >
+      {reported ? t('reported') : t('report')}
+    </button>
+  );
+}

--- a/src/components/ReviewForm.js
+++ b/src/components/ReviewForm.js
@@ -1,11 +1,13 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import StarRating from '@/components/StarRating';
 
 export default function ReviewForm({ listingId, onReviewSubmitted }) {
   const t = useTranslations('reviews');
+  const router = useRouter();
   const [open, setOpen] = useState(false);
   const [form, setForm] = useState({ user_email: '', rating: 0, review_text: '' });
   const [submitting, setSubmitting] = useState(false);
@@ -45,7 +47,14 @@ export default function ReviewForm({ listingId, onReviewSubmitted }) {
       }
 
       setSuccess(true);
-      onReviewSubmitted?.();
+      // Refresh the server-rendered review list so the new review
+      // appears without a manual page reload. Falls back to the
+      // legacy callback for any caller still wiring its own refetch.
+      if (onReviewSubmitted) {
+        onReviewSubmitted();
+      } else {
+        router.refresh();
+      }
     } catch {
       setError(t('networkError'));
     } finally {

--- a/src/components/ReviewList.js
+++ b/src/components/ReviewList.js
@@ -1,46 +1,26 @@
-'use client';
-
-import { useEffect, useState, useCallback } from 'react';
-import { useTranslations } from 'next-intl';
+import { getTranslations } from 'next-intl/server';
 import StarRating from '@/components/StarRating';
 import ReviewForm from '@/components/ReviewForm';
+import ReportReviewButton from '@/components/ReportReviewButton';
 
-export default function ReviewList({ listingId }) {
-  const t = useTranslations('reviews');
-  const [reviews, setReviews] = useState([]);
-  const [avgRating, setAvgRating] = useState(null);
-  const [reviewCount, setReviewCount] = useState(0);
-  const [loading, setLoading] = useState(true);
-  const [reported, setReported] = useState({});
-
-  const fetchReviews = useCallback(async () => {
-    try {
-      const res = await fetch(`/api/listings/${listingId}/reviews`);
-      if (!res.ok) return;
-      const data = await res.json();
-      setReviews(data.reviews);
-      setAvgRating(data.avg_rating);
-      setReviewCount(data.review_count);
-    } catch {
-      // silent — non-critical
-    } finally {
-      setLoading(false);
-    }
-  }, [listingId]);
-
-  useEffect(() => {
-    fetchReviews();
-  }, [fetchReviews]);
-
-  async function handleReport(reviewId) {
-    if (reported[reviewId]) return;
-    try {
-      await fetch(`/api/reviews/${reviewId}/report`, { method: 'POST' });
-      setReported((prev) => ({ ...prev, [reviewId]: true }));
-    } catch {
-      // silent
-    }
-  }
+/**
+ * ReviewList — server component. Renders the review summary, the list
+ * of reviews, and the (client) submit form. The data is fetched on
+ * the server (see src/lib/listingReviews.js) and passed in as props,
+ * so reviews ship in the SSR HTML for crawlers + first paint instead
+ * of arriving via a post-mount fetch.
+ *
+ * Per-row interactive affordances (the "report" button) live in the
+ * <ReportReviewButton> client island. The "write a review" form
+ * remains a client component because it owns its own form state.
+ */
+export default async function ReviewList({
+  listingId,
+  reviews = [],
+  avgRating = null,
+  reviewCount = 0,
+}) {
+  const t = await getTranslations('reviews');
 
   return (
     <div className="space-y-6">
@@ -55,54 +35,43 @@ export default function ReviewList({ listingId }) {
             <span className="text-sm font-semibold text-navy">
               {avgRating.toFixed(1)}
             </span>
-            <span className="text-xs text-gray-dark/50">
-              ({reviewCount})
-            </span>
+            <span className="text-xs text-gray-dark/50">({reviewCount})</span>
           </div>
         )}
       </div>
 
       {/* Review list */}
-      {loading ? (
-        <div className="space-y-3 animate-pulse">
-          {[1, 2].map((i) => (
-            <div key={i} className="rounded-xl border border-gray-200 p-4 space-y-2">
-              <div className="h-4 w-24 bg-gray-light rounded" />
-              <div className="h-3 w-full bg-gray-light rounded" />
-              <div className="h-3 w-3/4 bg-gray-light rounded" />
-            </div>
-          ))}
-        </div>
-      ) : reviews.length === 0 ? (
+      {reviews.length === 0 ? (
         <p className="text-sm text-gray-dark/50 italic">{t('noReviews')}</p>
       ) : (
         <div className="space-y-3">
           {reviews.map((review) => (
-            <div key={review.review_id} className="rounded-xl border border-gray-200 bg-white p-4 space-y-2">
+            <div
+              key={review.review_id}
+              className="rounded-xl border border-gray-200 bg-white p-4 space-y-2"
+            >
               <div className="flex items-center justify-between">
                 <StarRating value={review.rating} size="sm" />
                 <span className="text-xs text-gray-dark/40">
                   {new Date(review.created_at).toLocaleDateString()}
                 </span>
               </div>
-              <p className="text-sm text-gray-dark/80 leading-relaxed">{review.review_text}</p>
+              <p className="text-sm text-gray-dark/80 leading-relaxed">
+                {review.review_text}
+              </p>
               <div className="flex items-center justify-between pt-1">
-                <span className="text-xs text-gray-dark/40">{review.masked_email}</span>
-                <button
-                  onClick={() => handleReport(review.review_id)}
-                  disabled={!!reported[review.review_id]}
-                  className="text-xs text-gray-dark/30 hover:text-red-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-                >
-                  {reported[review.review_id] ? t('reported') : t('report')}
-                </button>
+                <span className="text-xs text-gray-dark/40">
+                  {review.masked_email}
+                </span>
+                <ReportReviewButton reviewId={review.review_id} />
               </div>
             </div>
           ))}
         </div>
       )}
 
-      {/* Submit form */}
-      <ReviewForm listingId={listingId} onReviewSubmitted={fetchReviews} />
+      {/* Submit form (client island) */}
+      <ReviewForm listingId={listingId} />
     </div>
   );
 }

--- a/src/lib/listingReviews.js
+++ b/src/lib/listingReviews.js
@@ -1,0 +1,56 @@
+import { cache } from 'react';
+import { getSupabase } from '@/lib/supabase';
+
+// Per-request memoized review fetch for the listing detail page.
+// Mirrors the query in src/app/api/listings/[id]/reviews/route.js so
+// the server-rendered review list and the public API return the same
+// shape. Wrapping in React's `cache()` lets this be called from both
+// the page and any future co-located server component during the same
+// render pass without re-querying Supabase.
+//
+// Returns { reviews, avg_rating, review_count } — same shape the old
+// client-side <ReviewList> consumed via fetch(). On any error we
+// degrade to an empty result rather than throwing, so a transient
+// review-table issue can't blow up the whole listing render.
+export const getListingReviews = cache(async (listingId) => {
+  const empty = { reviews: [], avg_rating: null, review_count: 0 };
+  if (!listingId || !/^\d[\d-]+$/.test(listingId)) return empty;
+
+  try {
+    const { data: reviews, error } = await getSupabase()
+      .from('reviews')
+      .select('review_id, rating, review_text, created_at, user_email')
+      .eq('listing_id', listingId)
+      .eq('moderated', false)
+      .order('created_at', { ascending: false });
+
+    if (error || !reviews) return empty;
+
+    let avg_rating = null;
+    if (reviews.length > 0) {
+      const sum = reviews.reduce((acc, r) => acc + r.rating, 0);
+      avg_rating = Math.round((sum / reviews.length) * 10) / 10;
+    }
+
+    const sanitised = reviews.map((r) => {
+      const [local, domain] = (r.user_email || '').split('@');
+      const masked_email =
+        (local ? local.charAt(0) : '') + '***@' + (domain || '');
+      return {
+        review_id: r.review_id,
+        rating: r.rating,
+        review_text: r.review_text,
+        created_at: r.created_at,
+        masked_email,
+      };
+    });
+
+    return {
+      reviews: sanitised,
+      avg_rating,
+      review_count: reviews.length,
+    };
+  } catch {
+    return empty;
+  }
+});


### PR DESCRIPTION
## Summary
- Simplify `deriveDestinations` in `src/app/[locale]/listing/[id]/page.js`: now reads `auth-medical`, `ahepa-hospital`, `auth-library` directly by faculty_id, dropping the old fallback chain / dedup / nearest-unique padding. Enabled by migration 035 + `compute_distances.py` (#56), which seeded those three reference points with real `faculty_distances` rows for every listing.
- Server-render the listing reviews. New `src/lib/listingReviews.js` is a `cache()`-wrapped server-side fetcher mirroring the query in `src/app/api/listings/[id]/reviews/route.js`. `ReviewList` becomes a server component; the per-row "report" button is extracted into a small `ReportReviewButton` client island. `ReviewForm` keeps `'use client'` (form state) and now calls `router.refresh()` after a successful submit so the new review appears without a manual reload.

## Changes
- `src/app/[locale]/listing/[id]/page.js`
  - Drop fallback chain in `deriveDestinations` (proxy via `auth-main`/philosophy/engineering/law, dedupe set, nearest-unique padding) — replaced with three direct `byId()` lookups. Updated the comment block.
  - Server-fetch reviews via `getListingReviews(listing.listing_id)` and pass `reviews`, `avgRating`, `reviewCount` as props to `<ReviewList>`.
- `src/lib/listingReviews.js` (new) — `cache()`-wrapped server fetcher. Same email-masking + avg-rating math as the API route. Returns `{ reviews, avg_rating, review_count }`. Degrades to empty result on error so a transient reviews-table issue can't blow up the listing render.
- `src/components/ReviewList.js` — refactored to a server component. Drops `'use client'`, `useEffect`, `useState`, `useCallback`, the loading skeleton, and the client-side fetch. Accepts `reviews`/`avgRating`/`reviewCount` as props.
- `src/components/ReportReviewButton.js` (new) — minimal client island for the per-review report action. Owns its own `reported`/`pending` state and the POST to `/api/reviews/[id]/report`.
- `src/components/ReviewForm.js` — adds `useRouter().refresh()` after a successful submit when `onReviewSubmitted` is not provided. Existing call sites that pass `onReviewSubmitted` continue to work; new SSR call site relies on `router.refresh()`.

## Testing
- [x] `npx eslint` clean on all five touched files.
- [ ] `npm run build` not run locally in this turn — flagging in case CI surfaces anything; the changes are mechanical (no new types, no new package deps) and lint is clean.
- [ ] Manual smoke on a logged-in student session against a listing with non-zero reviews — verify reviews appear in the SSR HTML (e.g. `curl /en/listing/0100001` will not show them anonymously due to `requireStudent` gate, but server-rendered content is present once authenticated).
- [ ] Confirm the three landmark rows render with real `walk` / `transit` values rather than `—` (i.e. migration 035 + `compute_distances.py --only-missing` ran on the env you're testing).

## Risks
- **Build verification skipped this turn.** The TypeScript-equivalent in this repo is JS + ESLint; lint is clean and the diff is mechanical. CI's `npm run build` step is the safety net here. If anything fails, the most likely culprit is the new `useRouter` import in `ReviewForm.js` — it's the standard `next/navigation` hook that's already used elsewhere in the codebase.
- **Reviews are still gated by `requireStudent`.** The PR description for the SSR change says "crawlers + first-paint" — to be precise, the body (including reviews) only renders for authenticated students. Anonymous crawlers see the AuthGate page; SEO metadata + JSON-LD continue to come from the layout. This is still a strict improvement over the prior state (reviews not in any SSR HTML at all) but worth flagging so we don't oversell the SEO win.
- **`router.refresh()` after review submit.** Replaces the old client refetch. UX should be the same or better (single round-trip of revalidated server data instead of a parallel client fetch). If a regression surfaces, dropping the `else router.refresh()` branch reverts to "shows success state, requires nav-away/back to see new review".
- **`auth-main` no longer surfaced.** Prod doesn't have it (per migration 035's notes); this aligns the page with prod reality. Dev clones that ran the committed seed do have `auth-main` — they will simply not see it in the table, which matches what students will see.

## Out-of-scope
- Did not touch `src/app/api/listings/[id]/reviews/route.js` (the public API). It still serves the same shape; nothing else consumes it currently. We could refactor the route to call `getListingReviews()` to remove duplication, but that's a follow-up — out of scope to keep this PR focused.
- Did not refactor `ReviewForm.js` beyond adding `router.refresh()`. The full client form remains a client component as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)