### PR TITLE
fix(landlord): top-bar layering — non-sticky, opaque, sidebar lift

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -135,8 +135,16 @@ export default function Navbar() {
   const inquiriesHref =
     authState.role === 'landlord' ? '/landlord/inquiries' : '/student/account';
 
+  const isLandlord = pathname?.startsWith('/landlord') ?? false;
+
   return (
-    <nav className="sticky top-0 z-50 bg-stone/95 backdrop-blur border-b border-night/10">
+    <nav
+      className={
+        isLandlord
+          ? 'z-50 bg-stone border-b border-night/10'
+          : 'sticky top-0 z-50 bg-stone/95 backdrop-blur border-b border-night/10'
+      }
+    >
       <TabTitleFlash count={unread.count} />
       <div className="mx-auto max-w-6xl px-5 py-4 flex items-center justify-between gap-6">
         <Link

--- a/src/components/landlord/LandlordShell.js
+++ b/src/components/landlord/LandlordShell.js
@@ -90,7 +90,7 @@ export default function LandlordShell({ title, eyebrow, actions, children }) {
   return (
     <div className="min-h-screen bg-stone flex">
       {/* Sidebar — desktop */}
-      <aside className="hidden lg:flex w-[240px] flex-col bg-night text-stone fixed inset-y-0 left-0 z-30">
+      <aside className="hidden lg:flex w-[240px] flex-col bg-night text-stone fixed inset-y-0 left-0 z-[60]">
         <SidebarContent
           t={t}
           pathname={pathname}

--- a/src/components/landlord/LandlordShell.js
+++ b/src/components/landlord/LandlordShell.js
@@ -119,7 +119,7 @@ export default function LandlordShell({ title, eyebrow, actions, children }) {
       {/* Main area */}
       <div className="flex-1 lg:ml-[240px] flex flex-col min-w-0">
         {/* Topbar */}
-        <header className="sticky top-0 z-20 bg-stone/95 backdrop-blur border-b border-night/10">
+        <header className="sticky top-0 z-20 bg-stone border-b border-night/10">
           <div className="px-5 md:px-8 py-4 flex items-center gap-4">
             {/* Mobile menu */}
             <button


### PR DESCRIPTION
## Summary

Three landlord-portal top-bar layering fixes, bundled because they're the same family of bug:

- **Non-sticky + opaque global Navbar on landlord routes.** [src/components/Navbar.js](src/components/Navbar.js): pathname-gated — on `/landlord/*` it becomes non-sticky and fully opaque (`bg-stone`, no blur). Stops page content like the dashboard's "Good to see you," greeting from reading through during scroll. Student / marketing surfaces keep the original sticky + translucent + blurred behavior.
- **Opaque LandlordShell topbar.** [src/components/landlord/LandlordShell.js:122](src/components/landlord/LandlordShell.js:122): topbar bg `bg-stone/95 backdrop-blur` → `bg-stone`. Stays `sticky top-0` so the page title remains pinned during long inquiry/listing scrolls — just no longer translucent.
- **Sidebar above the global Navbar.** [src/components/landlord/LandlordShell.js:93](src/components/landlord/LandlordShell.js:93): desktop sidebar z-index `z-30` → `z-[60]`. The teal column now reads as a single unbroken element from top to bottom; the navbar's leftmost 240px is hidden behind the sidebar (which already carries the StudentX × AUSOM brand, so no info is lost).

## Test plan

- [ ] **Landlord, scrolled (primary fix):** sign in as a landlord, open `/landlord/dashboard`, scroll. Global Navbar scrolls off the top; LandlordShell topbar (with greeting) stays pinned and fully opaque — page content slides cleanly under it.
- [ ] **Sidebar continuity:** desktop landlord viewport — teal sidebar extends from the very top of the viewport down, with no cream gap above "LANDLORD PORTAL".
- [ ] **Top-of-page sanity:** zero-scroll on a landlord page. All three elements (sidebar full-height, navbar visible to the right of the sidebar, topbar below) render without overlap artifacts.
- [ ] **Student route regression:** open `/results` (or `/student/account`), scroll. Global Navbar is **still sticky and still translucent + blurred** — exactly the prior behavior.
- [ ] **English locale:** open `/en/landlord/dashboard`. Same fixes apply (locale-stripped `pathname.startsWith('/landlord')` matches on `/en/...`).
- [ ] **Long-scroll page:** open `/landlord/inquiries` or `/landlord/listings`. Topbar stays opaque-and-pinned; page title remains readable while scrolling.
- [ ] **Mobile viewport:** at phone width on a landlord page, the LandlordShell hamburger (in its sticky topbar) is reachable at any scroll depth — landlord drawer can still be opened mid-scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)