### PR TITLE
feat(verification): handle ID-approved-without-subscription state

### DIFF
--- a/src/app/[locale]/landlord/dashboard/page.js
+++ b/src/app/[locale]/landlord/dashboard/page.js
@@ -397,7 +397,32 @@ function VerificationCard({ tier, isVerified, t }) {
     );
   }
 
-  // No subscription — original CTA to upgrade.
+  // ID approved but no subscription — show their progress + nudge to subscribe.
+  if (isVerified) {
+    return (
+      <Card tone="parchment" className="p-6 md:p-8">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-5">
+          <div className="flex items-center gap-5">
+            <VerifiedSeal size={52} />
+            <div>
+              <p className="label-caps text-gold">{t('widgetVerification')}</p>
+              <p className="font-display text-2xl text-night mt-1">
+                {t('idApprovedAwaitingSubscriptionTitle')}
+              </p>
+              <p className="text-night/70 text-sm mt-1 max-w-md">
+                {t('idApprovedAwaitingSubscriptionBody')}
+              </p>
+            </div>
+          </div>
+          <Button href="/landlord/get-verified" variant="gold" size="md">
+            {t('chooseSubscription')}
+          </Button>
+        </div>
+      </Card>
+    );
+  }
+
+  // No subscription, no approved ID — original CTA to upgrade.
   return (
     <Card tone="night" className="p-6 md:p-8">
       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-5">

--- a/src/app/[locale]/landlord/verification/page.js
+++ b/src/app/[locale]/landlord/verification/page.js
@@ -148,6 +148,7 @@ export default function LandlordVerificationPage() {
               submitError={submitError}
               submitSuccess={submitSuccess}
               onSubmit={handleSubmit}
+              subscribed={verifiedTier && verifiedTier !== 'none'}
             />
           </div>
         ) : (
@@ -167,7 +168,7 @@ export default function LandlordVerificationPage() {
   );
 }
 
-function UploadForm({ file, setFile, fileInputRef, submitting, submitError, submitSuccess, onSubmit }) {
+function UploadForm({ file, setFile, fileInputRef, submitting, submitError, submitSuccess, onSubmit, subscribed = false }) {
   if (submitSuccess) {
     return (
       <Card tone="parchment" className="px-6 py-5 flex items-start gap-4">
@@ -177,7 +178,9 @@ function UploadForm({ file, setFile, fileInputRef, submitting, submitError, subm
         <div>
           <p className="font-display text-lg text-night mb-1">Document submitted</p>
           <p className="text-sm text-night/70">
-            We&apos;ll review your ID within 1–2 business days and notify you when your badge is activated.
+            {subscribed
+              ? <>We&apos;ll review your ID within 1–2 business days and notify you when your badge is activated.</>
+              : <>We&apos;ll review your ID within 1–2 business days. A SuperLandlord subscription is also required for the Verified badge to appear publicly on your listings — you can subscribe at any time, before or after your ID is approved.</>}
           </p>
         </div>
       </Card>

--- a/src/messages/el.json
+++ b/src/messages/el.json
@@ -568,7 +568,10 @@
         "unverifiedBody": "Δείξε στους φοιτητές ότι είσαι γνήσιος — σήμα, προτεραιότητα, περισσότερα αιτήματα.",
         "subscribedAwaitingIdTitle": "Καλώς ήρθες στην SuperLandlord",
         "subscribedAwaitingIdBody": "Ένα τελευταίο βήμα — ανέβασε ταυτότητα για να ενεργοποιηθεί το σήμα Verified στις αγγελίες σου.",
-        "submitIdCta": "Ανέβασε ταυτότητα"
+        "submitIdCta": "Ανέβασε ταυτότητα",
+        "idApprovedAwaitingSubscriptionTitle": "Η ταυτότητά σου εγκρίθηκε",
+        "idApprovedAwaitingSubscriptionBody": "Τελευταίο βήμα — ξεκίνα συνδρομή για να εμφανίζεσαι δημόσια ως επαληθευμένος ιδιοκτήτης.",
+        "chooseSubscription": "Επίλεξε συνδρομή"
       }
     }
   },

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -568,7 +568,10 @@
         "unverifiedBody": "Show students you're a real landlord — seal, priority, more inquiries.",
         "subscribedAwaitingIdTitle": "Welcome to SuperLandlord",
         "subscribedAwaitingIdBody": "One last step — upload an ID to activate the Verified badge on your listings.",
-        "submitIdCta": "Upload ID"
+        "submitIdCta": "Upload ID",
+        "idApprovedAwaitingSubscriptionTitle": "Your ID is approved",
+        "idApprovedAwaitingSubscriptionBody": "Last step — subscribe to become a publicly verified landlord.",
+        "chooseSubscription": "Choose subscription"
       }
     }
   },


### PR DESCRIPTION
## Summary

Closes the two gaps a landlord could fall into after #78's two-step verification model went live:

- **Dashboard fourth state.** When `is_verified=true` and `verified_tier='none'`, the VerificationCard now shows "Your ID is approved — last step, subscribe to become a publicly verified landlord" with a "Choose subscription" CTA. Previously these users saw the generic "Get verified" prompt that ignored their already-approved ID.

- **Verification submit-success message branches on subscription.** Subscribed users still see "we'll notify you when your badge is activated"; unsubscribed users now get an explicit callout that a SuperLandlord subscription is required for the badge to appear publicly. Sets expectations up front rather than after the fact.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [x] Both i18n bundles parse with the new keys
- [ ] Post-deploy: simulate a landlord with `verified_tier='none', is_verified=true` (manual SQL) → dashboard shows new fourth state, CTA links to `/landlord/get-verified`.
- [ ] Post-deploy: unsubscribed landlord submits ID → success card mentions that subscription is needed for public badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)