### PR TITLE
fix(landlord): fallback SELECT for missing min_duration_months column

### DIFF
--- a/src/app/api/landlord/listings/[id]/route.js
+++ b/src/app/api/landlord/listings/[id]/route.js
@@ -36,21 +36,46 @@ export async function GET(request, { params }) {
 
   const { id } = await params;
   const authedSupabase = getSupabaseWithToken(token);
-  const { data, error } = await authedSupabase
+
+  const SINGLE_LISTING_SELECT = `
+    listing_id, landlord_id, rent_id, location_id, property_type_id,
+    description, photos, sqm, floor, available_from, min_duration_months,
+    rent ( rent_id, monthly_price, bills_included, deposit ),
+    location ( location_id, address, neighborhood, lat, lng ),
+    property_types ( property_type_id, name ),
+    listing_amenities ( amenities ( amenity_id, name ) )
+  `;
+  const SINGLE_LISTING_SELECT_FALLBACK = `
+    listing_id, landlord_id, rent_id, location_id, property_type_id,
+    description, photos, sqm, floor, available_from,
+    rent ( rent_id, monthly_price, bills_included, deposit ),
+    location ( location_id, address, neighborhood, lat, lng ),
+    property_types ( property_type_id, name ),
+    listing_amenities ( amenities ( amenity_id, name ) )
+  `;
+
+  let { data, error } = await authedSupabase
     .from('listings')
-    .select(`
-      listing_id, landlord_id, rent_id, location_id, property_type_id,
-      description, photos, sqm, floor, available_from, min_duration_months,
-      rent ( rent_id, monthly_price, bills_included, deposit ),
-      location ( location_id, address, neighborhood, lat, lng ),
-      property_types ( property_type_id, name ),
-      listing_amenities ( amenities ( amenity_id, name ) )
-    `)
+    .select(SINGLE_LISTING_SELECT)
     .eq('listing_id', id)
     .eq('landlord_id', landlordId)
     .single();
 
-  if (error || !data) {
+  if (error) {
+    const fallback = await authedSupabase
+      .from('listings')
+      .select(SINGLE_LISTING_SELECT_FALLBACK)
+      .eq('listing_id', id)
+      .eq('landlord_id', landlordId)
+      .single();
+
+    if (fallback.error || !fallback.data) {
+      return NextResponse.json({ error: 'Listing not found' }, { status: 404 });
+    }
+    data = fallback.data;
+  }
+
+  if (!data) {
     return NextResponse.json({ error: 'Listing not found' }, { status: 404 });
   }
 

--- a/src/app/api/landlord/listings/[id]/route.js
+++ b/src/app/api/landlord/listings/[id]/route.js
@@ -45,6 +45,9 @@ export async function GET(request, { params }) {
     property_types ( property_type_id, name ),
     listing_amenities ( amenities ( amenity_id, name ) )
   `;
+  // Pre-migration fallback: keep in sync with SINGLE_LISTING_SELECT minus
+  // any column that may not yet exist in prod (see route.js sibling for
+  // the same guard on the list-GET path).
   const SINGLE_LISTING_SELECT_FALLBACK = `
     listing_id, landlord_id, rent_id, location_id, property_type_id,
     description, photos, sqm, floor, available_from,

--- a/src/app/api/landlord/listings/route.js
+++ b/src/app/api/landlord/listings/route.js
@@ -24,6 +24,26 @@ const LANDLORD_LISTING_SELECT = `
   listing_amenities ( amenities ( amenity_id, name ) )
 `;
 
+const LANDLORD_LISTING_SELECT_FALLBACK = `
+  listing_id,
+  landlord_id,
+  is_featured,
+  rent_id,
+  location_id,
+  property_type_id,
+  description,
+  photos,
+  sqm,
+  floor,
+  available_from,
+  created_at,
+  updated_at,
+  rent ( rent_id, monthly_price, currency, bills_included, deposit ),
+  location ( location_id, address, neighborhood, lat, lng ),
+  property_types ( property_type_id, name ),
+  listing_amenities ( amenities ( amenity_id, name ) )
+`;
+
 const ALLOWED_MIN_DURATIONS = [1, 5, 9];
 
 // Coerces the form value (string "" / "1" / "5" / "9" or number / null / undefined)
@@ -60,15 +80,25 @@ export async function GET(request) {
   if (!landlordId) return NextResponse.json({ error: 'Landlord profile not found' }, { status: 404 });
 
   const authedSupabase = getSupabaseWithToken(token);
-  const { data, error } = await authedSupabase
+  let { data, error } = await authedSupabase
     .from('listings')
     .select(LANDLORD_LISTING_SELECT)
     .eq('landlord_id', landlordId)
     .order('created_at', { ascending: false });
 
   if (error) {
-    console.error('Failed to fetch landlord listings:', error);
-    return NextResponse.json({ error: 'Failed to fetch listings' }, { status: 500 });
+    console.warn('Landlord listings query failed, retrying without min_duration_months:', error.message);
+    const fallback = await authedSupabase
+      .from('listings')
+      .select(LANDLORD_LISTING_SELECT_FALLBACK)
+      .eq('landlord_id', landlordId)
+      .order('created_at', { ascending: false });
+
+    if (fallback.error) {
+      console.error('Failed to fetch landlord listings:', fallback.error);
+      return NextResponse.json({ error: 'Failed to fetch listings' }, { status: 500 });
+    }
+    data = fallback.data;
   }
 
   return NextResponse.json({ listings: data });

--- a/src/app/api/landlord/listings/route.js
+++ b/src/app/api/landlord/listings/route.js
@@ -24,6 +24,10 @@ const LANDLORD_LISTING_SELECT = `
   listing_amenities ( amenities ( amenity_id, name ) )
 `;
 
+// Pre-migration fallback: identical to LANDLORD_LISTING_SELECT minus columns
+// that may not yet exist in prod. When adding a column to LANDLORD_LISTING_SELECT
+// that ships ahead of its migration, also omit it here so the GET handler can
+// degrade gracefully instead of darking the landlord portal.
 const LANDLORD_LISTING_SELECT_FALLBACK = `
   listing_id,
   landlord_id,


### PR DESCRIPTION
## Summary

- Mirror the public `/api/listings` fallback-SELECT pattern on the two landlord listings GET routes so a deploy-before-migration window can't dark the landlord portal again.
- Triggered by today's incident: PR [#84](https://github.com/MichaelChar/StudentX/pull/84) deployed code that SELECTs `min_duration_months`, but migration 037 had to be applied to prod Supabase as a separate step. In between, the listings index, dashboard, and edit page all 500'd with "Failed to load listings".
- Migration 037 has been applied to production. This PR is the defensive guard so the next migration-lag window doesn't repeat the outage.

## Why the public API already has this and the landlord one didn't

PR #84 added a fallback `LISTING_SELECT_FALLBACK` to `/api/listings` (student-facing) but skipped the landlord routes. The student side stayed green during the migration lag; the landlord side went dark. This PR closes that asymmetry.

## What changed

- `src/app/api/landlord/listings/route.js` — added `LANDLORD_LISTING_SELECT_FALLBACK` (omits `min_duration_months`), retry-on-error in the `GET` handler, downgraded the primary-failure log from `error` to `warn` (the fallback path is the success branch). Comment on the fallback constant flags that future column additions need to be reflected here too.
- `src/app/api/landlord/listings/[id]/route.js` — same pattern in the single-listing `GET`. Pulled the SELECT strings out as locals to keep the diff readable.

`POST` (create) and `PATCH` (update) intentionally aren't wrapped in fallbacks: writing `min_duration_months` against a pre-migration DB should still fail loudly, since silently dropping the field would let landlords think they saved a duration they didn't.

## Edit-page behavior under fallback

The edit page (`src/app/[locale]/landlord/listings/[id]/edit/page.js:54`) reads `String(listing.min_duration_months ?? 9)`. When the fallback path drops the column, the form defaults to `"9"` (Academic year) — a sensible read-side default consistent with the migration's backfill. Save submits a PATCH; if the column still doesn't exist, the PATCH fails loudly (no fallback for writes), and the landlord sees an error rather than a silent partial save. Both branches are intended.

## Follow-up (separate work — not blocking this PR)

This is the right tactical fix, but it papers over a process problem. The CI migration-check workflow only validates that migrations apply against a clean stack — it does not block the Cloudflare Worker deploy until the prod migration has been applied. Worth filing a separate issue covering: (a) a CLAUDE.md convention that schema-touching PRs apply the migration before merge, (b) a CI gate that diffs `supabase/migrations/` and checks prod has them, (c) a synthetic that hits `/api/landlord/listings` and pages on 5xx (alongside the existing `synthetic-en-listing` cron).

## Test plan

- [x] `npm run lint` — clean
- [x] Local `npm run dev` boots, `GET /api/landlord/listings` returns 401 (auth required, route alive)
- [x] Production `GET /api/landlord/listings` returns 401 post-migration (no longer 500)
- [x] Manually verified prod schema: `min_duration_months smallint` exists, `rental_duration` dropped, all 13 listings backfilled to `9`
- [ ] **(reviewer)** Sign in as a landlord, load `/landlord/listings` — error banner gone, listings render
- [ ] **(reviewer)** Open the edit page for an existing listing — `min_duration_months` field pre-populates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)