### PR TITLE
chore(domain): flip URL bindings to studentx.uk + runbook fix

### DIFF
--- a/docs/runbooks/domain-setup.md
+++ b/docs/runbooks/domain-setup.md
@@ -133,10 +133,12 @@ Add to [`wrangler.jsonc`](../../wrangler.jsonc) (sibling of `triggers`):
 
 ```json
 "routes": [
-  { "pattern": "studentx.uk/*", "custom_domain": true },
-  { "pattern": "www.studentx.uk/*", "custom_domain": true }
+  { "pattern": "studentx.uk", "custom_domain": true },
+  { "pattern": "www.studentx.uk", "custom_domain": true }
 ]
 ```
+
+> Note: `custom_domain: true` routes take bare hostnames — wildcards (`/*`) and paths are rejected by `wrangler deploy` with "Wildcard operators (*) are not allowed in Custom Domains".
 
 Then:
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -25,12 +25,11 @@
     "NEXT_PUBLIC_SUPABASE_URL": "https://ecluqurlfbvkxrnoyhaq.supabase.co",
     "NEXT_PUBLIC_SUPABASE_ANON_KEY": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVjbHVxdXJsZmJ2a3hybm95aGFxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzQ3ODQ0MzUsImV4cCI6MjA5MDM2MDQzNX0.XspsrkDjv_AWltPgFqBQSocLXU4tBmq1auu_Zg8qTBE",
     // Canonical/sitemap/og:url + landlord email links all resolve from these.
-    // Code defaults to https://studentx.uk; the live deploy is the
-    // workers.dev host until the custom domain is wired up. Once
-    // `curl -I https://studentx.uk` returns 200, flip these to the
-    // custom domain (or just remove them, since the code falls back to it).
-    "NEXT_PUBLIC_SITE_URL": "https://studentx.studentx-gr.workers.dev",
-    "NEXT_PUBLIC_APP_URL": "https://studentx.studentx-gr.workers.dev",
+    // NEXT_PUBLIC_* are inlined at build time, so any local .env.local with a
+    // dev URL (http://localhost:3000) leaks into the build unless overridden
+    // explicitly at build (or the Worker is built from CI with no .env.local).
+    "NEXT_PUBLIC_SITE_URL": "https://studentx.uk",
+    "NEXT_PUBLIC_APP_URL": "https://studentx.uk",
     // Synthetic uptime check — guards against the i18n regression class fixed
     // in PR #48 (Greek copy leaking onto /en/listing/<id>). The */15 cron POSTs
     // to /api/cron/synthetic-en-listing, which fetches /en/listing/<id> and


### PR DESCRIPTION
## Summary

Follow-up to #94. Two small fixes after the live deploy:

1. **`wrangler.jsonc` URL flip** — `NEXT_PUBLIC_SITE_URL` and `NEXT_PUBLIC_APP_URL` now point at `https://studentx.uk` (was the workers.dev URL). The Worker is already serving on `studentx.uk` (cert provisioned, sitemap and canonical URLs verified `.uk`); this binding makes the future CI builds bake in the right URLs since `NEXT_PUBLIC_*` are inlined at build time.

2. **Runbook fix** — the example `routes` block in `docs/runbooks/domain-setup.md` had `"pattern": "studentx.uk/*"` which `wrangler deploy` rejects for `custom_domain: true` (custom domains take bare hostnames only — no wildcards, no paths). The earlier merge of #94 hit this exact error in CF Workers Build; commit `30a255b` already fixed `wrangler.jsonc` so deploys work, this PR fixes the runbook so the next person reading it doesn't repeat the mistake.

## Context

After #94 merged, CF Workers Build failed with `Wildcard operators (*) are not allowed in Custom Domains`. I deployed manually via `wrangler deploy` (after stripping `/*`) and pushed the wrangler fix as `30a255b` so future auto-deploys work. Mid-debug I discovered the deployed Worker was serving `localhost:3000` URLs in the sitemap — this PR's `wrangler.jsonc` change explains why and prevents recurrence (local `.env.local` was getting inlined at build time).

## Test plan

- [x] `https://studentx.uk` → 200 OK from Worker
- [x] Sitemap at `https://studentx.uk/sitemap.xml` lists `https://studentx.uk/...` URLs (verified after manual rebuild with explicit env override)
- [ ] After this merges + CF Workers Build runs from scratch (no `.env.local`): same sitemap output

🤖 Generated with [Claude Code](https://claude.com/claude-code)