### PR TITLE
chore(post-migration): fix zero-segment redirects, canonicals, stale docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,12 +219,9 @@ Failures still surface in `wrangler tail`.
 
 ## Email (Resend)
 
-**Currently logs-only in production.** Resend sends will work once
-`studentx.uk` is verified in Resend and `RESEND_API_KEY` is set as a
-Worker secret. The full DNS + Resend verification flow lives in
-`docs/runbooks/domain-setup.md`. Until then, all outbound email paths
-silently fail at the Resend send step (each wrapped in try/catch, so the
-surrounding flow keeps working):
+**Live in production.** `studentx.uk` is verified in Resend (DKIM/SPF/DMARC
+records on the CF zone) and `RESEND_API_KEY` is set as a Worker secret.
+Outbound paths sending from `alerts@studentx.uk`:
 
 - Synthetic check alerts (`/api/cron/synthetic-en-listing`)
 - Saved-searches digest (`/api/cron/saved-searches-digest`)
@@ -232,9 +229,7 @@ surrounding flow keeps working):
 - Inquiry notifications (`src/lib/inquiryEmail.js`)
 - Subscription welcome (`src/lib/subscriptionEmail.js`)
 
-**Workaround for testing:** `onboarding@resend.dev` is Resend's free testing
-sender, but it only delivers to the Resend account-owner email — it doesn't
-unblock user-facing notifications.
+The DNS + verification flow is documented in `docs/runbooks/domain-setup.md`.
 
 ## Tests
 

--- a/docs/runbooks/domain-setup.md
+++ b/docs/runbooks/domain-setup.md
@@ -1,6 +1,13 @@
 # Runbook — Register `studentx.uk` and verify Resend
 
-**Blocks:** Resend transactional email · Cloudflare zone-scoped features · production URL flip · [PR #51](https://github.com/MichaelChar/StudentX/pull/51) (closed pending domain) · [PR #63](https://github.com/MichaelChar/StudentX/pull/63) (pre-staged re-apply, draft)
+> **Status: completed (2026-05-03).** Domain registered, CF zone active,
+> Resend verified, `RESEND_API_KEY` set as a Worker secret, custom domain
+> serving HTTPS, `NEXT_PUBLIC_*` URL bindings flipped. Kept as historical
+> reference / playbook for future domain swaps. PRs: [#94](https://github.com/MichaelChar/StudentX/pull/94),
+> [#95](https://github.com/MichaelChar/StudentX/pull/95). PR #63 (pre-staged
+> email-subdomain branch) was superseded and closed.
+
+**Originally blocked:** Resend transactional email · Cloudflare zone-scoped features · production URL flip · [PR #51](https://github.com/MichaelChar/StudentX/pull/51) (closed pending domain) · [PR #63](https://github.com/MichaelChar/StudentX/pull/63) (pre-staged re-apply, closed)
 
 ## Why this exists
 

--- a/docs/runbooks/synthetic-en-listing.md
+++ b/docs/runbooks/synthetic-en-listing.md
@@ -28,7 +28,7 @@ Every 15 min, the Worker's `scheduled` handler POSTs to `/api/cron/synthetic-en-
 
 Any failed assertion (or non-200, or fetch timeout) attempts to send an email via Resend to `SYNTHETIC_ALERT_EMAIL`.
 
-> **Status as of merge:** the email alert path is configured in code but **logs-only in production** because Resend isn't set up yet (`studentx.uk` isn't a registered domain — see [the domain context note](#domain-context) below). Failures surface in `wrangler tail` logs only. To enable email alerts later: register the domain, verify it in Resend, set `RESEND_API_KEY` as a Worker secret. The route's email send is wrapped in try/catch so a missing `RESEND_API_KEY` doesn't break the check itself.
+> **Status (2026-05-03):** Resend is verified for `studentx.uk` and `RESEND_API_KEY` is set as a Worker secret — the alert path is live. On failure the route emails `SYNTHETIC_ALERT_EMAIL` from `alerts@studentx.uk`. Failures still surface in `wrangler tail` regardless. The route's email send is wrapped in try/catch, so a Resend hiccup doesn't break the check itself.
 
 ## Configuration
 
@@ -81,22 +81,9 @@ Production (manual run, doesn't wait for the next 15-min tick):
 
 ## Domain context
 
-The codebase fallback addresses (`alerts@studentx.uk`) and the `NEXT_PUBLIC_SITE_URL` default (`https://studentx.uk`) reference a domain that is not yet registered. The live deploy runs on `studentx.studentx-gr.workers.dev` (a `*.workers.dev` subdomain) until DNS is sorted. This is why the email alert path is currently logs-only:
-
-1. Resend rejects sends from unverified domains.
-2. `studentx.uk` can't be verified because it doesn't exist.
-3. Until the domain is registered + verified, all email-sending paths in the codebase (this synthetic, saved-searches digest, landlord message digest, inquiry email) silently fail at the Resend send step.
-
-To enable email here:
-
-1. Register `studentx.uk` (or pick a different domain and update `NEXT_PUBLIC_SITE_URL` + the from-addresses in code).
-2. Add the domain to Cloudflare (or whatever DNS host you'll use).
-3. In Resend, add a sending subdomain (e.g. `updates.studentx.uk`) and follow the DNS verification flow.
-4. `npx wrangler secret put RESEND_API_KEY --name studentx`
-5. Update `RESEND_FROM_EMAIL` in `wrangler.jsonc` (or each route's hardcoded from-address) to match the verified subdomain.
+`studentx.uk` is the live custom domain (since 2026-05-03). DKIM/SPF/DMARC records are on the CF zone, the apex is verified in Resend, and `RESEND_API_KEY` is a Worker secret. Email alerts from this synthetic check send from `alerts@studentx.uk`. The original setup history lives in [`docs/runbooks/domain-setup.md`](./domain-setup.md).
 
 ## Known limitations
 
 - **Same-network probe.** The cron runs inside the same Cloudflare Worker that serves the page. Doesn't simulate a US user's edge cache. Acceptable because the listing page currently sets `Cache-Control: private, no-cache, no-store, must-revalidate` — there is no edge cache to test from a different POP.
-- **No alert dedupe.** A sustained outage would email every 15 min once email is wired up. If this becomes annoying, add a `synthetic_alert_state(check_name, last_alert_at)` Supabase row and gate the email on `now() - last_alert_at > 1 hour`.
-- **Logs-only until email is configured.** See [Domain context](#domain-context) above.
+- **No alert dedupe.** A sustained outage emails every 15 min. If this becomes annoying, add a `synthetic_alert_state(check_name, last_alert_at)` Supabase row and gate the email on `now() - last_alert_at > 1 hour`.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -151,9 +151,17 @@ const nextConfig = {
       ]),
       { source: '/listing/:id', destination: '/property/listing/:id', permanent: true },
       { source: '/en/listing/:id', destination: '/en/property/listing/:id', permanent: true },
+      // `:path*` matches one or more segments — the zero-segment case
+      // (bookmarked /landlord with no trailing path) needs an explicit
+      // sibling rule, otherwise the destination keeps the literal `:path*`
+      // placeholder and the user lands on a broken URL.
+      { source: '/landlord', destination: '/property/landlord', permanent: true },
       { source: '/landlord/:path*', destination: '/property/landlord/:path*', permanent: true },
+      { source: '/en/landlord', destination: '/en/property/landlord', permanent: true },
       { source: '/en/landlord/:path*', destination: '/en/property/landlord/:path*', permanent: true },
+      { source: '/alerts', destination: '/property/alerts', permanent: true },
       { source: '/alerts/:path*', destination: '/property/alerts/:path*', permanent: true },
+      { source: '/en/alerts', destination: '/en/property/alerts', permanent: true },
       { source: '/en/alerts/:path*', destination: '/en/property/alerts/:path*', permanent: true },
       { source: '/en', destination: '/en/property', permanent: true },
     ];

--- a/src/app/[locale]/property/about/page.js
+++ b/src/app/[locale]/property/about/page.js
@@ -3,12 +3,20 @@ import { getTranslations, setRequestLocale } from 'next-intl/server';
 import OrnamentRule from '@/components/ui/OrnamentRule';
 import Button from '@/components/ui/Button';
 
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://studentx.uk';
+
 export async function generateMetadata({ params }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'about' });
+  const elUrl = `${SITE_URL}/property/about`;
+  const enUrl = `${SITE_URL}/en/property/about`;
   return {
     title: t('metaTitle'),
     description: t('metaDescription'),
+    alternates: {
+      canonical: locale === 'el' ? elUrl : enUrl,
+      languages: { el: elUrl, en: enUrl, 'x-default': elUrl },
+    },
   };
 }
 

--- a/src/app/[locale]/property/layout.js
+++ b/src/app/[locale]/property/layout.js
@@ -1,0 +1,30 @@
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://studentx.uk';
+
+// Default canonical for /property routes. The root [locale]/layout.js sets a
+// site-root canonical (https://studentx.uk), which points at a redirect after
+// the directory moved under /property — risks Google de-indexing /property in
+// favor of a redirect-only URL. Override here so the directory homepage and
+// any sub-page that doesn't supply its own canonical (e.g. /property/about)
+// inherits a canonical that actually resolves.
+//
+// Sub-routes with their own layout.js metadata (quiz, results, listing/[id])
+// already override this with route-specific URLs.
+export async function generateMetadata({ params }) {
+  const { locale } = await params;
+  const elUrl = `${SITE_URL}/property`;
+  const enUrl = `${SITE_URL}/en/property`;
+  return {
+    alternates: {
+      canonical: locale === 'el' ? elUrl : enUrl,
+      languages: {
+        el: elUrl,
+        en: enUrl,
+        'x-default': elUrl,
+      },
+    },
+  };
+}
+
+export default function PropertyLayout({ children }) {
+  return children;
+}

--- a/src/components/landlord/LandlordShell.js
+++ b/src/components/landlord/LandlordShell.js
@@ -16,7 +16,7 @@ import BauhausLoader from '@/components/BauhausLoader';
   verification, billing). Auth pages (login/signup/etc.) skip this shell.
 
   Auth gate is the shell's responsibility: if no Supabase session, redirect
-  to /landlord/login. This centralizes the check so pages don't re-implement.
+  to /property/landlord/login. This centralizes the check so pages don't re-implement.
 */
 
 const NAV_ITEMS = [


### PR DESCRIPTION
## Summary

PM review of [#94](https://github.com/MichaelChar/StudentX/pull/94) (domain migration) and [#96](https://github.com/MichaelChar/StudentX/pull/96) (route migration) surfaced two real bugs and some doc staleness. This PR fixes them.

## Bugs

**1. Zero-segment legacy redirects** ([next.config.mjs](next.config.mjs))

`/landlord/:path*` → `/property/landlord/:path*` only matches with at least one path segment. A bookmarked bare `/landlord` was 308-ing to a literal `/property/landlord/:path*` URL — broken. Same for `/en/landlord` and `/alerts`.

Confirmed live before fix:
```
/landlord     →  /property/landlord/:path*  (literal)
```

After fix:
```
/landlord     →  /property/landlord  (clean)
/landlord/dashboard  →  /property/landlord/dashboard  (still works)
```

**2. Canonical pointed to redirect root**

`/property` and `/property/about` both emitted `<link rel="canonical" href="https://studentx.uk">` — but `/` is itself a 308 to `/property` since the route migration. SEO smell — risks Google de-indexing `/property` in favor of a redirect-only URL.

Fix:
- New [src/app/[locale]/property/layout.js](src/app/%5Blocale%5D/property/layout.js) sets the directory-home canonical (and language alternates) for /property and any sub-page that doesn't override
- Added alternates block to [src/app/[locale]/property/about/page.js](src/app/%5Blocale%5D/property/about/page.js)'s existing `generateMetadata`
- Sub-routes with their own canonicals (quiz, results, listing/[id]) keep overriding correctly

After fix (verified):
```
/property         canonical = http://localhost:3000/property
/property/about   canonical = http://localhost:3000/property/about
/en/property      canonical = http://localhost:3000/en/property
/property/quiz    canonical = http://localhost:3000/property/quiz   (still per-route)
```

## Stale docs

- [CLAUDE.md](CLAUDE.md) Email section: was "logs-only in production", flipped to "Live in production" with the verified-domain context
- [docs/runbooks/domain-setup.md](docs/runbooks/domain-setup.md): added "Status: completed (2026-05-03)" header so future readers don't treat it as a forward-looking checklist
- [docs/runbooks/synthetic-en-listing.md](docs/runbooks/synthetic-en-listing.md): "Status as of merge" note flipped from logs-only to live; "Domain context" section condensed since the situation is no longer ongoing
- [src/components/landlord/LandlordShell.js](src/components/landlord/LandlordShell.js) comment referenced `/landlord/login`; updated to `/property/landlord/login` (code was already correct)

## Test plan

- [x] `npm run lint` — clean (1 pre-existing warning)
- [x] `npm run test` — 80/80 passed
- [x] `npm run build` — successful
- [x] Dev server: `/landlord` → 308 → `/property/landlord` (clean URL)
- [x] Dev server: `/landlord/dashboard` → 308 → `/property/landlord/dashboard` (wildcard still works)
- [x] Dev server: `/property` canonical = `/property`; `/property/about` canonical = `/property/about`
- [x] Dev server: `/property/quiz`, `/property/results` keep per-route canonicals
- [ ] After deploy: `curl -sI https://studentx.uk/landlord` returns clean 308 to `/property/landlord`

🤖 Generated with [Claude Code](https://claude.com/claude-code)