### PR TITLE
feat(oauth): mark Google/Apple sign-in as 'coming soon'

### DIFF
--- a/src/components/student/OAuthProviders.js
+++ b/src/components/student/OAuthProviders.js
@@ -1,86 +1,45 @@
 'use client';
 
-import { useState } from 'react';
-import { useLocale, useTranslations } from 'next-intl';
-import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { useTranslations } from 'next-intl';
 
+// OAuth (Google + Apple) is intentionally disabled while the Supabase
+// providers aren't configured yet. Buttons render in a "coming soon"
+// disabled state — visible so users know the option exists, blurred
+// + grayed so it's clearly not interactive. The original sign-in flow
+// (signInWithOAuth + redirect) is preserved in git history; restore
+// from there when the providers are wired up.
 export default function OAuthProviders({ context = 'login' }) {
   const t = useTranslations('student.oauth');
-  const locale = useLocale();
-  const [pending, setPending] = useState(null);
-  const [error, setError] = useState('');
-
-  async function handleOAuth(provider) {
-    setError('');
-    setPending(provider);
-
-    // Read `next` lazily from window so this component doesn't need
-    // a Suspense boundary on the signup page (which doesn't use one
-    // for the rest of its UI).
-    const params = new URLSearchParams(window.location.search);
-    const nextRaw = params.get('next') || '';
-    const safeNext = nextRaw.startsWith('/') ? nextRaw : '';
-
-    const origin = window.location.origin;
-    const callback = `${origin}/${locale}/student/auth/callback${
-      safeNext ? `?next=${encodeURIComponent(safeNext)}` : ''
-    }`;
-
-    const supabase = getSupabaseBrowser();
-    const { error: oauthError } = await supabase.auth.signInWithOAuth({
-      provider,
-      options: {
-        redirectTo: callback,
-        // The role tag tells handle_new_student_user (migration 029,
-        // extended in 030) to provision the students row when the
-        // auth.users insert lands. Migration 030 also accepts the
-        // provider stamp as a fallback if this tag is ever missing.
-        data: { role: 'student' },
-      },
-    });
-
-    if (oauthError) {
-      setError(oauthError.message || t('errorGeneric'));
-      setPending(null);
-    }
-    // On success, the browser navigates away — leave pending set so
-    // the button stays in its loading state until the redirect.
-  }
 
   const googleLabel = t(context === 'signup' ? 'signupGoogle' : 'continueWithGoogle');
   const appleLabel = t(context === 'signup' ? 'signupApple' : 'continueWithApple');
+  const comingSoon = t('comingSoon');
+
+  const buttonClass =
+    'w-full inline-flex items-center justify-center gap-3 border border-night/15 rounded-sm px-4 py-2.5 text-sm text-night bg-white opacity-50 grayscale cursor-not-allowed select-none';
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-3" aria-label={t('portal')}>
       <button
         type="button"
-        disabled={pending !== null}
-        onClick={() => handleOAuth('google')}
-        aria-label={googleLabel}
-        className="w-full inline-flex items-center justify-center gap-3 border border-night/15 rounded-sm px-4 py-2.5 text-sm text-night bg-white hover:bg-night/[0.03] disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        disabled
+        aria-disabled="true"
+        title={comingSoon}
+        className={buttonClass}
       >
-        <GoogleMark />
-        <span>{pending === 'google' ? t('signingIn') : googleLabel}</span>
+        <span className="blur-[0.5px]"><GoogleMark /></span>
+        <span>{googleLabel} {comingSoon}</span>
       </button>
       <button
         type="button"
-        disabled={pending !== null}
-        onClick={() => handleOAuth('apple')}
-        aria-label={appleLabel}
-        className="w-full inline-flex items-center justify-center gap-3 border border-night/15 rounded-sm px-4 py-2.5 text-sm text-night bg-white hover:bg-night/[0.03] disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        disabled
+        aria-disabled="true"
+        title={comingSoon}
+        className={buttonClass}
       >
-        <AppleMark />
-        <span>{pending === 'apple' ? t('signingIn') : appleLabel}</span>
+        <span className="blur-[0.5px]"><AppleMark /></span>
+        <span>{appleLabel} {comingSoon}</span>
       </button>
-
-      {error && (
-        <p
-          role="alert"
-          className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-sm px-3 py-2"
-        >
-          {error}
-        </p>
-      )}
     </div>
   );
 }

--- a/src/messages/el.json
+++ b/src/messages/el.json
@@ -650,6 +650,7 @@
       "continueWithApple": "Συνέχεια με Apple",
       "signupGoogle": "Εγγραφή με Google",
       "signupApple": "Εγγραφή με Apple",
+      "comingSoon": "(σύντομα)",
       "signingIn": "Σύνδεση…",
       "callbackLoading": "Σε συνδέουμε…",
       "errorTitle": "Η σύνδεση απέτυχε",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -650,6 +650,7 @@
       "continueWithApple": "Continue with Apple",
       "signupGoogle": "Sign up with Google",
       "signupApple": "Sign up with Apple",
+      "comingSoon": "(coming soon)",
       "signingIn": "Signing in…",
       "callbackLoading": "Signing you in…",
       "errorTitle": "Sign-in failed",


### PR DESCRIPTION
## Summary

The Google and Apple OAuth providers aren't yet configured in Supabase, so clicking "Continue with Google" / "Continue with Apple" wouldn't actually do anything (the `signInWithOAuth` call would either fail or redirect to an unconfigured destination). Instead of leaving them as live-but-broken, render them as disabled "coming soon" buttons — visible so the option is clearly on the roadmap, but obviously not interactive yet.

### Changes

- `src/components/student/OAuthProviders.js`: removed the `signInWithOAuth` handler, useState plumbing, and click logic. Buttons now hardcoded `disabled` + `aria-disabled="true"`, rendered with `opacity-50 grayscale cursor-not-allowed select-none`. Brand marks get a subtle `blur-[0.5px]` to reinforce "not ready".
- `src/messages/{en,el}.json`: added `student.oauth.comingSoon` key (`(coming soon)` / `(σύντομα)`) appended to each button label.

The original sign-in flow is preserved in git history — restore from there when the providers are wired up.

Net diff: 3 files, +26 / −65.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Buttons render in dev preview with `disabled=true`, `aria-disabled="true"`, expected classes (`opacity-50 grayscale cursor-not-allowed select-none`), and the brand mark wrapped in `blur-[0.5px]`. Labels read "Continue with Google (coming soon)" / "Συνέχεια με Google (σύντομα)".
- [x] Screenshot confirms greyed-out, blurred-icon visual treatment with "(σύντομα)" suffix.
- [ ] Manual on prod after merge: click attempts do nothing (button is non-interactive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)