### PR TITLE
fix(email): send from alerts@updates.studentx.gr (DRAFT — pending domain registration)

### DIFF
--- a/src/app/api/cron/landlord-message-digest/route.js
+++ b/src/app/api/cron/landlord-message-digest/route.js
@@ -23,7 +23,7 @@ function getServiceSupabase() {
 // to absorb a burst of student messages into a single email.
 const MIN_INTERVAL = '4 minutes 30 seconds';
 
-const FROM_ADDRESS = 'StudentX <alerts@studentx.gr>';
+const FROM_ADDRESS = 'StudentX <alerts@updates.studentx.gr>';
 
 function isCronAuthorized(request) {
   const secret = process.env.CRON_SECRET;

--- a/src/app/api/cron/saved-searches-digest/route.js
+++ b/src/app/api/cron/saved-searches-digest/route.js
@@ -134,7 +134,7 @@ export async function POST(request) {
       const manageUrl = `${appUrl}/alerts/manage?token=${search.unsubscribe_token}`;
 
       await resend.emails.send({
-        from: 'StudentX Alerts <alerts@studentx.gr>',
+        from: 'StudentX Alerts <alerts@updates.studentx.gr>',
         to: search.email,
         subject: digestEmailSubject(search.label, matches.length),
         html: digestEmailHtml({

--- a/src/app/api/saved-searches/route.js
+++ b/src/app/api/saved-searches/route.js
@@ -51,7 +51,7 @@ export async function POST(request) {
     try {
       const resend = getResend();
       await resend.emails.send({
-        from: 'StudentX Alerts <alerts@studentx.gr>',
+        from: 'StudentX Alerts <alerts@updates.studentx.gr>',
         to: email.trim().toLowerCase(),
         subject: confirmationEmailSubject(label?.trim()),
         html: confirmationEmailHtml({

--- a/src/lib/inquiryEmail.js
+++ b/src/lib/inquiryEmail.js
@@ -2,7 +2,7 @@ import { getSupabase } from '@/lib/supabase';
 import { getResend } from '@/lib/resend';
 import { inquiryEmailHtml, inquiryEmailSubject } from '@/templates/email/inquiry';
 
-const FROM_ADDRESS = 'StudentX <alerts@studentx.gr>';
+const FROM_ADDRESS = 'StudentX <alerts@updates.studentx.gr>';
 
 function resolveLandlordEmailLocale(request, landlord) {
   if (landlord?.preferred_locale === 'el' || landlord?.preferred_locale === 'en') {


### PR DESCRIPTION
> [!WARNING]
> **DO NOT MERGE** until `studentx.gr` is registered AND `updates.studentx.gr` is verified in Resend.

## Why this PR exists

PR #51 (https://github.com/MichaelChar/StudentX/pull/51) made the same from-address swap but was closed on 2026-04-27 because the parent domain `studentx.gr` is not yet registered (NXDOMAIN), which means `updates.studentx.gr` cannot be verified in Resend.

This PR re-stages the identical diff as a draft so the change is ready to merge the moment the domain is registered and the Resend subdomain is verified — saves time on the day.

## Change

Swap the Resend `from` address from `alerts@studentx.gr` to `alerts@updates.studentx.gr` (the verified subdomain we plan to use) across all four send sites.

## Files

- `src/lib/inquiryEmail.js`
- `src/app/api/cron/landlord-message-digest/route.js`
- `src/app/api/cron/saved-searches-digest/route.js`
- `src/app/api/saved-searches/route.js`

## Pre-merge checklist (operator)

See the domain-setup runbook PR (sibling PR being created in parallel; will live at `docs/runbooks/domain-setup.md`).

- [ ] `studentx.gr` registered at registrar
- [ ] `updates.studentx.gr` DNS records added (SPF, DKIM, DMARC per Resend instructions)
- [ ] Resend dashboard shows `updates.studentx.gr` as Verified
- [ ] Manual smoke: trigger one inquiry, one saved-search confirmation, one digest — all deliver

Once the domain is verified in Resend, mark this PR ready-for-review and merge.