### PR TITLE
ci: block PR merge until new migration is applied to prod

### DIFF
--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -23,3 +23,88 @@ jobs:
 
       - name: Start Supabase local stack (applies all migrations)
         run: supabase start
+
+  applied-to-prod:
+    # Block merge until any new migration in this PR has actually been
+    # applied to production Supabase. Cloudflare deploys on push-to-main
+    # with no migration gate, so merging ahead of the migration darks
+    # any route that SELECTs the new column (incident 2026-05-02, PR #85).
+    # See CLAUDE.md > Database (Supabase) > Migration ordering.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout (full history for base diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find new migration files in this PR
+        id: diff
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "${{ github.base_ref }}" --depth=1 || true
+          NEW_FILES=$(git diff --name-only --diff-filter=A \
+            "origin/${{ github.base_ref }}...HEAD" \
+            -- 'supabase/migrations/*.sql' || true)
+          if [ -z "$NEW_FILES" ]; then
+            echo "No new migration files added in this PR — nothing to verify."
+            echo "new_files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "New migration files added in this PR:"
+          echo "$NEW_FILES"
+          {
+            echo "new_files<<EOF"
+            echo "$NEW_FILES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Fetch applied migrations from production
+        if: steps.diff.outputs.new_files != ''
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SUPABASE_ACCESS_TOKEN:-}" ] || [ -z "${SUPABASE_PROJECT_REF:-}" ]; then
+            echo "::warning::SUPABASE_ACCESS_TOKEN secret or SUPABASE_PROJECT_REF variable not configured — gate will warn-but-pass until they're set. See PR description for setup."
+            : > /tmp/applied-names.txt
+            exit 0
+          fi
+          # Tolerate both response shapes: bare array (REST API) or
+          # { migrations: [...] } envelope (some clients/proxies).
+          curl --fail --silent --show-error \
+            -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
+            "https://api.supabase.com/v1/projects/$SUPABASE_PROJECT_REF/database/migrations" \
+            | jq -r '
+              if type == "array" then .[]
+              elif (.migrations // null | type) == "array" then .migrations[]
+              else empty end
+              | .name // empty
+            ' > /tmp/applied-names.txt
+          echo "Found $(wc -l < /tmp/applied-names.txt) applied migrations on prod (most recent 10):"
+          tail -n 10 /tmp/applied-names.txt
+
+      - name: Verify new migrations are applied to prod
+        if: steps.diff.outputs.new_files != ''
+        run: |
+          set -euo pipefail
+          if [ ! -s /tmp/applied-names.txt ]; then
+            echo "::warning::No applied-migration list available — skipping enforcement (see prior step)."
+            exit 0
+          fi
+          missing=0
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            stem=$(basename "$f" .sql)
+            # Some historical rows in schema_migrations stored `name`
+            # without the leading NNN_ prefix; allow either form to match.
+            stripped=$(echo "$stem" | sed -E 's/^[0-9]+_//')
+            if grep -qxE "(${stem}|${stripped})" /tmp/applied-names.txt; then
+              echo "✓ $stem is applied to prod"
+            else
+              echo "::error file=$f::Migration '$stem' is not yet applied to production Supabase. Apply it (mcp__supabase__apply_migration or 'supabase db push --linked') before merging. See CLAUDE.md > Database (Supabase) > Migration ordering."
+              missing=1
+            fi
+          done <<< "${{ steps.diff.outputs.new_files }}"
+          exit $missing

--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -82,7 +82,9 @@ jobs:
               else empty end
               | .name // empty
             ' > /tmp/applied-names.txt
-          echo "Found $(wc -l < /tmp/applied-names.txt) applied migrations on prod (most recent 10):"
+          # Note: API order isn't a documented contract, so this is "last
+          # 10 from the API response", not "most recently applied".
+          echo "Found $(wc -l < /tmp/applied-names.txt) applied migrations on prod (last 10 from API response):"
           tail -n 10 /tmp/applied-names.txt
 
       - name: Verify new migrations are applied to prod
@@ -98,12 +100,17 @@ jobs:
             [ -z "$f" ] && continue
             stem=$(basename "$f" .sql)
             # Some historical rows in schema_migrations stored `name`
-            # without the leading NNN_ prefix; allow either form to match.
+            # without the leading NNN_ prefix (e.g. when applied via the
+            # Supabase CLI vs. an explicit-name client). Allow either form
+            # to match. Don't tighten this without auditing the historical
+            # data — the corner case is "PR adds NNN_foo.sql while prod
+            # has an unrelated row named 'foo'", which is rare enough to
+            # accept rather than risk false positives on legacy rows.
             stripped=$(echo "$stem" | sed -E 's/^[0-9]+_//')
             if grep -qxE "(${stem}|${stripped})" /tmp/applied-names.txt; then
               echo "✓ $stem is applied to prod"
             else
-              echo "::error file=$f::Migration '$stem' is not yet applied to production Supabase. Apply it (mcp__supabase__apply_migration or 'supabase db push --linked') before merging. See CLAUDE.md > Database (Supabase) > Migration ordering."
+              echo "::error file=$f::Migration '$stem' is not yet applied to production Supabase. Apply it ('supabase db push --linked') before merging. See CLAUDE.md > Database (Supabase) > Migration ordering."
               missing=1
             fi
           done <<< "${{ steps.diff.outputs.new_files }}"


### PR DESCRIPTION
## Summary

Item #2 from the PR [#85](https://github.com/MichaelChar/StudentX/pull/85) PM follow-up: a CI gate that prevents the deploy-before-migrate ordering bug at PR-merge time. Closes the loop on the 2026-05-02 incident in three layers:

| Layer | What it does | Where |
|---|---|---|
| Detection | 15-min synthetic on `/api/landlord/listings` | PR #86 (merged) |
| Convention | "Apply before merge" rule | CLAUDE.md (PR #86, merged) |
| **Prevention** | **CI gate that fails the PR if the migration isn't on prod** | **This PR** |

## What changed

`.github/workflows/migration-check.yml` gains a second job, `applied-to-prod`, running in parallel with the existing `apply-migrations` job:

1. **Diff for new migration files.** `git diff --diff-filter=A "origin/${BASE}...HEAD" -- 'supabase/migrations/*.sql'`. No new files → no-op.
2. **Fetch the applied list from prod.** Supabase Management API at `https://api.supabase.com/v1/projects/<ref>/database/migrations` returns every applied migration. Tolerates both response shapes (bare array vs. `{migrations: [...]}` envelope).
3. **Verify each new file matches an applied row.** Match by either the full file stem (`037_listing_min_duration`) or the stripped form (`listing_min_duration`) — prod has both styles historically, depending on whether `mcp__supabase__apply_migration` or the Supabase CLI applied them.
4. **Fail the workflow with a `::error file=...` annotation** if any new migration is unapplied. The annotation tells reviewers exactly which migration to apply and points to the CLAUDE.md section explaining why.

Verified locally: bash logic correctly identifies an applied migration via stem match, an applied migration via stripped match, and a fake unapplied migration → exit 1.

## Required setup (one-time, repo admin only)

Both must be configured for the gate to actually enforce:

| Where | Name | Value |
|---|---|---|
| Repo settings → **Secrets** → Actions | `SUPABASE_ACCESS_TOKEN` | A personal access token from <https://supabase.com/dashboard/account/tokens> (read scope is sufficient — only hits the `database/migrations` list endpoint) |
| Repo settings → **Variables** → Actions | `SUPABASE_PROJECT_REF` | The prod project ref (e.g. `ecluqurlfbvkxrnoyhaq`) — visible in the dashboard URL or in `NEXT_PUBLIC_SUPABASE_URL` |

**Until both are set, the gate warn-but-passes** with a workflow-level warning. This avoids the chicken-and-egg of needing the secrets to exist before this PR can merge. After merge, configure them and the next migration-touching PR will exercise the gate.

## Risk surface considered

- **False positive:** PR adds `038_foo.sql`, prod hasn't applied it yet → gate fails (correct, that's the point).
- **False negative:** PR adds `038_foo.sql`, prod applied a different migration with `name = 'foo'` → gate passes incorrectly. This is the price of the relaxed name match needed for historical data. In practice the leading number-stripped name has to match exactly, which is unlikely for distinct migrations. Acceptable tradeoff.
- **Token leak:** the Supabase access token is read-only-scoped against the migrations list endpoint and stored as a GH Actions secret (encrypted at rest, masked in logs). Standard exposure surface for CI tokens.
- **Provider outage:** if `api.supabase.com` is down, the `curl --fail` step errors and the gate fails. Reviewers can re-run the workflow once the API is back. Not silently passing on outage is the safer default.

## Test plan

- [x] YAML syntax — parses cleanly via Ruby YAML.
- [x] Bash diff + grep logic — manually simulated with three migration scenarios (applied/exact, applied/stripped, unapplied) and verified the script correctly identifies each.
- [ ] **(reviewer / post-merge)** Set `SUPABASE_ACCESS_TOKEN` + `SUPABASE_PROJECT_REF`. Open a follow-up PR adding any migration file (even an empty one) — confirm the gate fails. Apply the migration, confirm the gate passes.
- [ ] **(reviewer / post-merge)** When the gate goes live, update the CLAUDE.md "Migration ordering" subsection with a one-line pointer to it. (Flagged in PR #86's review.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)