### PR TITLE
chore: landlord-listings synthetic canary + migration-ordering convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,7 +162,7 @@ Adding a new cron is a one-line entry in each table.
 
 Runbook: `docs/runbooks/synthetic-en-listing.md`.
 
-`/api/cron/synthetic-en-listing` runs **5 independent canaries** every 15 min,
+`/api/cron/synthetic-en-listing` runs **6 independent canaries** every 15 min,
 each soft-failing into a per-check report:
 
 1. `en-listing-locale` — `/en/listing/<SYNTHETIC_LISTING_ID>` contains
@@ -172,7 +172,9 @@ each soft-failing into a per-check report:
    `walk_minutes` across `faculty_distances`.
 3. `soft-404` — `/listing/does-not-exist` returns HTTP 404.
 4. `og-default` — `/og-default.png` serves with `image/png` content-type.
-5. `missing-message` — `/en` body contains no `MISSING_MESSAGE:` substring
+5. `landlord-listings-api` — `/api/landlord/listings` (no auth) returns 401,
+   not 5xx. Guards against the column-missing crash class fixed in PR #85.
+6. `missing-message` — `/en` body contains no `MISSING_MESSAGE:` substring
    (catches missing en.json keys).
 
 Failure path emails `SYNTHETIC_ALERT_EMAIL` via Resend — currently
@@ -185,8 +187,18 @@ Failures still surface in `wrangler tail`.
 
 - **Postgres + Auth + Storage + Realtime.** Inquiries use Supabase realtime channels.
 - **Migrations:** `supabase/migrations/` (NOT a top-level `migrations/`).
-  Numbered (`001_*` through `035_*`); CI applies them on every PR via
+  Numbered (`001_*` through `037_*`); CI applies them on every PR via
   `.github/workflows/migration-check.yml` (PR #45) using `supabase start`.
+- **Migration ordering — apply to prod BEFORE merging the consuming PR.**
+  Cloudflare deploys on push-to-main and there is no migration-aware gate;
+  if a PR adds/renames a column referenced by a SELECT, the deploy will
+  reach prod ahead of the migration and any route that touches the column
+  will 500 in the gap. Convention: when a PR includes a migration, apply
+  it to prod (`mcp__supabase__apply_migration` or `supabase db push`)
+  during PR review, paste the confirmation into the PR, then merge.
+  Affected routes should still be defensive — see the fallback-SELECT
+  pattern in `src/app/api/listings/route.js` and
+  `src/app/api/landlord/listings/route.js` (PR #85, post-incident).
 - **Star schema** (see `docs/schema.md`). `listings` is the fact table;
   `listings.location_id → location`, `listings.rent_id → rent`,
   `listings.landlord_id → landlords`. `transformListing.js`

--- a/src/app/api/cron/synthetic-en-listing/route.js
+++ b/src/app/api/cron/synthetic-en-listing/route.js
@@ -153,6 +153,37 @@ async function checkOgDefault(appUrl) {
   }
 }
 
+// /api/landlord/listings without an Authorization header should return 401
+// (route alive, auth-gated). A 5xx instead means the route crashed before
+// reaching the auth check — historically because a SELECT referenced a
+// column that didn't yet exist in prod (incident 2026-05-02, PR #85). The
+// fallback SELECT added in #85 makes this 5xx unlikely, but a brand-new
+// column-add in a future PR could still escape if the fallback constant
+// isn't kept in sync. Catch it within 15 minutes instead of via support.
+async function checkLandlordListingsApi(appUrl) {
+  const url = `${appUrl}/api/landlord/listings`;
+  try {
+    const res = await fetchUrl(url);
+    if (res.status >= 500) {
+      return {
+        name: 'landlord-listings-api',
+        ok: false,
+        reason: `expected 401 (auth-gated), got ${res.status} — route is crashing before auth`,
+      };
+    }
+    if (res.status !== 401) {
+      return {
+        name: 'landlord-listings-api',
+        ok: false,
+        reason: `expected 401, got ${res.status}`,
+      };
+    }
+    return { name: 'landlord-listings-api', ok: true };
+  } catch (err) {
+    return { name: 'landlord-listings-api', ok: false, reason: `fetch threw: ${err.message || err.name}` };
+  }
+}
+
 // next-intl renders `MISSING_MESSAGE: ...` placeholders when a key is absent
 // from the locale's messages bundle. Treat any such substring on /en as a
 // regression — it means a translation key was added without a peer in en.json.
@@ -228,6 +259,7 @@ export async function POST(request) {
     checkListingApiDistanceVariety(appUrl, listingId),
     checkSoft404(appUrl),
     checkOgDefault(appUrl),
+    checkLandlordListingsApi(appUrl),
     checkNoMissingMessage(appUrl),
   ]);
   for (const r of additional) {


### PR DESCRIPTION
## Summary

Two post-incident hardening items flagged by PM review on [#85](https://github.com/MichaelChar/StudentX/pull/85). Detection (#3) and convention (#1) from that review's three-part follow-up; the CI gate (#2) gets its own focused PR next.

## What's in this PR

### 1. New synthetic canary — `landlord-listings-api`

`src/app/api/cron/synthetic-en-listing/route.js` gains a 6th check that hits `/api/landlord/listings` with no Authorization header and asserts a `401` response. A `5xx` means the route is crashing before reaching the auth check — exactly the failure mode of the 2026-05-02 incident. PR #85's fallback SELECT makes this 5xx unlikely, but a future column-add that doesn't keep the fallback constant in sync could still slip through. This catches it within 15 min.

### 2. CLAUDE.md migration-ordering convention

A new subsection under **Database (Supabase)** documenting the rule that a PR with a schema migration must apply that migration to prod BEFORE merging — Cloudflare deploys on push-to-main with no migration gate, so merge-then-migrate guarantees a prod outage window. Treats the defensive fallback-SELECT pattern as a backstop, not a substitute.

### 3. Drive-by

- Updated the canary count (5 → 6) and the migration-numbering range (035_* → 037_*) on the same CLAUDE.md pass.

## Why this isn't bundled with the CI gate

The CI gate (item #2 from the PM review) is a more complex change — needs a Supabase access token in GitHub secrets, a script that diffs `supabase/migrations/` between PR base and head and queries `supabase_migrations.schema_migrations` on prod, and a thoughtful policy on false positives (e.g. data-only migrations that don't show up in `schema_migrations` if they were applied via raw SQL). Worth its own focused PR + review per direction.

## Test plan

- [x] `npm run lint` — clean
- [x] Local dev — `POST /api/cron/synthetic-en-listing` with `x-cron-secret` returns the new canary in `checks[]`, `landlord-listings-api` reports `ok: true` against the local route. Other canary failures (`en-listing-locale`, `soft-404`) are pre-existing dev-server-vs-CF-Worker artifacts and pass in prod.
- [ ] **(reviewer / post-merge)** Wait for the next 15-min cron tick, then `wrangler tail` to confirm the new canary appears in the result and reports `ok: true` against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)