### PR TITLE
chore(listings): rename featured pill to "Verified", drop top-left seal

### DIFF
--- a/src/components/ListingCard.js
+++ b/src/components/ListingCard.js
@@ -2,7 +2,6 @@ import Image from 'next/image';
 import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/navigation';
 import Pill from '@/components/ui/Pill';
-import VerifiedSeal from '@/components/ui/VerifiedSeal';
 import Icon from '@/components/ui/Icon';
 
 /*
@@ -42,14 +41,9 @@ export default function ListingCard({ listing, fromQuery = '' }) {
     >
       {/* Photo */}
       <div className="relative aspect-[4/3] bg-parchment">
-        {isVerified && (
-          <div className="absolute top-3 left-3 z-10">
-            <VerifiedSeal size={38} />
-          </div>
-        )}
         {listing.is_featured && (
           <span className="absolute top-3 right-3 z-10">
-            <Pill variant="verified">{tCard('featured')}</Pill>
+            <Pill variant="verified">{tCard('verified')}</Pill>
           </span>
         )}
         {photo ? (


### PR DESCRIPTION
## Summary

- Top-right pill on featured ListingCard renamed from `tCard('featured')` → `tCard('verified')` (Επαληθευμένος / Verified)
- Removed the top-left `VerifiedSeal` checkmark from ListingCard so we don't double-up gold marks on featured cards
- AUTh programme pill (bottom of card) unchanged

## Why

Per design feedback on #92's deployed result: the gold halo + a separate seal + a "Featured" pill was three signals saying mostly the same thing. Consolidating to one "Verified" pill on the photo, halo as the secondary cue.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test` — 80/80 pass
- [x] Visual: Laodigitrias listing renders with gold halo + "ΕΠΑΛΗΘΕΥΜΕΝΟΣ" pill top-right, no top-left tick
- [ ] After merge: confirm prod deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)