### PR TITLE
fix(billing): route paid verification through in-app checkout

### DIFF
--- a/src/app/[locale]/landlord/get-verified/page.js
+++ b/src/app/[locale]/landlord/get-verified/page.js
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 
 import LandlordShell from '@/components/landlord/LandlordShell';
@@ -8,6 +9,7 @@ import Button from '@/components/ui/Button';
 import Pill from '@/components/ui/Pill';
 import Icon from '@/components/ui/Icon';
 import VerifiedSeal from '@/components/ui/VerifiedSeal';
+import { useAccessToken } from '@/lib/useAccessToken';
 
 /*
   Propylaea pricing / Get Verified page. Two tiers, seal-gold accents,
@@ -22,7 +24,6 @@ const PAID_TIERS = [
     price: '€49',
     period: '/yr',
     highlight: false,
-    stripeUrl: 'https://buy.stripe.com/bJe7sLdhg0KY7ep3S3awo00',
     features: [
       { label: 'Listing cap', value: 'Up to 5' },
       { label: 'Photos per listing', value: 'Unlimited' },
@@ -39,7 +40,6 @@ const PAID_TIERS = [
     price: '€99',
     period: '/yr',
     highlight: true,
-    stripeUrl: 'https://buy.stripe.com/00wcN55OO51ebuF60bawo02',
     features: [
       { label: 'Listing cap', value: 'Up to 12 (+€5/mo overage)' },
       { label: 'Photos per listing', value: 'Unlimited' },
@@ -53,9 +53,35 @@ const PAID_TIERS = [
 
 export default function GetVerifiedPage() {
   const t = useTranslations('landlord.getVerified');
+  const tBilling = useTranslations('landlord.billing');
+  const accessToken = useAccessToken();
+  const [pendingTier, setPendingTier] = useState(null);
+  const [error, setError] = useState('');
 
-  function handleChoose(stripeUrl) {
-    window.location.assign(stripeUrl);
+  async function handleChoose(tierKey) {
+    setError('');
+    setPendingTier(tierKey);
+    try {
+      const res = await fetch('/api/landlord/billing/checkout', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken || ''}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ tier: tierKey }),
+      });
+      const { url, error: apiError } = await res.json();
+      if (!res.ok || !url) {
+        setError(apiError || tBilling('checkoutError'));
+        setPendingTier(null);
+        return;
+      }
+      window.location.assign(url);
+    } catch (err) {
+      console.error('[GetVerified] checkout failed:', err);
+      setError(tBilling('checkoutError'));
+      setPendingTier(null);
+    }
   }
 
   return (
@@ -70,11 +96,19 @@ export default function GetVerifiedPage() {
             <TierCard
               key={tier.key}
               tier={tier}
-              onChoose={() => handleChoose(tier.stripeUrl)}
+              onChoose={() => handleChoose(tier.key)}
               ctaLabel={t('chooseTier')}
+              disabled={pendingTier !== null}
+              loading={pendingTier === tier.key}
             />
           ))}
         </div>
+
+        {error && (
+          <p className="mt-6 text-sm text-red-700 bg-red-50 border border-red-200 rounded-sm px-3 py-2 max-w-2xl">
+            {error}
+          </p>
+        )}
 
         <p className="mt-8 label-caps text-night/40">{t('stripeNote')}</p>
       </div>
@@ -82,7 +116,7 @@ export default function GetVerifiedPage() {
   );
 }
 
-function TierCard({ tier, onChoose, ctaLabel }) {
+function TierCard({ tier, onChoose, ctaLabel, disabled = false, loading = false }) {
   return (
     <Card
       tone={tier.highlight ? 'night' : 'white'}
@@ -177,8 +211,9 @@ function TierCard({ tier, onChoose, ctaLabel }) {
           onClick={onChoose}
           variant={tier.highlight ? 'gold' : 'primary'}
           className="w-full justify-center"
+          disabled={disabled}
         >
-          {ctaLabel}
+          {loading ? '…' : ctaLabel}
         </Button>
       </div>
     </Card>

--- a/src/app/[locale]/landlord/onboarding/page.js
+++ b/src/app/[locale]/landlord/onboarding/page.js
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { useAccessToken } from '@/lib/useAccessToken';
 
 const TIERS = [
   {
@@ -63,7 +64,10 @@ const TIERS = [
 
 export default function LandlordOnboardingPage() {
   const router = useRouter();
+  const accessToken = useAccessToken();
   const [loading, setLoading] = useState(true);
+  const [pendingTier, setPendingTier] = useState(null);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     async function init() {
@@ -82,13 +86,34 @@ export default function LandlordOnboardingPage() {
     init();
   }, [router]);
 
-  function handleChoose(tierKey) {
+  async function handleChoose(tierKey) {
     if (tierKey === 'free') {
       router.push('/landlord/dashboard');
-    } else if (tierKey === 'verified') {
-      window.location.assign('https://buy.stripe.com/bJe7sLdhg0KY7ep3S3awo00');
-    } else if (tierKey === 'verified_pro') {
-      window.location.assign('https://buy.stripe.com/00wcN55OO51ebuF60bawo02');
+      return;
+    }
+
+    setError('');
+    setPendingTier(tierKey);
+    try {
+      const res = await fetch('/api/landlord/billing/checkout', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken || ''}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ tier: tierKey, returnTo: 'onboarding' }),
+      });
+      const { url, error: apiError } = await res.json();
+      if (!res.ok || !url) {
+        setError(apiError || 'Failed to start checkout. Please try again.');
+        setPendingTier(null);
+        return;
+      }
+      window.location.assign(url);
+    } catch (err) {
+      console.error('[LandlordOnboarding] checkout failed:', err);
+      setError('Failed to start checkout. Please try again.');
+      setPendingTier(null);
     }
   }
 
@@ -151,19 +176,26 @@ export default function LandlordOnboardingPage() {
               <div className="p-6 pt-0">
                 <button
                   onClick={() => handleChoose(tier.key)}
-                  className={`w-full py-3 rounded-xl font-heading font-semibold transition-colors ${
+                  disabled={pendingTier !== null}
+                  className={`w-full py-3 rounded-xl font-heading font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                     tier.key === 'free'
                       ? 'bg-navy text-white hover:bg-navy/90'
                       : 'bg-gold text-white hover:bg-gold/90'
                   }`}
                 >
-                  Choose this tier
+                  {pendingTier === tier.key ? '…' : 'Choose this tier'}
                 </button>
               </div>
             </div>
           ))}
         </div>
       </div>
+
+      {error && (
+        <p className="mt-6 max-w-md text-sm text-red-700 bg-red-50 border border-red-200 rounded-lg px-3 py-2">
+          {error}
+        </p>
+      )}
 
       <p className="text-xs text-gray-dark/40 mt-8">
         Paid plans use secure checkout via Stripe. Cancel anytime.


### PR DESCRIPTION
## Summary

- The two paid-checkout entry points (`/landlord/get-verified` and `/landlord/onboarding`) were redirecting to hardcoded `buy.stripe.com` Payment Links, which create Checkout Sessions with no metadata. The webhook handler bails on missing `landlord_id` / `plan_id`, so paid landlords never got `verified_tier` flipped.
- Both pages now POST to the existing `/api/landlord/billing/checkout` route, which sets the right metadata, links the Stripe customer to the landlord, and returns a Checkout URL — matching the (orphaned, unused) `BillingSection` pattern.
- Webhook, schema, and `getOrCreateCustomer` are unchanged — they always handled this correctly; they just never received a session with the right metadata.

One affected landlord (`landlord_id=0106`) was healed manually post-deploy plan: `subscriptions` row inserted, `verified_tier='verified'`, `is_verified=true`, `onboarding_completed=true`, `stripe_customer_id` linked.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` succeeds; both routes appear in the route list
- [x] Dev server boots clean; both pages serve 200 with auth-gate redirect intact
- [ ] Post-deploy: a fresh paid checkout (real €49 charge, refunded) flips `verified_tier` end-to-end via the prod webhook

🤖 Generated with [Claude Code](https://claude.com/claude-code)