### PR TITLE
fix(listing-card): tie VERIFIED badge to landlord verification

### DIFF
--- a/src/components/ListingCard.js
+++ b/src/components/ListingCard.js
@@ -34,14 +34,14 @@ export default function ListingCard({ listing, fromQuery = '' }) {
     <Link
       href={href}
       className={`group block bg-white rounded-sm overflow-hidden transition-all focus-visible:outline-2 focus-visible:outline-gold focus-visible:outline-offset-2 ${
-        listing.is_featured
+        isVerified
           ? 'border-2 border-gold/60 shadow-[0_0_12px_-2px_rgba(191,155,48,0.4)] hover:shadow-[0_0_18px_-2px_rgba(191,155,48,0.55)]'
           : 'border border-night/10 hover:border-blue/40 hover:shadow-[0_2px_18px_-8px_rgba(10,20,54,0.25)]'
       }`}
     >
       {/* Photo */}
       <div className="relative aspect-[4/3] bg-parchment">
-        {listing.is_featured && (
+        {isVerified && (
           <span className="absolute top-3 right-3 z-10">
             <Pill variant="verified">{tCard('verified')}</Pill>
           </span>


### PR DESCRIPTION
## Summary

The gold **VERIFIED** pill and gold border on listing cards were driven by `listing.is_featured` — a per-listing boolean set by the Stripe webhook on subscription activation. Listings created *after* the subscription was set up missed the flag, so two listings from the same verified landlord could show inconsistent badges (one with the gold seal, one without).

This wires both the gold border and the VERIFIED pill to the existing `isVerified` variable, which is already computed from the landlord's `verified_tier` + `is_verified` fields. Now all listings from a verified landlord display consistently.

`is_featured` is preserved for sort ordering ([listings/route.js:239](src/app/api/listings/route.js#L239)) and metrics — those uses are unrelated to the badge display.

## Test plan

- [x] `npm run lint` — clean (only pre-existing unrelated warning)
- [x] `npm run test` — 87/87 passing
- [x] Verified locally on `/property/results`: both listings from the same verified landlord now show the gold border + VERIFIED pill; an unverified landlord's listing correctly shows neither

🤖 Generated with [Claude Code](https://claude.com/claude-code)