### PR TITLE
fix(auth): wrap login + signup in try/catch with 15s timeout

### DIFF
--- a/src/app/[locale]/landlord/login/page.js
+++ b/src/app/[locale]/landlord/login/page.js
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter, Link } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { withTimeout } from '@/lib/withTimeout';
 import { useTranslations } from 'next-intl';
 
 import AuthShell from '@/components/landlord/AuthShell';
@@ -21,20 +22,23 @@ export default function LandlordLoginPage() {
     e.preventDefault();
     setError('');
     setLoading(true);
+    try {
+      const supabase = getSupabaseBrowser();
+      const { error: authError } = await withTimeout(
+        supabase.auth.signInWithPassword({ email, password }),
+      );
 
-    const supabase = getSupabaseBrowser();
-    const { error: authError } = await supabase.auth.signInWithPassword({
-      email,
-      password,
-    });
+      if (authError) {
+        setError(authError.message);
+        return;
+      }
 
-    if (authError) {
-      setError(authError.message);
+      router.push('/landlord/dashboard');
+    } catch (err) {
+      setError(err.message || 'Something went wrong. Please try again.');
+    } finally {
       setLoading(false);
-      return;
     }
-
-    router.push('/landlord/dashboard');
   }
 
   return (

--- a/src/app/[locale]/landlord/signup/page.js
+++ b/src/app/[locale]/landlord/signup/page.js
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter, Link } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { withTimeout } from '@/lib/withTimeout';
 import { useLocale, useTranslations } from 'next-intl';
 
 import AuthShell from '@/components/landlord/AuthShell';
@@ -29,42 +30,49 @@ export default function LandlordSignupPage() {
     }
 
     setLoading(true);
-
-    const supabase = getSupabaseBrowser();
-    const siteUrl = window.location.origin;
-    const { data: authData, error: authError } = await supabase.auth.signUp({
-      email,
-      password,
-      options: {
-        emailRedirectTo: `${siteUrl}/${locale}/landlord/login`,
-      },
-    });
-    if (authError) {
-      setError(authError.message);
-      setLoading(false);
-      return;
-    }
-
-    const session = authData.session;
-    if (session?.access_token) {
-      const res = await fetch('/api/landlord/profile', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${session.access_token}`,
-        },
-        body: JSON.stringify({ name }),
-      });
-      if (!res.ok) {
-        await supabase.auth.signOut();
-        const { error: profileError } = await res.json();
-        setError(profileError || t('profileCreateFailed'));
-        setLoading(false);
+    try {
+      const supabase = getSupabaseBrowser();
+      const siteUrl = window.location.origin;
+      const { data: authData, error: authError } = await withTimeout(
+        supabase.auth.signUp({
+          email,
+          password,
+          options: {
+            emailRedirectTo: `${siteUrl}/${locale}/landlord/login`,
+          },
+        }),
+      );
+      if (authError) {
+        setError(authError.message);
         return;
       }
-    }
 
-    router.push('/landlord/verify-email');
+      const session = authData.session;
+      if (session?.access_token) {
+        const res = await withTimeout(
+          fetch('/api/landlord/profile', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${session.access_token}`,
+            },
+            body: JSON.stringify({ name }),
+          }),
+        );
+        if (!res.ok) {
+          await supabase.auth.signOut();
+          const { error: profileError } = await res.json().catch(() => ({}));
+          setError(profileError || t('profileCreateFailed'));
+          return;
+        }
+      }
+
+      router.push('/landlord/verify-email');
+    } catch (err) {
+      setError(err.message || 'Something went wrong. Please try again.');
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (

--- a/src/app/[locale]/student/login/page.js
+++ b/src/app/[locale]/student/login/page.js
@@ -4,6 +4,7 @@ import { Suspense, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useRouter, Link } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { withTimeout } from '@/lib/withTimeout';
 import { useTranslations } from 'next-intl';
 
 import AuthShell from '@/components/landlord/AuthShell';
@@ -29,39 +30,44 @@ function StudentLoginInner() {
     e.preventDefault();
     setError('');
     setLoading(true);
+    try {
+      const supabase = getSupabaseBrowser();
+      const { data, error: authError } = await withTimeout(
+        supabase.auth.signInWithPassword({ email, password }),
+      );
 
-    const supabase = getSupabaseBrowser();
-    const { data, error: authError } = await supabase.auth.signInWithPassword({
-      email,
-      password,
-    });
+      if (authError) {
+        setError(authError.message);
+        return;
+      }
 
-    if (authError) {
-      setError(authError.message);
+      // Sync cookie eagerly so the next navigation's RSC sees auth without
+      // waiting for SessionSync's onAuthStateChange to fire.
+      if (data.session?.access_token) {
+        await withTimeout(
+          fetch('/api/auth/session', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ access_token: data.session.access_token }),
+          }),
+        );
+      }
+
+      if (safeNext) {
+        // useRouter.push with a locale-prefixed path won't accept ?, so we
+        // hand a raw URL to window.location for paths that include query
+        // strings (the common case when AuthGate threads search/results
+        // state back into the next URL).
+        window.location.assign(safeNext);
+        return;
+      }
+
+      router.push('/student/account');
+    } catch (err) {
+      setError(err.message || 'Something went wrong. Please try again.');
+    } finally {
       setLoading(false);
-      return;
     }
-
-    // Sync cookie eagerly so the next navigation's RSC sees auth without
-    // waiting for SessionSync's onAuthStateChange to fire.
-    if (data.session?.access_token) {
-      await fetch('/api/auth/session', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ access_token: data.session.access_token }),
-      });
-    }
-
-    if (safeNext) {
-      // useRouter.push with a locale-prefixed path won't accept ?, so we
-      // hand a raw URL to window.location for paths that include query
-      // strings (the common case when AuthGate threads search/results
-      // state back into the next URL).
-      window.location.assign(safeNext);
-      return;
-    }
-
-    router.push('/student/account');
   }
 
   return (

--- a/src/app/[locale]/student/signup/page.js
+++ b/src/app/[locale]/student/signup/page.js
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter, Link } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { withTimeout } from '@/lib/withTimeout';
 import { useLocale, useTranslations } from 'next-intl';
 
 import AuthShell from '@/components/landlord/AuthShell';
@@ -30,57 +31,66 @@ export default function StudentSignupPage() {
     }
 
     setLoading(true);
-
-    const supabase = getSupabaseBrowser();
-    const siteUrl = window.location.origin;
-    const { data: authData, error: authError } = await supabase.auth.signUp({
-      email,
-      password,
-      options: {
-        emailRedirectTo: `${siteUrl}/${locale}/student/login`,
-        data: { display_name: name, role: 'student' },
-      },
-    });
-    if (authError) {
-      setError(authError.message);
-      setLoading(false);
-      return;
-    }
-
-    const session = authData.session;
-    if (session?.access_token) {
-      // Persist the session into the server-readable cookie before we
-      // call the profile endpoint — Supabase signUp returns a session
-      // immediately when email confirmations aren't enforced, but the
-      // SessionSync onAuthStateChange listener may not have fired yet.
-      await fetch('/api/auth/session', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ access_token: session.access_token }),
-      });
-
-      const res = await fetch('/api/student/profile', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${session.access_token}`,
-        },
-        body: JSON.stringify({ display_name: name, preferred_locale: locale }),
-      });
-      if (!res.ok) {
-        await supabase.auth.signOut();
-        const { error: profileError } = await res.json().catch(() => ({}));
-        setError(profileError || t('profileCreateFailed'));
-        setLoading(false);
+    try {
+      const supabase = getSupabaseBrowser();
+      const siteUrl = window.location.origin;
+      const { data: authData, error: authError } = await withTimeout(
+        supabase.auth.signUp({
+          email,
+          password,
+          options: {
+            emailRedirectTo: `${siteUrl}/${locale}/student/login`,
+            data: { display_name: name, role: 'student' },
+          },
+        }),
+      );
+      if (authError) {
+        setError(authError.message);
         return;
       }
-      router.push('/student/account');
-      return;
-    }
 
-    // Email confirmation enforced → no session yet. Send them to the
-    // shared verify-email screen, mirroring the landlord flow.
-    router.push('/student/verify-email');
+      const session = authData.session;
+      if (session?.access_token) {
+        // Persist the session into the server-readable cookie before we
+        // call the profile endpoint — Supabase signUp returns a session
+        // immediately when email confirmations aren't enforced, but the
+        // SessionSync onAuthStateChange listener may not have fired yet.
+        await withTimeout(
+          fetch('/api/auth/session', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ access_token: session.access_token }),
+          }),
+        );
+
+        const res = await withTimeout(
+          fetch('/api/student/profile', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${session.access_token}`,
+            },
+            body: JSON.stringify({ display_name: name, preferred_locale: locale }),
+          }),
+        );
+        if (!res.ok) {
+          await supabase.auth.signOut();
+          const { error: profileError } = await res.json().catch(() => ({}));
+          setError(profileError || t('profileCreateFailed'));
+          return;
+        }
+        router.push('/student/account');
+        return;
+      }
+
+      // Email confirmation enforced → no session yet. Send them to the
+      // shared verify-email screen, mirroring the landlord flow.
+      router.push('/student/verify-email');
+    } catch (err) {
+      setError(err.message || 'Something went wrong. Please try again.');
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (

--- a/src/lib/withTimeout.js
+++ b/src/lib/withTimeout.js
@@ -1,0 +1,20 @@
+/**
+ * Race a promise against a timeout. Resolves with the promise's value if it
+ * settles before `ms` elapses, otherwise rejects with a "Request timed out"
+ * error. Used in auth-flow handlers (login / signup / reset-password) where
+ * a hung Supabase call or fetch would otherwise leave the user stuck on a
+ * loading spinner with no error message and no way to recover — typically
+ * caused by Cloudflare Workers cold-start latency or transient mobile-network
+ * drops.
+ */
+export function withTimeout(promise, ms = 15000) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) =>
+      setTimeout(
+        () => reject(new Error('Request timed out. Please try again.')),
+        ms,
+      ),
+    ),
+  ]);
+}


### PR DESCRIPTION
## Summary

User reported the student login button getting stuck on "Signing in…" indefinitely with no error and no recovery — same class of bug as the reset-password hang fixed in [#73](https://github.com/MichaelChar/StudentX/pull/73).

Root cause is structural: all four auth pages (student/landlord × login/signup) `await supabase.auth.{signInWithPassword,signUp}(...)` and follow-up POSTs to `/api/auth/session`, `/api/student/profile`, `/api/landlord/profile` with no try/catch and no timeout. On the happy path `setLoading(false)` is never reached because navigation takes over. But when any of those calls hangs — Cloudflare Workers cold-start latency, transient mobile-network drop, etc. — the spinner stays forever and no error surfaces to the user.

### Fix

- Extract a tiny shared `withTimeout(promise, ms = 15000)` at [src/lib/withTimeout.js](src/lib/withTimeout.js) — races the promise against a 15s timeout, rejects with `"Request timed out. Please try again."` if it doesn't settle.
- Wrap every awaited Supabase / fetch call in `withTimeout(...)` across all four pages.
- Wrap each submit handler in an outer `try/catch/finally` so `setLoading(false)` always runs and any thrown error (including timeouts) surfaces as a visible error instead of a stuck spinner.

Files touched:
- `src/lib/withTimeout.js` (new)
- `src/app/[locale]/student/login/page.js`
- `src/app/[locale]/student/signup/page.js`
- `src/app/[locale]/landlord/login/page.js`
- `src/app/[locale]/landlord/signup/page.js`

(The reset-password pages from #73 already have an inline equivalent. Not deduping them in this PR — leaves the diff focused.)

This is defensive plumbing — it makes failures visible so we can diagnose what's actually slow under the hood, not a root-cause fix for the underlying Supabase / Workers latency.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] Login page renders in dev preview, form fields wired up, no console / server errors
- [x] `withTimeout` unit-tested in browser eval: resolves promises pass through, hung promises reject after the timeout window with the expected message
- [ ] Manual on prod after merge: user retries login, either succeeds within 15s or sees an error message (not a stuck spinner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)