### PR TITLE
fix(reset-password): wrap updateUser in try/catch + 15s timeout

### DIFF
--- a/src/app/[locale]/landlord/reset-password/page.js
+++ b/src/app/[locale]/landlord/reset-password/page.js
@@ -54,15 +54,30 @@ export default function ResetPasswordPage() {
     }
 
     setLoading(true);
-    const supabase = getSupabaseBrowser();
-    const { error: updateError } = await supabase.auth.updateUser({ password });
-    setLoading(false);
+    try {
+      const supabase = getSupabaseBrowser();
+      const updatePromise = supabase.auth.updateUser({ password });
+      const timeoutPromise = new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new Error('Request timed out. Please try again.')),
+          15000,
+        ),
+      );
+      const { error: updateError } = await Promise.race([
+        updatePromise,
+        timeoutPromise,
+      ]);
 
-    if (updateError) {
-      setError(updateError.message);
-      return;
+      if (updateError) {
+        setError(updateError.message);
+        return;
+      }
+      setDone(true);
+    } catch (err) {
+      setError(err.message || 'Something went wrong. Please try again.');
+    } finally {
+      setLoading(false);
     }
-    setDone(true);
   }
 
   if (done) {

--- a/src/app/[locale]/student/reset-password/page.js
+++ b/src/app/[locale]/student/reset-password/page.js
@@ -50,15 +50,30 @@ export default function StudentResetPasswordPage() {
     }
 
     setLoading(true);
-    const supabase = getSupabaseBrowser();
-    const { error: updateError } = await supabase.auth.updateUser({ password });
-    setLoading(false);
+    try {
+      const supabase = getSupabaseBrowser();
+      const updatePromise = supabase.auth.updateUser({ password });
+      const timeoutPromise = new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new Error('Request timed out. Please try again.')),
+          15000,
+        ),
+      );
+      const { error: updateError } = await Promise.race([
+        updatePromise,
+        timeoutPromise,
+      ]);
 
-    if (updateError) {
-      setError(updateError.message);
-      return;
+      if (updateError) {
+        setError(updateError.message);
+        return;
+      }
+      setDone(true);
+    } catch (err) {
+      setError(err.message || t('genericError') || 'Something went wrong.');
+    } finally {
+      setLoading(false);
     }
-    setDone(true);
   }
 
   if (done) {


### PR DESCRIPTION
## Summary

Both student and landlord reset-password pages awaited `supabase.auth.updateUser({ password })` with no try/catch and no timeout. If the call hung or threw, `setLoading(false)` never ran — the button got stuck on "Updating…" indefinitely with no error message surfaced.

This was reproduced on a phone session this morning: the user submitted, saw "UPDATING…", and the page never resolved.

The fix wraps the call in `try/catch/finally` with a 15s `Promise.race` timeout, guaranteeing:
- `setLoading(false)` always runs (button re-enables)
- Any thrown error surfaces as a visible error message
- A hung Supabase call times out at 15s with "Request timed out. Please try again."

This is defensive plumbing, not a root-cause fix — it makes failures visible so we can diagnose if it happens again. The actual cause of the original hang is still unknown (most likely a transient mobile-network issue, but could also be a real Supabase error that was being swallowed).

Same pattern applied to:
- `src/app/[locale]/student/reset-password/page.js`
- `src/app/[locale]/landlord/reset-password/page.js`

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Both pages render in dev preview without console / server errors
- [ ] Manual: trigger an actual reset on prod, confirm the button now either succeeds or shows an error within 15s

🤖 Generated with [Claude Code](https://claude.com/claude-code)