### PR TITLE
feat(email): Resend webhook → suppression list with send-side guard

### DIFF
--- a/__tests__/api/resendWebhook.test.js
+++ b/__tests__/api/resendWebhook.test.js
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock the supabase service client so we can spy on upsert calls without
+// hitting a real DB. The webhook route imports `createClient` directly from
+// `@supabase/supabase-js`, so we mock that.
+const mockUpsert = vi.fn();
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({ upsert: mockUpsert }),
+  }),
+}));
+
+// Realistic-looking Svix webhook secret. The format Resend hands you is
+// `whsec_<base64>` — the bytes after the prefix are the HMAC key.
+const WEBHOOK_KEY_BYTES = new Uint8Array(32).fill(0x42);
+const WEBHOOK_SECRET = `whsec_${btoa(String.fromCharCode(...WEBHOOK_KEY_BYTES))}`;
+
+async function signSvix({ id, timestamp, body }) {
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    WEBHOOK_KEY_BYTES,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sig = await crypto.subtle.sign(
+    'HMAC',
+    cryptoKey,
+    new TextEncoder().encode(`${id}.${timestamp}.${body}`),
+  );
+  return btoa(String.fromCharCode(...new Uint8Array(sig)));
+}
+
+function makeRequest({ body, signedTimestamp, signature, idOverride }) {
+  const id = idOverride || 'msg_test_123';
+  const headers = new Headers({
+    'svix-id': id,
+    'svix-timestamp': String(signedTimestamp),
+    'svix-signature': `v1,${signature}`,
+    'content-type': 'application/json',
+  });
+  return new Request('http://localhost/api/webhooks/resend', {
+    method: 'POST',
+    headers,
+    body,
+  });
+}
+
+async function loadHandler() {
+  // Re-import the route per test so module-scope env reads pick up changes.
+  vi.resetModules();
+  const mod = await import('@/app/api/webhooks/resend/route');
+  return mod.POST;
+}
+
+describe('POST /api/webhooks/resend', () => {
+  beforeEach(() => {
+    process.env.RESEND_WEBHOOK_SECRET = WEBHOOK_SECRET;
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+    mockUpsert.mockReset();
+    mockUpsert.mockResolvedValue({ error: null });
+  });
+
+  afterEach(() => {
+    delete process.env.RESEND_WEBHOOK_SECRET;
+  });
+
+  it('rejects with 503 when RESEND_WEBHOOK_SECRET is unset', async () => {
+    delete process.env.RESEND_WEBHOOK_SECRET;
+    const POST = await loadHandler();
+    const res = await POST(
+      new Request('http://localhost/api/webhooks/resend', {
+        method: 'POST',
+        body: '{}',
+      }),
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it('rejects with 401 when signature is missing', async () => {
+    const POST = await loadHandler();
+    const res = await POST(
+      new Request('http://localhost/api/webhooks/resend', {
+        method: 'POST',
+        body: '{"type":"email.bounced"}',
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects with 401 when signature does not match', async () => {
+    const ts = Math.floor(Date.now() / 1000);
+    const body = JSON.stringify({ type: 'email.bounced', data: { to: ['x@y.com'] } });
+    const req = makeRequest({ body, signedTimestamp: ts, signature: 'AAAA' });
+    const POST = await loadHandler();
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects with 401 when timestamp is outside the replay window', async () => {
+    const ts = Math.floor(Date.now() / 1000) - 60 * 60; // 1h old
+    const body = JSON.stringify({ type: 'email.bounced', data: { to: ['x@y.com'] } });
+    const sig = await signSvix({ id: 'msg_test_123', timestamp: ts, body });
+    const req = makeRequest({ body, signedTimestamp: ts, signature: sig });
+    const POST = await loadHandler();
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('suppresses recipients on email.bounced', async () => {
+    const ts = Math.floor(Date.now() / 1000);
+    const body = JSON.stringify({
+      type: 'email.bounced',
+      data: {
+        email_id: 'evt_abc',
+        to: ['Bouncer@example.com', 'b@example.com'],
+        bounce: { type: 'Permanent' },
+      },
+    });
+    const sig = await signSvix({ id: 'msg_test_123', timestamp: ts, body });
+    const req = makeRequest({ body, signedTimestamp: ts, signature: sig });
+
+    const POST = await loadHandler();
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    const [rows, opts] = mockUpsert.mock.calls[0];
+    expect(rows).toEqual([
+      {
+        email: 'bouncer@example.com', // normalized lowercase
+        reason: 'bounced',
+        bounce_type: 'Permanent',
+        source_event_id: 'evt_abc',
+      },
+      {
+        email: 'b@example.com',
+        reason: 'bounced',
+        bounce_type: 'Permanent',
+        source_event_id: 'evt_abc',
+      },
+    ]);
+    expect(opts).toEqual({ onConflict: 'email', ignoreDuplicates: true });
+  });
+
+  it('suppresses recipients on email.complained with reason="complained"', async () => {
+    const ts = Math.floor(Date.now() / 1000);
+    const body = JSON.stringify({
+      type: 'email.complained',
+      data: { email_id: 'evt_xyz', to: ['c@example.com'] },
+    });
+    const sig = await signSvix({ id: 'msg_test_123', timestamp: ts, body });
+    const req = makeRequest({ body, signedTimestamp: ts, signature: sig });
+
+    const POST = await loadHandler();
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    const [rows] = mockUpsert.mock.calls[0];
+    expect(rows[0]).toEqual({
+      email: 'c@example.com',
+      reason: 'complained',
+      bounce_type: null,
+      source_event_id: 'evt_xyz',
+    });
+  });
+
+  it('ignores non-bounce/complaint events without writing', async () => {
+    const ts = Math.floor(Date.now() / 1000);
+    const body = JSON.stringify({
+      type: 'email.delivered',
+      data: { to: ['delivered@example.com'] },
+    });
+    const sig = await signSvix({ id: 'msg_test_123', timestamp: ts, body });
+    const req = makeRequest({ body, signedTimestamp: ts, signature: sig });
+
+    const POST = await loadHandler();
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ignored).toBe('email.delivered');
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/cron/landlord-message-digest/route.js
+++ b/src/app/api/cron/landlord-message-digest/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import { getResend } from '@/lib/resend';
+import { isEmailSuppressed } from '@/lib/emailSuppressions';
 import {
   landlordMessageDigestHtml,
   landlordMessageDigestSubject,
@@ -103,6 +104,13 @@ export async function POST(request) {
       // this digest is lost for this period. Same tradeoff as the
       // saved-searches digest — missing one email beats double-sending.
       const locale = resolveLocale(row.landlord_locale);
+
+      if (await isEmailSuppressed(row.landlord_email)) {
+        console.warn(
+          `[landlord-digest] skipping send — ${row.landlord_email} is suppressed`,
+        );
+        continue;
+      }
 
       await resend.emails.send({
         from: FROM_ADDRESS,

--- a/src/app/api/cron/saved-searches-digest/route.js
+++ b/src/app/api/cron/saved-searches-digest/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getSupabase } from '@/lib/supabase';
 import { getResend } from '@/lib/resend';
+import { isEmailSuppressed } from '@/lib/emailSuppressions';
 import { digestEmailHtml, digestEmailSubject } from '@/templates/email/digest';
 import { transformListing } from '@/lib/transformListing';
 
@@ -136,6 +137,11 @@ export async function POST(request) {
       // is lost for this period (no resend on retry). For digests this is
       // the right tradeoff: missing one digest beats double-sending.
       const manageUrl = `${appUrl}/property/alerts/manage?token=${search.unsubscribe_token}`;
+
+      if (await isEmailSuppressed(search.email)) {
+        console.warn(`[saved-search-digest] skipping send — ${search.email} is suppressed`);
+        continue;
+      }
 
       await resend.emails.send({
         from: 'StudentX Alerts <alerts@studentx.uk>',

--- a/src/app/api/saved-searches/route.js
+++ b/src/app/api/saved-searches/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getSupabase } from '@/lib/supabase';
 import { getResend } from '@/lib/resend';
+import { isEmailSuppressed } from '@/lib/emailSuppressions';
 import {
   confirmationEmailHtml,
   confirmationEmailSubject,
@@ -49,17 +50,22 @@ export async function POST(request) {
     const manageUrl = `${appUrl}/property/alerts/manage?token=${data.unsubscribe_token}`;
 
     try {
-      const resend = getResend();
-      await resend.emails.send({
-        from: 'StudentX Alerts <alerts@studentx.uk>',
-        to: email.trim().toLowerCase(),
-        subject: confirmationEmailSubject(label?.trim()),
-        html: confirmationEmailHtml({
-          label: label?.trim(),
-          manageUrl,
-          frequency: freq,
-        }),
-      });
+      const recipient = email.trim().toLowerCase();
+      if (await isEmailSuppressed(recipient)) {
+        console.warn(`[saved-search-confirmation] skipping — ${recipient} is suppressed`);
+      } else {
+        const resend = getResend();
+        await resend.emails.send({
+          from: 'StudentX Alerts <alerts@studentx.uk>',
+          to: recipient,
+          subject: confirmationEmailSubject(label?.trim()),
+          html: confirmationEmailHtml({
+            label: label?.trim(),
+            manageUrl,
+            frequency: freq,
+          }),
+        });
+      }
     } catch (emailErr) {
       console.error('Confirmation email error (non-fatal):', emailErr);
     }

--- a/src/app/api/webhooks/resend/route.js
+++ b/src/app/api/webhooks/resend/route.js
@@ -1,0 +1,149 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+// Resend (via Svix) signs every webhook. We verify the signature before
+// trusting the payload, otherwise anyone who learns this URL could insert
+// arbitrary suppressions and DoS our email delivery.
+//
+// Headers Svix sends:
+//   svix-id         — unique message id (msg_xxx)
+//   svix-timestamp  — unix seconds, used in the signed payload + replay window
+//   svix-signature  — space-separated list like "v1,sig1 v1,sig2"
+//                     (multiple sigs supported during secret rotation)
+//
+// The webhook secret format is `whsec_<base64>`. We base64-decode the part
+// after the prefix, then HMAC-SHA256 of `{svix-id}.{svix-timestamp}.{rawBody}`
+// with that key, then base64-encode the result and compare to one of the
+// v1 signatures.
+
+const REPLAY_TOLERANCE_SECONDS = 5 * 60;
+
+async function verifySvixSignature({ rawBody, headers, secret }) {
+  const svixId = headers.get('svix-id');
+  const svixTimestamp = headers.get('svix-timestamp');
+  const svixSignature = headers.get('svix-signature');
+
+  if (!svixId || !svixTimestamp || !svixSignature) {
+    return { ok: false, reason: 'missing svix headers' };
+  }
+
+  // Replay protection. Svix's recommendation is 5 min.
+  const ts = Number(svixTimestamp);
+  if (!Number.isFinite(ts)) {
+    return { ok: false, reason: 'malformed svix-timestamp' };
+  }
+  const drift = Math.abs(Date.now() / 1000 - ts);
+  if (drift > REPLAY_TOLERANCE_SECONDS) {
+    return { ok: false, reason: `timestamp drift ${Math.round(drift)}s exceeds tolerance` };
+  }
+
+  // The secret arrives prefixed with `whsec_`; the portion after is the
+  // base64-encoded HMAC key.
+  const keyB64 = secret.startsWith('whsec_') ? secret.slice('whsec_'.length) : secret;
+  const keyBytes = Uint8Array.from(atob(keyB64), (c) => c.charCodeAt(0));
+
+  const cryptoKey = await crypto.subtle.importKey(
+    'raw',
+    keyBytes,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+
+  const signedPayload = `${svixId}.${svixTimestamp}.${rawBody}`;
+  const sigBuf = await crypto.subtle.sign('HMAC', cryptoKey, new TextEncoder().encode(signedPayload));
+  // base64-encode without using Buffer (not available on Workers runtime)
+  const sigB64 = btoa(String.fromCharCode(...new Uint8Array(sigBuf)));
+
+  // svix-signature is "v1,xxx v1,yyy" — at least one v1 sig must match.
+  const provided = svixSignature.split(' ').filter((s) => s.startsWith('v1,'));
+  for (const p of provided) {
+    if (p.slice('v1,'.length) === sigB64) {
+      return { ok: true };
+    }
+  }
+  return { ok: false, reason: 'no v1 signature matched' };
+}
+
+function getServiceSupabase() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+    { auth: { persistSession: false } },
+  );
+}
+
+export async function POST(request) {
+  const secret = process.env.RESEND_WEBHOOK_SECRET;
+  if (!secret) {
+    // Don't return 200 — we want Resend to retry once the secret is set.
+    console.error('[resend-webhook] RESEND_WEBHOOK_SECRET not configured; rejecting');
+    return NextResponse.json({ error: 'Webhook not configured' }, { status: 503 });
+  }
+
+  // Read body once as text so signature verification and JSON parsing both
+  // see the exact same byte sequence.
+  const rawBody = await request.text();
+
+  const verification = await verifySvixSignature({
+    rawBody,
+    headers: request.headers,
+    secret,
+  });
+  if (!verification.ok) {
+    console.warn(`[resend-webhook] signature verification failed: ${verification.reason}`);
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
+  }
+
+  let event;
+  try {
+    event = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  // Resend payload shape (https://resend.com/docs/dashboard/webhooks/event-types):
+  //   { type: 'email.bounced' | 'email.complained' | ... ,
+  //     created_at, data: { email_id, to: [], from, subject, ... bounce: { ... } } }
+  const type = event?.type;
+  const data = event?.data || {};
+  const recipients = Array.isArray(data.to) ? data.to : [];
+  const eventId = data.email_id || event?.id || null;
+
+  if (type !== 'email.bounced' && type !== 'email.complained') {
+    // Acknowledge silently — Resend may send delivered/opened/clicked events
+    // we don't act on. Returning 200 prevents retries.
+    return NextResponse.json({ ok: true, ignored: type || 'unknown' });
+  }
+
+  if (recipients.length === 0) {
+    console.warn(`[resend-webhook] ${type} arrived with no recipients`);
+    return NextResponse.json({ ok: true, suppressed: 0 });
+  }
+
+  const reason = type === 'email.bounced' ? 'bounced' : 'complained';
+  const bounceType = type === 'email.bounced' ? data?.bounce?.type || null : null;
+
+  const rows = recipients.map((email) => ({
+    email: String(email).trim().toLowerCase(),
+    reason,
+    bounce_type: bounceType,
+    source_event_id: eventId,
+  }));
+
+  const supabase = getServiceSupabase();
+  // upsert on email PK so a duplicate webhook delivery doesn't error.
+  // We don't update existing rows — the FIRST suppression reason wins
+  // (a bounced address that later complains stays "bounced", which is
+  // the more actionable signal for triage).
+  const { error } = await supabase
+    .from('email_suppressions')
+    .upsert(rows, { onConflict: 'email', ignoreDuplicates: true });
+
+  if (error) {
+    console.error('[resend-webhook] suppression upsert failed:', error.message);
+    return NextResponse.json({ error: 'DB write failed' }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, suppressed: rows.length, type });
+}

--- a/src/lib/emailSuppressions.js
+++ b/src/lib/emailSuppressions.js
@@ -1,0 +1,39 @@
+import { getSupabase } from '@/lib/supabase';
+
+/**
+ * Returns true if the email address is on the suppression list.
+ *
+ * Soft-fails: any error reading the suppression table returns `false` so a
+ * Supabase outage doesn't block the entire transactional email flow. The
+ * existing "email is best-effort" pattern (every send is wrapped in
+ * try/catch by callers) is what makes this safe — at worst we send to a
+ * suppressed address one extra time and Resend will bounce it again,
+ * which the webhook will re-record. We log the error so it's still visible
+ * in `wrangler tail`.
+ *
+ * @param {string} email — the recipient address (any casing/whitespace; we
+ *   normalize). Returns false for empty/null input.
+ */
+export async function isEmailSuppressed(email) {
+  const normalized = (email || '').trim().toLowerCase();
+  if (!normalized) return false;
+
+  try {
+    const { data, error } = await getSupabase()
+      .from('email_suppressions')
+      .select('email')
+      .eq('email', normalized)
+      .maybeSingle();
+
+    if (error) {
+      // Don't throw — let the send proceed. An RLS leak or a row-not-found
+      // is the realistic failure mode here, neither of which is fatal.
+      console.warn(`[emailSuppressions] check failed for ${normalized}:`, error.message);
+      return false;
+    }
+    return !!data;
+  } catch (err) {
+    console.warn(`[emailSuppressions] threw for ${normalized}:`, err.message);
+    return false;
+  }
+}

--- a/src/lib/inquiryEmail.js
+++ b/src/lib/inquiryEmail.js
@@ -1,5 +1,6 @@
 import { getSupabase } from '@/lib/supabase';
 import { getResend } from '@/lib/resend';
+import { isEmailSuppressed } from '@/lib/emailSuppressions';
 import { inquiryEmailHtml, inquiryEmailSubject } from '@/templates/email/inquiry';
 
 const FROM_ADDRESS = 'StudentX <alerts@studentx.uk>';
@@ -60,6 +61,11 @@ export async function sendLandlordInquiryEmail({
 
     if (!landlord?.email) {
       console.warn(`Inquiry ${inquiryId}: no landlord email on file for listing ${listingId}`);
+      return;
+    }
+
+    if (await isEmailSuppressed(landlord.email)) {
+      console.warn(`Inquiry ${inquiryId}: skipping send — ${landlord.email} is suppressed`);
       return;
     }
 

--- a/src/lib/subscriptionEmail.js
+++ b/src/lib/subscriptionEmail.js
@@ -1,4 +1,5 @@
 import { getResend } from '@/lib/resend';
+import { isEmailSuppressed } from '@/lib/emailSuppressions';
 import { subscriptionWelcomeHtml, subscriptionWelcomeSubject } from '@/templates/email/subscriptionWelcome';
 
 const FROM_ADDRESS = 'StudentX <alerts@studentx.uk>';
@@ -12,8 +13,7 @@ const TIER_DISPLAY_NAMES = {
  * Send the subscription welcome email after a Stripe checkout completes.
  * Errors are swallowed (logged): the webhook must always ack 2xx, and a
  * Resend hiccup should never block downstream `customer.subscription.*`
- * events. Currently logs-only in production until studentx.uk is verified
- * with Resend (see CLAUDE.md → Email).
+ * events.
  */
 export async function sendSubscriptionWelcomeEmail({ supabase, landlordId, tier }) {
   try {
@@ -25,6 +25,11 @@ export async function sendSubscriptionWelcomeEmail({ supabase, landlordId, tier 
 
     if (!landlord?.email) {
       console.warn(`Subscription welcome: no email for landlord ${landlordId}`);
+      return;
+    }
+
+    if (await isEmailSuppressed(landlord.email)) {
+      console.warn(`Subscription welcome: skipping send — ${landlord.email} is suppressed`);
       return;
     }
 

--- a/supabase/migrations/040_email_suppressions.sql
+++ b/supabase/migrations/040_email_suppressions.sql
@@ -1,0 +1,46 @@
+-- Email suppression list driven by Resend webhook events.
+--
+-- Why: Resend POSTs `email.bounced` and `email.complained` events to our
+-- /api/webhooks/resend endpoint. Adding a recipient to this table prevents
+-- the send-side helpers (lib/emailSuppressions.js) from re-sending and
+-- damaging our sender reputation. Once an address is here it stays here
+-- (manual cleanup if a user fixes their inbox and asks to be re-enabled).
+--
+-- RLS: anon can SELECT (so the email-sending paths, which mostly use the
+-- anon client, can check before sending without each path needing its own
+-- service-role plumbing). Only service_role can INSERT/UPDATE/DELETE — the
+-- webhook handler is the only writer. Email addresses here aren't sensitive
+-- (the senders already had them, by definition).
+
+CREATE TABLE IF NOT EXISTS email_suppressions (
+  -- Stored lowercase + trimmed at insert time so lookups are deterministic
+  -- regardless of how the recipient address was originally spelled.
+  email TEXT PRIMARY KEY,
+
+  -- Why we suppressed. Constrained so a typo in webhook handling can't
+  -- silently slip a new value past us.
+  reason TEXT NOT NULL CHECK (reason IN ('bounced', 'complained')),
+
+  -- For bounces, the kind of bounce ('Permanent', 'Transient', etc. — Resend
+  -- forwards SES values verbatim). null for complaints. Useful when manually
+  -- triaging whether a soft bounce should be cleared from the list.
+  bounce_type TEXT,
+
+  -- The Resend event id, for audit / dedupe if a webhook delivers twice.
+  source_event_id TEXT,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE email_suppressions ENABLE ROW LEVEL SECURITY;
+
+-- Read access for both anon and authenticated. The send-side helper uses
+-- the anon client to check suppressions; this lets it work without each
+-- caller needing a service-role client.
+CREATE POLICY "Suppression list is publicly readable"
+  ON email_suppressions FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+-- No INSERT/UPDATE/DELETE policies — service_role bypasses RLS, so only
+-- the webhook handler (which uses SUPABASE_SERVICE_ROLE_KEY) can write.


### PR DESCRIPTION
## Summary

Wires Resend's `email.bounced` and `email.complained` webhook events into a new `email_suppressions` table, and adds a send-side check in every transactional path so we stop sending to addresses we know are dead.

This is the "full" option from the post-domain-migration scoping conversation — protects sender reputation in the long term. At current 13-listing scale it's mostly insurance; pays off as volume grows.

## What's in it

| File | Why |
|---|---|
| [`supabase/migrations/040_email_suppressions.sql`](supabase/migrations/040_email_suppressions.sql) | New table. anon/authenticated SELECT, service_role-only INSERT. **Already applied to prod** per the project's migration-ordering rule. |
| [`src/app/api/webhooks/resend/route.js`](src/app/api/webhooks/resend/route.js) | Webhook handler. Manual Svix signature verify via `crypto.subtle`, 5-min replay tolerance, supports multiple v1 sigs (secret rotation). Upserts with `onConflict: 'email', ignoreDuplicates`. |
| [`src/lib/emailSuppressions.js`](src/lib/emailSuppressions.js) | `isEmailSuppressed(email)` helper. Soft-fails on read errors so a Supabase blip never blocks an email send. |
| Five send paths | `inquiryEmail`, `subscriptionEmail`, `landlord-message-digest`, `saved-searches-digest`, `saved-searches` (confirmation). All call `isEmailSuppressed` before `resend.emails.send`. |
| [`__tests__/api/resendWebhook.test.js`](__tests__/api/resendWebhook.test.js) | 7 unit tests for the webhook handler. |

The synthetic-check route's alert email is **deliberately excluded** — that's an operational alert to the admin email, must always try regardless of suppression state.

## Why anon-readable suppressions table

Considered locking SELECT to service_role too, but the existing send paths (inquiry, saved-searches, etc.) use the anon Supabase client. Forcing service-role plumbing into each of them adds risk for no gain — email addresses on the suppression list aren't sensitive (the senders already had them, by definition). INSERT is still locked to service_role so only the webhook handler writes.

## Manual config after merge

These are external, can't do them from a PR:

1. **Register webhook with Resend.** Go to https://resend.com/webhooks → Add Endpoint → URL `https://studentx.uk/api/webhooks/resend`, subscribe to `email.bounced` + `email.complained`. (I can do this via API if you give me the Resend token again, or you can do it via dashboard.)
2. **Store the Resend-generated webhook signing secret** as a Worker secret: `RESEND_WEBHOOK_SECRET`. Use `wrangler versions secret put RESEND_WEBHOOK_SECRET --name studentx`.
3. **(Optional) Trigger a test event** from the Resend webhook UI to confirm the handler works end-to-end.

Until those are done, the route returns 503 (Resend will retry until the secret is set — by design).

## Test plan

- [x] `npm run lint` — clean (1 pre-existing warning)
- [x] `npm run test` — 87/87 passed (7 new)
- [x] `npm run build` — successful
- [x] Migration applied to prod
- [ ] After merge: register webhook in Resend dashboard
- [ ] After merge: `wrangler versions secret put RESEND_WEBHOOK_SECRET`
- [ ] After merge: trigger a test bounce from Resend, confirm the row lands in `email_suppressions`
- [ ] After merge: send a real test inquiry to a suppressed address, confirm log shows skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)