### PR TITLE
feat(listings): subscription-driven featured halo

### DIFF
--- a/src/app/[locale]/landlord/listings/page.js
+++ b/src/app/[locale]/landlord/listings/page.js
@@ -25,8 +25,6 @@ export default function LandlordListingsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [deleting, setDeleting] = useState(null);
-  const [togglingFeatured, setTogglingFeatured] = useState(null);
-
   useEffect(() => {
     (async () => {
       const supabase = getSupabaseBrowser();
@@ -76,40 +74,6 @@ export default function LandlordListingsPage() {
     }
   }
 
-  async function handleToggleFeatured(listingId, currentlyFeatured) {
-    setTogglingFeatured(listingId);
-    try {
-      if (!accessToken) {
-        setTogglingFeatured(null);
-        router.replace('/landlord/login');
-        return;
-      }
-      const res = await fetch(`/api/landlord/listings/${listingId}`, {
-        method: 'PATCH',
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ is_featured: !currentlyFeatured }),
-      });
-      if (res.ok) {
-        setListings((prev) =>
-          prev.map((l) =>
-            l.listing_id === listingId ? { ...l, is_featured: !currentlyFeatured } : l
-          )
-        );
-      } else {
-        const data = await res.json().catch(() => ({}));
-        alert(data.error || t('featuredError'));
-      }
-    } catch (err) {
-      console.error('[LandlordListings] toggle_featured failed:', err);
-      alert(t('featuredError'));
-    } finally {
-      setTogglingFeatured(null);
-    }
-  }
-
   return (
     <LandlordShell
       eyebrow="Portfolio"
@@ -150,14 +114,7 @@ export default function LandlordListingsPage() {
                 <ListingRow
                   listing={listing}
                   deleting={deleting === listing.listing_id}
-                  toggling={togglingFeatured === listing.listing_id}
                   onDelete={() => handleDelete(listing.listing_id)}
-                  onToggleFeatured={() =>
-                    handleToggleFeatured(
-                      listing.listing_id,
-                      listing.is_featured
-                    )
-                  }
                   t={t}
                 />
               </li>
@@ -169,7 +126,7 @@ export default function LandlordListingsPage() {
   );
 }
 
-function ListingRow({ listing, deleting, toggling, onDelete, onToggleFeatured, t }) {
+function ListingRow({ listing, deleting, onDelete, t }) {
   const photo = listing.photos?.find((url) => typeof url === 'string' && url.startsWith('http'));
   const address = listing.location?.address || t('noAddress');
   const heading = listing.title || address;
@@ -199,7 +156,7 @@ function ListingRow({ listing, deleting, toggling, onDelete, onToggleFeatured, t
           <p className="font-display text-xl text-night truncate">
             {heading}
           </p>
-          {listing.is_featured && <Pill variant="verified">Featured</Pill>}
+          {listing.is_featured && <Pill variant="verified">{t('featured')}</Pill>}
         </div>
         {/* Address always rendered on this internal surface — landlords
             identify their own listings by street most reliably. For
@@ -217,17 +174,6 @@ function ListingRow({ listing, deleting, toggling, onDelete, onToggleFeatured, t
       </div>
 
       <div className="flex flex-wrap items-center gap-2 shrink-0">
-        <button
-          onClick={onToggleFeatured}
-          disabled={toggling}
-          className={`label-caps px-3 py-1.5 rounded-sm border transition-colors disabled:opacity-50 ${
-            listing.is_featured
-              ? 'border-gold text-gold hover:bg-gold hover:text-white'
-              : 'border-night/20 text-night/60 hover:border-gold hover:text-gold'
-          }`}
-        >
-          {toggling ? '…' : listing.is_featured ? t('featured') : t('unfeatured')}
-        </button>
         <Link
           href={`/listing/${listing.listing_id}`}
           target="_blank"

--- a/src/app/[locale]/results/page.js
+++ b/src/app/[locale]/results/page.js
@@ -9,7 +9,6 @@ import { useTranslations } from 'next-intl';
 import ListingCard from '@/components/ListingCard';
 import SaveSearchModal from '@/components/SaveSearchModal';
 import Button from '@/components/ui/Button';
-import Card from '@/components/ui/Card';
 import Pill from '@/components/ui/Pill';
 import Icon from '@/components/ui/Icon';
 import GlobeLoader from '@/components/GlobeLoader';
@@ -207,9 +206,6 @@ function ResultsContent() {
     }));
   }
 
-  const featured = listings.find((l) => l.is_featured);
-  const regular = listings.filter((l) => !l.is_featured);
-
   // Show loader as a full-screen overlay until BOTH animation completes
   // AND the initial listings fetch has finished. Both conditions guard
   // against jank: the loader hides only when there's something legible
@@ -322,10 +318,6 @@ function ResultsContent() {
           {/* List view */}
           {viewMode === 'list' && (
             <>
-              {featured && !loading && (
-                <FeaturedCard featured={featured} t={t} />
-              )}
-
               {loading && (
                 <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-5">
                   {Array.from({ length: 6 }).map((_, i) => (
@@ -345,9 +337,9 @@ function ResultsContent() {
                 </div>
               )}
 
-              {!loading && !error && regular.length > 0 && (
+              {!loading && !error && listings.length > 0 && (
                 <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-5">
-                  {regular.map((listing) => (
+                  {listings.map((listing) => (
                     <ListingCard
                       key={listing.listing_id}
                       listing={listing}
@@ -590,36 +582,6 @@ function FilterPanel({
         + Save this search
       </button>
     </div>
-  );
-}
-
-function FeaturedCard({ featured, t }) {
-  return (
-    <Card
-      tone="night"
-      className="mb-8 relative overflow-hidden bg-night text-stone p-8 md:p-10"
-    >
-      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-5">
-        <div>
-          <p className="label-caps text-gold mb-3">
-            {t('featuredTitle')}
-          </p>
-          <p className="font-display text-2xl md:text-3xl text-stone leading-tight max-w-lg">
-            {t('featuredBody')}
-          </p>
-        </div>
-        <Link
-          href={`/listing/${featured.listing_id}`}
-          className="label-caps text-gold hover:text-white transition-colors shrink-0"
-        >
-          {t('featuredCta')} →
-        </Link>
-      </div>
-      <div
-        aria-hidden="true"
-        className="absolute -bottom-20 -right-16 w-72 h-72 rounded-full bg-gold/15 blur-2xl"
-      />
-    </Card>
   );
 }
 

--- a/src/app/api/landlord/listings/[id]/route.js
+++ b/src/app/api/landlord/listings/[id]/route.js
@@ -185,7 +185,6 @@ export async function PATCH(request, { params }) {
 
   // Update listing row
   const listingUpdate = {};
-  if (body.is_featured !== undefined) listingUpdate.is_featured = !!body.is_featured;
   // Title semantics:
   //   undefined → leave alone (don't include in update)
   //   null OR empty-after-normalization → 400 (cannot clear a required field)

--- a/src/app/api/landlord/listings/route.js
+++ b/src/app/api/landlord/listings/route.js
@@ -261,6 +261,15 @@ export async function POST(request) {
   }
   const listingId = landlordId + String(nextSeq).padStart(3, '0');
 
+  // Auto-feature listings for landlords with an active subscription
+  const { data: activeSub } = await supabase
+    .from('subscriptions')
+    .select('subscription_id')
+    .eq('landlord_id', landlordId)
+    .eq('status', 'active')
+    .limit(1);
+  const isFeatured = activeSub && activeSub.length > 0;
+
   // Insert listing row
   const { data: listing, error: listingError } = await authedSupabase
     .from('listings')
@@ -278,6 +287,7 @@ export async function POST(request) {
       floor: body.floor != null && body.floor !== '' ? parseInt(body.floor, 10) : null,
       available_from: body.available_from || null,
       min_duration_months: parseMinDuration(body.min_duration_months),
+      is_featured: isFeatured,
     })
     .select('listing_id')
     .single();

--- a/src/app/api/webhooks/stripe/route.js
+++ b/src/app/api/webhooks/stripe/route.js
@@ -80,6 +80,8 @@ async function handleSubscriptionCreated(supabase, session) {
     .eq('landlord_id', landlordId)
     .in('status', ['active', 'past_due', 'trialing']);
 
+  const { start, end } = getPeriodBounds(subscription);
+
   await supabase.from('subscriptions').insert({
     landlord_id: landlordId,
     plan_id: planId,
@@ -87,8 +89,8 @@ async function handleSubscriptionCreated(supabase, session) {
     stripe_subscription_id: subscription.id,
     status: subscription.status === 'active' ? 'active' : 'incomplete',
     billing_interval: subscription.items.data[0]?.plan?.interval === 'year' ? 'annual' : 'monthly',
-    current_period_start: new Date(subscription.current_period_start * 1000).toISOString(),
-    current_period_end: new Date(subscription.current_period_end * 1000).toISOString(),
+    current_period_start: start ? new Date(start * 1000).toISOString() : null,
+    current_period_end: end ? new Date(end * 1000).toISOString() : null,
     cancel_at_period_end: subscription.cancel_at_period_end,
   });
 
@@ -102,8 +104,23 @@ async function handleSubscriptionCreated(supabase, session) {
       .update({ verified_tier: verifiedTier, onboarding_completed: true })
       .eq('landlord_id', landlordId);
 
+    await supabase
+      .from('listings')
+      .update({ is_featured: true })
+      .eq('landlord_id', landlordId);
+
     await sendSubscriptionWelcomeEmail({ supabase, landlordId, tier: verifiedTier });
   }
+}
+
+// Stripe API ≥ 2024-06 moves period bounds onto the items, not the subscription
+// itself. Fall back to items[0] so older + newer payloads both work.
+function getPeriodBounds(subscription) {
+  const item = subscription.items?.data?.[0];
+  return {
+    start: subscription.current_period_start ?? item?.current_period_start,
+    end: subscription.current_period_end ?? item?.current_period_end,
+  };
 }
 
 async function handleSubscriptionUpdated(supabase, subscription) {
@@ -117,31 +134,44 @@ async function handleSubscriptionUpdated(supabase, subscription) {
     unpaid: 'past_due',
   };
 
+  const { start, end } = getPeriodBounds(subscription);
+
   await supabase
     .from('subscriptions')
     .update({
       status: statusMap[subscription.status] || subscription.status,
-      current_period_start: new Date(subscription.current_period_start * 1000).toISOString(),
-      current_period_end: new Date(subscription.current_period_end * 1000).toISOString(),
+      current_period_start: start ? new Date(start * 1000).toISOString() : null,
+      current_period_end: end ? new Date(end * 1000).toISOString() : null,
       cancel_at_period_end: subscription.cancel_at_period_end,
       updated_at: new Date().toISOString(),
     })
     .eq('stripe_subscription_id', subscription.id);
 
-  // If subscription canceled, reset verified tier
-  if (subscription.status === 'canceled' || subscription.status === 'incomplete_expired') {
-    const { data: sub } = await supabase
-      .from('subscriptions')
-      .select('landlord_id')
-      .eq('stripe_subscription_id', subscription.id)
-      .single();
+  // Sync landlord state to subscription status. `is_featured` (the gold-halo
+  // signal on listings) tracks whether the landlord is currently paying:
+  // active or trialing → featured; anything else → not featured. Idempotent,
+  // so it's safe to apply on every update.
+  const { data: sub } = await supabase
+    .from('subscriptions')
+    .select('landlord_id')
+    .eq('stripe_subscription_id', subscription.id)
+    .single();
 
-    if (sub?.landlord_id) {
-      await supabase
-        .from('landlords')
-        .update({ verified_tier: 'none' })
-        .eq('landlord_id', sub.landlord_id);
-    }
+  if (!sub?.landlord_id) return;
+
+  const shouldFeature =
+    subscription.status === 'active' || subscription.status === 'trialing';
+
+  await supabase
+    .from('listings')
+    .update({ is_featured: shouldFeature })
+    .eq('landlord_id', sub.landlord_id);
+
+  if (subscription.status === 'canceled' || subscription.status === 'incomplete_expired') {
+    await supabase
+      .from('landlords')
+      .update({ verified_tier: 'none' })
+      .eq('landlord_id', sub.landlord_id);
   }
 }
 
@@ -161,11 +191,16 @@ async function handleSubscriptionDeleted(supabase, subscription) {
     })
     .eq('stripe_subscription_id', subscription.id);
 
-  // Reset verified tier
+  // Reset verified tier and featured status
   if (sub?.landlord_id) {
     await supabase
       .from('landlords')
       .update({ verified_tier: 'none' })
+      .eq('landlord_id', sub.landlord_id);
+
+    await supabase
+      .from('listings')
+      .update({ is_featured: false })
       .eq('landlord_id', sub.landlord_id);
   }
 }

--- a/src/components/ListingCard.js
+++ b/src/components/ListingCard.js
@@ -34,7 +34,11 @@ export default function ListingCard({ listing, fromQuery = '' }) {
   return (
     <Link
       href={href}
-      className="group block bg-white border border-night/10 rounded-sm overflow-hidden hover:border-blue/40 hover:shadow-[0_2px_18px_-8px_rgba(10,20,54,0.25)] transition-all focus-visible:outline-2 focus-visible:outline-gold focus-visible:outline-offset-2"
+      className={`group block bg-white rounded-sm overflow-hidden transition-all focus-visible:outline-2 focus-visible:outline-gold focus-visible:outline-offset-2 ${
+        listing.is_featured
+          ? 'border-2 border-gold/60 shadow-[0_0_12px_-2px_rgba(191,155,48,0.4)] hover:shadow-[0_0_18px_-2px_rgba(191,155,48,0.55)]'
+          : 'border border-night/10 hover:border-blue/40 hover:shadow-[0_2px_18px_-8px_rgba(10,20,54,0.25)]'
+      }`}
     >
       {/* Photo */}
       <div className="relative aspect-[4/3] bg-parchment">
@@ -45,7 +49,7 @@ export default function ListingCard({ listing, fromQuery = '' }) {
         )}
         {listing.is_featured && (
           <span className="absolute top-3 right-3 z-10">
-            <Pill variant="programme">AUTh programme</Pill>
+            <Pill variant="verified">{tCard('featured')}</Pill>
           </span>
         )}
         {photo ? (

--- a/supabase/migrations/039_backfill_is_featured_from_subscriptions.sql
+++ b/supabase/migrations/039_backfill_is_featured_from_subscriptions.sql
@@ -1,0 +1,25 @@
+-- 039_backfill_is_featured_from_subscriptions.sql
+--
+-- After PR-XX, listings.is_featured is no longer a manual landlord toggle —
+-- it tracks whether the listing's landlord has an active (or trialing) Stripe
+-- subscription. The webhook keeps it in sync going forward; this migration
+-- reconciles the existing rows so historic state matches the new model.
+--
+-- Featured iff the landlord has at least one subscription in status
+-- 'active' or 'trialing'. Everything else is set to false.
+
+UPDATE listings
+SET is_featured = TRUE
+WHERE landlord_id IN (
+  SELECT landlord_id
+  FROM subscriptions
+  WHERE status IN ('active', 'trialing')
+);
+
+UPDATE listings
+SET is_featured = FALSE
+WHERE landlord_id NOT IN (
+  SELECT landlord_id
+  FROM subscriptions
+  WHERE status IN ('active', 'trialing')
+);


### PR DESCRIPTION
## Summary

- Featured listings now render in the regular results grid (sorted first) with a gold halo + i18n'd "Προβεβλημένο/Featured" pill — replaces the generic FeaturedCard banner that hid listing details.
- `is_featured` becomes subscription-driven: Stripe webhook flips it on for active/trialing subs, off for canceled/past-due/etc. Manual landlord toggle removed.
- Migration 039 backfills `is_featured` so existing rows match the new invariant. Already applied to prod.

## Why

A landlord (Plateia Laodigitrias 5) couldn't find their paid listing on `/results`. Root cause: it was rendered as a generic FeaturedCard banner with no photos/address/price instead of as a recognizable card.

## Notes

- Also fixed a latent webhook bug: `current_period_start` falls back to `subscription.items[0].current_period_start` (where Stripe API ≥ 2024-06 puts period bounds).
- `handleSubscriptionUpdated` now reacts to all status transitions (active ↔ past_due ↔ trialing ↔ canceled), not just cancellation.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test` — 80/80 pass
- [x] Visual on `/en/results`: Laodigitrias listing appears first with gold halo + Featured pill, photo/address/€600 price visible
- [x] Migration 039 applied to prod (no-op against current data — already consistent)
- [ ] After merge: confirm Cloudflare deploy succeeds and `/results` still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)