### PR TITLE
fix(navbar): wrap auth probe in withTimeout so it always resolves

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { Link, useRouter, usePathname } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { withTimeout } from '@/lib/withTimeout';
 import LocaleSwitcher from './LocaleSwitcher';
 import Icon from './ui/Icon';
 import UnreadBadge from './UnreadBadge';
@@ -28,17 +29,21 @@ export default function Navbar() {
   ];
 
   // Shared fetcher — refreshes unread count using the current session token.
+  // All awaits are timeout-wrapped so a hung Supabase / API call can't leave
+  // the badge in a stale state forever.
   const fetchUnread = useCallback(async () => {
-    const supabase = getSupabaseBrowser();
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session?.access_token) {
-      setUnread({ count: 0, role: null });
-      return;
-    }
     try {
-      const res = await fetch('/api/me/unread', {
-        headers: { Authorization: `Bearer ${session.access_token}` },
-      });
+      const supabase = getSupabaseBrowser();
+      const { data: { session } } = await withTimeout(supabase.auth.getSession());
+      if (!session?.access_token) {
+        setUnread({ count: 0, role: null });
+        return;
+      }
+      const res = await withTimeout(
+        fetch('/api/me/unread', {
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        }),
+      );
       if (!res.ok) return;
       const json = await res.json();
       setUnread({ count: json.count || 0, role: json.role || null });
@@ -50,23 +55,30 @@ export default function Navbar() {
   // Resolve role through /api/auth/me using the browser session token. The
   // server endpoint returns { user: null } when unauthenticated, so guests
   // settle into the signed-out state without us treating non-200s as errors.
+  // The whole probe is wrapped in try/catch + withTimeout so setAuthState
+  // ({ ready: true }) ALWAYS runs — without it, a hung getSession() (e.g.
+  // stale session-refresh on Cloudflare Workers cold start) leaves the
+  // navbar stuck on the placeholder forever, which previously hid the
+  // landlord-login link from guests on flaky sessions.
   useEffect(() => {
     let cancelled = false;
     const supabase = getSupabaseBrowser();
 
     async function refresh() {
-      const { data: { session } } = await supabase.auth.getSession();
-      if (!session?.access_token) {
-        if (!cancelled) {
-          setAuthState({ ready: true, role: null, name: null });
-          setUnread({ count: 0, role: null });
-        }
-        return;
-      }
       try {
-        const res = await fetch('/api/auth/me', {
-          headers: { Authorization: `Bearer ${session.access_token}` },
-        });
+        const { data: { session } } = await withTimeout(supabase.auth.getSession());
+        if (!session?.access_token) {
+          if (!cancelled) {
+            setAuthState({ ready: true, role: null, name: null });
+            setUnread({ count: 0, role: null });
+          }
+          return;
+        }
+        const res = await withTimeout(
+          fetch('/api/auth/me', {
+            headers: { Authorization: `Bearer ${session.access_token}` },
+          }),
+        );
         if (!res.ok) {
           if (!cancelled) setAuthState({ ready: true, role: null, name: null });
           return;


### PR DESCRIPTION
## Summary

Follow-up to [#75](https://github.com/MichaelChar/StudentX/pull/75). User reported that in their Safari session the desktop navbar was showing only a faded "Sign in" placeholder — the **LANDLORD** login link was missing for guests. A fresh incognito session against the same URL rendered the expected guest state (`SIGN IN` + `LANDLORD`).

The Navbar has three render branches:

```js
if (!authState.ready) return placeholder;       // single faded "SIGN IN"
if (authState.role) return signedInControls;    // "MY ACCOUNT" + "SIGN OUT"
return guestControls;                            // "SIGN IN" + "LANDLORD"
```

Their Safari session was stuck in branch 1 because the auth-state probe in [`Navbar.js`](src/components/Navbar.js) was hanging:

```js
const { data: { session } } = await supabase.auth.getSession();   // hung
// setAuthState({ ready: true, ... }) never reached
```

`getSession()` lives outside the probe's existing try/catch, so a hang (stale session-refresh on Cloudflare Workers cold start, flaky network, etc.) leaves `authState.ready` permanently `false`.

### Fix

Same shape as #73 / #75:
- Wrap `supabase.auth.getSession()` and `fetch('/api/auth/me')` in `withTimeout(...)` (15s default).
- Bring the entire probe under one outer `try/catch` so any thrown timeout (or other error) lands in `catch` and still calls `setAuthState({ ready: true, role: null })` — placeholder always resolves to a real state.
- Apply the same treatment to `fetchUnread` (badge probe) for consistency.

Single file: `src/components/Navbar.js`. Reuses `withTimeout` from #75.

## Test plan

- [x] `node --check` passes on `Navbar.js` and `withTimeout.js` (local node_modules is in a corrupted state from this session — relying on CI's clean install for the real lint + build)
- [ ] CI: `npm run lint` + `npm run build` clean
- [ ] Manual on prod after merge: in the previously stuck Safari session, the navbar resolves to either guest (SIGN IN + LANDLORD) or signed-in (MY ACCOUNT + SIGN OUT) within ~15s instead of staying on the placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)