### PR TITLE
chore(lint): ignore .claude/worktrees and coverage in eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,14 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Sub-agent worktrees (PR #53 gitignore). Each agent worktree is a
+    // full copy of the repo including its own .next/ build artifacts;
+    // without this ignore, eslint walks them and duplicates every
+    // source-file error N times.
+    ".claude/worktrees/**",
+    // Vitest coverage output (also gitignored). Generated files; not
+    // ours to lint.
+    "coverage/**",
   ]),
   {
     // PR #61's eslint-config-next bump (16.2.1 → 16.2.4) tightened


### PR DESCRIPTION
## Summary

PR #69's CI run surfaced **192 lint problems (74 errors, 118 warnings)** on the post-PR-#61 stricter `eslint-config-next 16.2.4`. Inspection: ~95% are duplicate counts of the same source-file errors, multiplied across `.claude/worktrees/agent-*/` copies (sub-agent worktrees from the recent multi-PR work cycle), plus errors in `.next/build/*` artifacts living inside those worktrees. Plus 3 entries in `coverage/` (vitest output).

This PR adds both paths to eslint's `globalIgnores`. Both are already gitignored ([PR #53](https://github.com/MichaelChar/StudentX/pull/53) for `.claude/worktrees/`; vitest's coverage output is gitignored per `/coverage` rule). It just makes lint match.

## Before / After

| | Before | After |
|---|---|---|
| **Total lint problems** | 192 | **5** |
| **Errors** | 74 | **0** |
| **Warnings** | 118 | 5 |

## Remaining 5 warnings (intentionally not addressed in this PR)

| File | Rule | Status |
|---|---|---|
| [`cf/worker-entry.mjs:75`](cf/worker-entry.mjs#L75) | `import/no-anonymous-default-export` | Load-bearing — Cloudflare Workers expect `export default { ... }` at module top-level. |
| [`src/app/[locale]/alerts/manage/page.js:48`](src/app/[locale]/alerts/manage/page.js#L48) | `react-hooks/set-state-in-effect` | Intentional fetch-on-mount pattern; rule downgraded to warn in PR #69. |
| [`src/app/[locale]/results/page.js:86`](src/app/[locale]/results/page.js#L86) | `react-hooks/set-state-in-effect` | Same. |
| [`src/app/[locale]/results/page.js:178`](src/app/[locale]/results/page.js#L178) | `react-hooks/set-state-in-effect` | Same — second occurrence in this file (the `fetchListings()` effect). |
| [`src/components/BillingSection.js:39`](src/components/BillingSection.js#L39) | `react-hooks/set-state-in-effect` | Same. |

Addressing these would touch real component logic — out of scope for a lint-config cleanup PR. They could be a follow-up if you want to systematically refactor the `useEffect → fetch → setState` pattern.

## Verification

- [x] `npm run lint` — 5 warnings, 0 errors (down from 192/74).
- [x] `npm run test` — 45/45 pass.
- [x] `npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
