### PR TITLE
perf(homepage): use count endpoint for stat tile

### DIFF
--- a/src/app/[locale]/property/page.js
+++ b/src/app/[locale]/property/page.js
@@ -17,14 +17,17 @@ export default function LandingPage() {
   const t = useTranslations('propylaea.landing');
   const [listingCount, setListingCount] = useState(null);
 
-  // Live count of active listings, used in the stat tile.
+  // Live count of active listings, used in the stat tile. Calls a
+  // dedicated count endpoint instead of fetching the full listings
+  // payload — the previous version downloaded ~80 KB of joined rows
+  // just to read `.length`.
   useEffect(() => {
     let cancelled = false;
-    fetch('/api/listings')
+    fetch('/api/listings/count')
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (cancelled || !data) return;
-        const n = Array.isArray(data.listings) ? data.listings.length : 0;
+        const n = typeof data.count === 'number' ? data.count : 0;
         setListingCount(n);
       })
       .catch(() => {});

--- a/src/app/api/listings/count/route.js
+++ b/src/app/api/listings/count/route.js
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { getSupabase } from "@/lib/supabase";
+
+// Lightweight count endpoint for the landing-page stat tile. The full
+// `/api/listings` GET runs a 6-relation JOIN and returns ~80 KB of JSON;
+// the homepage was calling it just to read `data.listings.length`. This
+// endpoint uses Supabase's `head: true` modifier so Postgres returns
+// only a count, no rows. Cache headers mirror PUBLIC_CACHE_HEADERS in
+// next.config.mjs so Cloudflare's edge serves repeat hits.
+export async function GET() {
+  try {
+    const { count, error } = await getSupabase()
+      .from("listings")
+      .select("*", { count: "exact", head: true });
+
+    if (error) {
+      console.error("Listings count query failed:", error);
+      return NextResponse.json({ error: "Failed to fetch count" }, { status: 500 });
+    }
+
+    const response = NextResponse.json({ count: count ?? 0 });
+    response.headers.set(
+      "Cache-Control",
+      "public, s-maxage=300, stale-while-revalidate=86400"
+    );
+    return response;
+  } catch (err) {
+    console.error("Unexpected error in GET /api/listings/count:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/listings/count` returning `{ count }` via Supabase's `head: true` modifier (no rows in the response).
- Updates the landing-page stat tile to call the count endpoint instead of `GET /api/listings` and reading `.length`.

The previous version downloaded ~80 KB of fully-joined rows on every homepage view just to display a single integer. The count query is several bytes.

This is fix 1 of 4 from the perf review — see plan for the others (SQL pushdown easy wins, issue #67 anon/auth split, image variants).

## Test plan
- [x] `npm run lint` clean
- [x] `npm run test` — 87/87 passing
- [x] `npm run build` — `/api/listings/count` shows in route table
- [x] Local dev — homepage loads, stat tile shows "14" (the live count), single `GET /api/listings/count → 200` in network tab, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)