### PR TITLE
perf(middleware): edge-cache anonymous listing detail (issue #67)

### DIFF
--- a/__tests__/api/syntheticEnListing.test.js
+++ b/__tests__/api/syntheticEnListing.test.js
@@ -1,12 +1,21 @@
 import { describe, it, expect } from 'vitest';
-import { evaluateBody } from '@/app/api/cron/synthetic-en-listing/route';
+import {
+  evaluateBody,
+  evaluateAnonCacheHeader,
+  evaluateAuthedCacheHeader,
+} from '@/app/api/cron/synthetic-en-listing/route';
 
-// The cache-header regression guard added in PR #64. Issue #67 tracks
-// the deferred middleware-level anon/auth split that would let listing
-// routes safely return public cache. Until that ships, evaluateBody
-// must fail loudly if /en/property/listing/<id> ever returns public, s-maxage=...
-// — that's the session-leak shape the original cache-rework attempt
-// was reverted to avoid.
+// Cache-header regression guards. Pre-PR #105 the canary asserted
+// /en/property/listing/<id> must NEVER return public, s-maxage=... —
+// that was correct then because the route was statically pinned to
+// PRIVATE_CACHE_HEADERS for both anon and authed users.
+//
+// PR #105 split the cache-control per-request in middleware:
+//   anon (no sb-access-token cookie)  → public, s-maxage=300, ...
+//   authed (cookie present, any value) → private, no-cache, no-store, ...
+//
+// The canary now runs both directions on every tick: anon must include
+// `public, s-maxage=`; authed with a synthetic stub cookie must NOT.
 
 const PRIVATE_CC = 'private, no-cache, no-store, must-revalidate';
 const PUBLIC_CC = 'public, s-maxage=300, stale-while-revalidate=86400';
@@ -21,60 +30,73 @@ const GREEK_LEAK_BODY =
 const MISSING_MARKER_BODY = '<html lang="en"><body>Welcome</body></html>';
 
 describe('evaluateBody', () => {
-  it('passes on 200 + English markers + private cache', () => {
-    expect(
-      evaluateBody({ status: 200, body: VALID_BODY, cacheControl: PRIVATE_CC }),
-    ).toEqual({ ok: true });
+  it('passes on 200 + English markers', () => {
+    expect(evaluateBody({ status: 200, body: VALID_BODY })).toEqual({ ok: true });
   });
 
   it('fails when status is non-200', () => {
-    const result = evaluateBody({ status: 500, body: VALID_BODY, cacheControl: PRIVATE_CC });
+    const result = evaluateBody({ status: 500, body: VALID_BODY });
     expect(result.ok).toBe(false);
     expect(result.reason).toMatch(/non-200/);
   });
 
-  // The whole point of issue #67. If anyone re-promotes /listing/* to
-  // PUBLIC_CACHE_HEADERS without doing the middleware split first, this
-  // assertion catches it on the next 15-min cron tick.
-  it('fails when auth-gated route returns public, s-maxage=... (session-leak guard)', () => {
-    const result = evaluateBody({ status: 200, body: VALID_BODY, cacheControl: PUBLIC_CC });
-    expect(result.ok).toBe(false);
-    expect(result.reason).toMatch(/forbidden public cache header/);
-  });
-
-  it('also catches s-maxage with no comma-space (defensive regex)', () => {
-    const result = evaluateBody({
-      status: 200,
-      body: VALID_BODY,
-      cacheControl: 'public,s-maxage=60',
-    });
-    expect(result.ok).toBe(false);
-    expect(result.reason).toMatch(/forbidden public cache header/);
-  });
-
   it('fails when a required English marker is missing', () => {
-    const result = evaluateBody({
-      status: 200,
-      body: MISSING_MARKER_BODY,
-      cacheControl: PRIVATE_CC,
-    });
+    const result = evaluateBody({ status: 200, body: MISSING_MARKER_BODY });
     expect(result.ok).toBe(false);
     expect(result.reason).toMatch(/missing required EN marker/);
   });
 
   it('fails when a forbidden Greek marker leaks onto /en/', () => {
-    const result = evaluateBody({
-      status: 200,
-      body: GREEK_LEAK_BODY,
-      cacheControl: PRIVATE_CC,
-    });
+    const result = evaluateBody({ status: 200, body: GREEK_LEAK_BODY });
     expect(result.ok).toBe(false);
     expect(result.reason).toMatch(/forbidden EL marker/);
   });
+});
 
-  it('treats empty cacheControl as ok (private branch via missing header)', () => {
-    expect(
-      evaluateBody({ status: 200, body: VALID_BODY, cacheControl: '' }),
-    ).toEqual({ ok: true });
+describe('evaluateAnonCacheHeader', () => {
+  it('passes when anon response includes public, s-maxage=...', () => {
+    expect(evaluateAnonCacheHeader(PUBLIC_CC)).toEqual({ ok: true });
+  });
+
+  it('passes on the comma-spaceless variant', () => {
+    expect(evaluateAnonCacheHeader('public,s-maxage=60')).toEqual({ ok: true });
+  });
+
+  it('fails when middleware drops back to private (anon perf regression)', () => {
+    const result = evaluateAnonCacheHeader(PRIVATE_CC);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/anon listing detail must serve public/);
+  });
+
+  it('fails when the header is missing entirely', () => {
+    const result = evaluateAnonCacheHeader('');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/anon listing detail must serve public/);
+  });
+});
+
+describe('evaluateAuthedCacheHeader', () => {
+  it('passes when authed response is private/no-store', () => {
+    expect(evaluateAuthedCacheHeader(PRIVATE_CC)).toEqual({ ok: true });
+  });
+
+  // Session-leak guard. If the authed branch ever returns public, s-maxage=...
+  // (e.g. middleware regresses to passing the anon header through), Cloudflare
+  // caches the gated body and serves it to other users. This is the original
+  // failure mode that made the pre-PR-105 cache attempt unsafe to ship.
+  it('fails when authed route returns public, s-maxage=... (session-leak)', () => {
+    const result = evaluateAuthedCacheHeader(PUBLIC_CC);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/session-leak/);
+  });
+
+  it('also catches s-maxage with no comma-space (defensive regex)', () => {
+    const result = evaluateAuthedCacheHeader('public,s-maxage=60');
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/session-leak/);
+  });
+
+  it('treats empty cacheControl as ok (no public, s-maxage=)', () => {
+    expect(evaluateAuthedCacheHeader('')).toEqual({ ok: true });
   });
 });

--- a/docs/runbooks/synthetic-en-listing.md
+++ b/docs/runbooks/synthetic-en-listing.md
@@ -16,15 +16,23 @@ The bug can recur whenever a new locale-aware server component is added or a sub
 | Cron dispatch (cron expr → route) | [`cf/worker-entry.mjs`](../../cf/worker-entry.mjs) `CRON_ROUTES` |
 | Check logic + alerting | [`src/app/api/cron/synthetic-en-listing/route.js`](../../src/app/api/cron/synthetic-en-listing/route.js) |
 
-Every 15 min, the Worker's `scheduled` handler POSTs to `/api/cron/synthetic-en-listing` with the `x-cron-secret` header. The route fetches `${NEXT_PUBLIC_APP_URL}/en/listing/${SYNTHETIC_LISTING_ID}` and asserts:
+Every 15 min, the Worker's `scheduled` handler POSTs to `/api/cron/synthetic-en-listing` with the `x-cron-secret` header. The route fetches `${NEXT_PUBLIC_APP_URL}/en/property/listing/${SYNTHETIC_LISTING_ID}` and asserts:
 
-**Required (must be present in body):**
+**Body (anon fetch — `en-listing-locale`):**
+
+Required (must be present):
 - `<html lang="en"`
 - `Sign in to view this listing` — from `student.gate.title` in [`src/messages/en.json`](../../src/messages/en.json)
 
-**Forbidden (must NOT be present in body):**
+Forbidden (must NOT be present):
 - `lang="el"`
 - `Συνδέσου` — from `student.gate.title` in [`src/messages/el.json`](../../src/messages/el.json)
+
+**Cache headers (anon fetch — `en-listing-anon-cache`):**
+- Response **must** include `public, s-maxage=` — middleware (PR #105 / issue #67) sets this for visitors without an `sb-access-token` cookie so Cloudflare's edge can cache the AuthGate body across anon viewers. If the header drops back to `private` we silently lose the perf win.
+
+**Cache headers (authed fetch — `en-listing-authed-cache`):**
+- A second fetch goes out with `Cookie: sb-access-token=synthetic-canary-stub`. The middleware checks cookie *presence* only (not validity), so any non-empty value trips the authed branch. The response **must NOT** include `public, s-maxage=`. If it does, the gated body is CDN-cacheable across users — the original session-leak shape that issue #67 was filed for.
 
 Any failed assertion (or non-200, or fetch timeout) attempts to send an email via Resend to `SYNTHETIC_ALERT_EMAIL`.
 
@@ -46,13 +54,15 @@ Secrets (set via `wrangler secret put`, not in `wrangler.jsonc`):
 
 ## When the alert fires
 
-Subject: `[StudentX synthetic] /en/listing/<id> failed: <reason>`
+Subject: `[StudentX synthetic] N check(s) failed`
 
-Body includes status code, which assertion failed, and the first 500 chars of the returned HTML. Possible reasons:
+Body includes the failing check name, reason, and the first 500 chars of the anon HTML response. Possible reasons:
 
 - `non-200 status: <code>` — the page errored or redirected. Check the Worker logs.
-- `missing required EN marker: <marker>` — the page returned 200 but the English copy disappeared. Either the gate copy was edited (update marker below) or the i18n regression class is back.
-- `forbidden EL marker present: <marker>` — Greek leaked onto the EN page. **This is the regression we're guarding against** — investigate `getTranslations` calls in any recently-changed server component.
+- `missing required EN marker: <marker>` — page returned 200 but the English copy disappeared. Either the gate copy was edited (update marker constants in `route.js`) or the i18n regression class from PR #48 is back.
+- `forbidden EL marker present: <marker>` — Greek leaked onto the EN page. **i18n regression** — investigate `getTranslations` calls in any recently-changed server component.
+- `anon listing detail must serve public, s-maxage=...` — the middleware-set per-request cache header (PR #105) regressed for anon visitors. Either middleware.js stopped matching the path, or `next.config.mjs` re-introduced a static `private` rule that's overriding it. Run the curl commands in the [Manual cache-header probe](#manual-cache-header-probe) section to localise.
+- `authed listing detail returned public, s-maxage=... — session-leak risk` — **stop and investigate immediately**. The cookied request branch is now serving cacheable headers; if Cloudflare honours them, gated bodies will leak across users. Most likely cause: `next.config.mjs` got a static `public` rule for `/property/listing/*` (the same regression class the pre-PR-105 attempt was reverted for). Roll back the offending change or pin both static + middleware to private until investigated.
 - `fetch threw: ...` — the Worker couldn't reach the public hostname. Could be a Worker outage or DNS issue.
 
 ## Maintenance
@@ -83,7 +93,28 @@ Production (manual run, doesn't wait for the next 15-min tick):
 
 `studentx.uk` is the live custom domain (since 2026-05-03). DKIM/SPF/DMARC records are on the CF zone, the apex is verified in Resend, and `RESEND_API_KEY` is a Worker secret. Email alerts from this synthetic check send from `alerts@studentx.uk`. The original setup history lives in [`docs/runbooks/domain-setup.md`](./domain-setup.md).
 
+## Manual cache-header probe
+
+When investigating a `*-cache` failure, the same two requests the canary makes can be reproduced with curl from any shell:
+
+```bash
+# Anon — must include `cache-control: public, s-maxage=300, ...`
+curl -sI https://studentx.uk/en/property/listing/0100006 | grep -i cache-control
+
+# Authed — must NOT include `public, s-maxage=...` (private/no-store is fine)
+curl -sI -H 'Cookie: sb-access-token=any-non-empty-value' \
+  https://studentx.uk/en/property/listing/0100006 | grep -i cache-control
+
+# Bonus — confirm Cloudflare is actually caching the anon variant.
+# Run twice; second call should show `cf-cache-status: HIT`.
+curl -sI https://studentx.uk/en/property/listing/0100006 | grep -i cf-cache-status
+curl -sI https://studentx.uk/en/property/listing/0100006 | grep -i cf-cache-status
+```
+
+If the anon request returns `private` or the authed request returns `public, s-maxage=`, the middleware split has broken — start with `git log middleware.js next.config.mjs` to find the offending change.
+
 ## Known limitations
 
-- **Same-network probe.** The cron runs inside the same Cloudflare Worker that serves the page. Doesn't simulate a US user's edge cache. Acceptable because the listing page currently sets `Cache-Control: private, no-cache, no-store, must-revalidate` — there is no edge cache to test from a different POP.
+- **Same-network probe.** The cron runs inside the same Cloudflare Worker that serves the page, so it sees the origin response, not what a different PoP returns from cache. The header check is still meaningful (it confirms the Worker is sending the right `cache-control` for both branches), but a real session-leak across PoPs would only surface via the manual two-tab browser test in `docs/runbooks/`. Worth running that test by hand once a week post-PR-#105 deploy until the design is settled.
+- **`Vary: Cookie` may not split CDN keys on Cloudflare free tier.** If a session leak is observed despite the canary passing, add a Cloudflare Cache Rule in the dashboard: "Bypass cache when Cookie contains `sb-access-token`". This sacrifices the perf win for authed users (small fraction of traffic on a directory site) and keeps anon caching intact.
 - **No alert dedupe.** A sustained outage emails every 15 min. If this becomes annoying, add a `synthetic_alert_state(check_name, last_alert_at)` Supabase row and gate the email on `now() - last_alert_at > 1 hour`.

--- a/middleware.js
+++ b/middleware.js
@@ -1,9 +1,50 @@
 import createMiddleware from 'next-intl/middleware';
 import { routing } from './src/i18n/routing';
+import { SB_ACCESS_TOKEN_COOKIE } from './src/lib/authCookies';
 
-export default createMiddleware(routing);
+// Wraps next-intl's middleware so we can post-process the response with
+// auth-aware Cache-Control on listing detail pages (issue #67).
+//
+// Background. /property/listing/[id] renders different copy for
+// authenticated students vs anonymous visitors (gated contact details,
+// inquiry CTA). Pinning it to PRIVATE_CACHE_HEADERS in next.config.mjs
+// kept it correct but uncacheable — every visit hit the Worker plus
+// Supabase. A previous attempt to flip the static rule to PUBLIC was
+// reverted because authenticated requests inherited the public header
+// and risked the CDN serving the gated body to other users.
+//
+// The split here is per-request: anonymous (no sb-access-token cookie)
+// → cacheable at the edge for 5 min; authenticated → uncacheable.
+// Vary: Cookie tells well-behaved caches that cookie presence changes
+// the response. The next.config.mjs static rules for these paths are
+// removed in the same PR so they don't override what we set here.
+//
+// Cloudflare specifics: the free tier strips cookies from the cache
+// key by default and may not honour Vary: Cookie. If prod curl shows
+// the cached anon body served to authed users, add a Cache Rule
+// "Bypass cache when Cookie contains sb-access-token" in the dashboard.
+const PUBLIC_CACHE = 'public, s-maxage=300, stale-while-revalidate=86400';
+const PRIVATE_CACHE = 'private, no-cache, no-store, must-revalidate';
+const LISTING_DETAIL_PATH = /^\/(?:en\/)?property\/listing\/[^/]+\/?$/;
+
+const intlMiddleware = createMiddleware(routing);
+
+export default function middleware(request) {
+  const response = intlMiddleware(request);
+  if (!response) return response;
+
+  const pathname = request.nextUrl?.pathname || '';
+  if (!LISTING_DETAIL_PATH.test(pathname)) return response;
+
+  const cookieHeader = request.headers.get('cookie') || '';
+  const hasAuthCookie = cookieHeader.includes(`${SB_ACCESS_TOKEN_COOKIE}=`);
+
+  response.headers.set('Cache-Control', hasAuthCookie ? PRIVATE_CACHE : PUBLIC_CACHE);
+  // Vary: Cookie on these paths is set in next.config.mjs — middleware
+  // header mutations to Vary get clobbered by Next's response pipeline.
+  return response;
+}
 
 export const config = {
-  // Match all pathnames except for API routes, Next.js internals, and static files
   matcher: ['/((?!api|_next|_vercel|.*\\..*).*)'],
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -82,22 +82,22 @@ const nextConfig = {
         source: '/:path*',
         headers: SECURITY_HEADERS,
       },
-      // Auth-bound surfaces stay private. /listing/[id] is gated by
-      // requireStudent and renders an AuthGate body to anonymous users —
-      // CDN-caching it would serve one viewer's gated/non-gated body to
-      // another. /student/* (account, inquiries) is per-session.
+      // Auth-bound surfaces stay private at the static-rule level.
+      // /student/* and /property/landlord/* are per-session and never
+      // shareable across users.
       //
-      // Tried promoting /listing/* to PUBLIC_CACHE_HEADERS (PR
-      // "fix(perf): edge-cache anonymous listing detail GETs") and verified
-      // via prod curl that the static config rule wins over Next's
-      // runtime per-request cache header — an authenticated request
-      // (Cookie: sb-access-token=...) still received
-      // `public, s-maxage=300, stale-while-revalidate=86400`, which would
-      // CDN-cache the gated body. Reverted; keeping listing pages private
-      // until the anon vs auth split can be done in middleware (issue
-      // #67). The requireStudent cookie-fast-path below is still
-      // a defensible micro-optimization (skips one Supabase round-trip
-      // per anonymous request) even though the response stays uncacheable.
+      // /property/listing/[id] is intentionally NOT pinned here. It
+      // renders different copy for authenticated vs anonymous viewers
+      // (gated contact info), but the anon body IS shareable across
+      // anon visitors. middleware.js sets Cache-Control per-request
+      // based on the sb-access-token cookie — public for anon (so
+      // Cloudflare's edge serves repeat hits), private for authed
+      // (so the gated body is never cached). Issue #67 / commit history:
+      // an earlier attempt to flip the static rule to PUBLIC was
+      // reverted because authed users then inherited the public header.
+      // Keeping listing detail OUT of both static rules so middleware
+      // is the sole arbiter; the public-cache negative lookahead below
+      // therefore continues to exclude these paths.
       {
         source: '/property/landlord/:path*',
         headers: PRIVATE_CACHE_HEADERS,
@@ -107,20 +107,27 @@ const nextConfig = {
         headers: PRIVATE_CACHE_HEADERS,
       },
       {
-        source: '/property/listing/:path*',
-        headers: PRIVATE_CACHE_HEADERS,
-      },
-      {
-        source: '/:locale(en)/property/listing/:path*',
-        headers: PRIVATE_CACHE_HEADERS,
-      },
-      {
         source: '/student/:path*',
         headers: PRIVATE_CACHE_HEADERS,
       },
       {
         source: '/:locale(en)/student/:path*',
         headers: PRIVATE_CACHE_HEADERS,
+      },
+      // Vary: Cookie on listing detail responses so Cloudflare's edge
+      // treats anon (no sb-access-token) and authed (with cookie)
+      // requests as separate cache entries — prevents serving the
+      // cached anon body to an authenticated visitor. Setting this
+      // here rather than in middleware because Next's response
+      // pipeline tends to replace middleware-set Vary headers.
+      // Cache-Control itself is set per-request by middleware.js.
+      {
+        source: '/property/listing/:path*',
+        headers: [{ key: 'Vary', value: 'Cookie' }],
+      },
+      {
+        source: '/:locale(en)/property/listing/:path*',
+        headers: [{ key: 'Vary', value: 'Cookie' }],
       },
       // All other HTML routes are public-cacheable. The negative lookahead
       // skips api / _next / auth-gated surfaces / files with extensions

--- a/src/app/api/cron/synthetic-en-listing/route.js
+++ b/src/app/api/cron/synthetic-en-listing/route.js
@@ -36,42 +36,50 @@ function isCronAuthorized(request) {
   return searchParams.get('secret') === secret;
 }
 
-async function fetchUrl(url, { method = 'GET' } = {}) {
+// Synthetic-only stub cookie. Middleware checks for cookie *presence*
+// only (not validity) when deciding the cache-control branch — see
+// middleware.js. So any non-empty value here trips the authed branch
+// and we can verify the server-side split without holding a real JWT.
+const SYNTHETIC_AUTH_COOKIE = 'sb-access-token=synthetic-canary-stub';
+
+async function fetchUrl(url, { method = 'GET', cookie = '' } = {}) {
+  const headers = { 'user-agent': 'StudentX-synthetic/1.0' };
+  if (cookie) headers.cookie = cookie;
   const res = await fetch(url, {
     method,
-    headers: { 'user-agent': 'StudentX-synthetic/1.0' },
+    headers,
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     redirect: 'manual',
   });
   return res;
 }
 
-async function fetchListingHtml(url) {
-  const res = await fetchUrl(url);
+async function fetchListingHtml(url, { cookie } = {}) {
+  const res = await fetchUrl(url, { cookie });
   const body = await res.text();
   return {
     status: res.status,
     body,
     cacheControl: res.headers.get('cache-control') || '',
+    cfCacheStatus: res.headers.get('cf-cache-status') || '',
   };
 }
 
-// Auth-gated routes must NOT serve `public, s-maxage=...` — that would let
-// CF cache the gated body and serve it to a different viewer. Static
-// next.config.mjs rules win over Next runtime stamping (see PR #64 +
-// issue #67), so misconfiguring the headers config is the realistic
-// regression. Catch it on every cron tick.
-const FORBIDDEN_PUBLIC_CACHE_RE = /public,\s*s-maxage=/i;
+// Cache-header expectations after the issue #67 split (PR #105):
+//   anon (no sb-access-token cookie) → must include `public, s-maxage=...`
+//     (middleware lets Cloudflare's edge cache the AuthGate body)
+//   authed (cookie present)          → must NOT include public, s-maxage=...
+//     (the body contains gated contact info; CDN-caching it would leak)
+//
+// The forbidden direction is the original session-leak shape the
+// pre-PR-105 attempt was reverted for. The required direction is the
+// new shape: if middleware ever drops back to private for anon, we
+// silently lose the perf win and want to know within 15 min.
+const PUBLIC_CACHE_RE = /public,\s*s-maxage=/i;
 
-export function evaluateBody({ status, body, cacheControl }) {
+export function evaluateBody({ status, body }) {
   if (status !== 200) {
     return { ok: false, reason: `non-200 status: ${status}` };
-  }
-  if (FORBIDDEN_PUBLIC_CACHE_RE.test(cacheControl)) {
-    return {
-      ok: false,
-      reason: `forbidden public cache header on auth-gated route: ${cacheControl}`,
-    };
   }
   for (const marker of EN_MARKERS_REQUIRED) {
     if (!body.includes(marker)) {
@@ -82,6 +90,26 @@ export function evaluateBody({ status, body, cacheControl }) {
     if (body.includes(marker)) {
       return { ok: false, reason: `forbidden EL marker present: ${marker}` };
     }
+  }
+  return { ok: true };
+}
+
+export function evaluateAnonCacheHeader(cacheControl) {
+  if (!PUBLIC_CACHE_RE.test(cacheControl || '')) {
+    return {
+      ok: false,
+      reason: `anon listing detail must serve public, s-maxage=... (issue #67); got: ${cacheControl || '(none)'}`,
+    };
+  }
+  return { ok: true };
+}
+
+export function evaluateAuthedCacheHeader(cacheControl) {
+  if (PUBLIC_CACHE_RE.test(cacheControl || '')) {
+    return {
+      ok: false,
+      reason: `authed listing detail returned public, s-maxage=... — session-leak risk: ${cacheControl}`,
+    };
   }
   return { ok: true };
 }
@@ -230,24 +258,39 @@ export async function POST(request) {
   const checks = [];
   const failures = [];
 
-  // --- Original assertion: /en/listing renders without Greek leakage -------
+  function record(name, verdict) {
+    const result = { name, ...verdict };
+    checks.push(result);
+    if (!verdict.ok) failures.push(result);
+  }
+
+  // --- /en listing detail, anon: locale check + anon cache header ---------
+  // (post-PR #105: anon must now receive public, s-maxage=... so Cloudflare
+  // can cache the AuthGate body across visitors.)
   let enListingExcerpt = '';
   try {
     const fetched = await fetchListingHtml(enListingUrl);
-    const verdict = evaluateBody(fetched);
-    if (verdict.ok) {
-      checks.push({ name: 'en-listing-locale', ok: true });
-    } else {
+    record('en-listing-locale', evaluateBody(fetched));
+    record('en-listing-anon-cache', evaluateAnonCacheHeader(fetched.cacheControl));
+    if (fetched.status !== 200 || !checks.find((c) => c.name === 'en-listing-locale')?.ok) {
       enListingExcerpt = (fetched.body || '').slice(0, 500);
-      const failure = { name: 'en-listing-locale', ok: false, reason: verdict.reason };
-      checks.push(failure);
-      failures.push(failure);
     }
   } catch (err) {
     const reason = `fetch threw: ${err.name || 'Error'} ${err.message || ''}`.trim();
-    const failure = { name: 'en-listing-locale', ok: false, reason };
-    checks.push(failure);
-    failures.push(failure);
+    record('en-listing-locale', { ok: false, reason });
+    record('en-listing-anon-cache', { ok: false, reason });
+  }
+
+  // --- Same URL, with synthetic auth cookie: authed cache header ----------
+  // (session-leak guard. Middleware checks cookie presence only, not
+  // validity — any non-empty sb-access-token value trips the authed
+  // branch, so we can verify the per-request split without a real JWT.)
+  try {
+    const fetched = await fetchListingHtml(enListingUrl, { cookie: SYNTHETIC_AUTH_COOKIE });
+    record('en-listing-authed-cache', evaluateAuthedCacheHeader(fetched.cacheControl));
+  } catch (err) {
+    const reason = `fetch threw: ${err.name || 'Error'} ${err.message || ''}`.trim();
+    record('en-listing-authed-cache', { ok: false, reason });
   }
 
   // --- Additional assertions, run independently ----------------------------


### PR DESCRIPTION
## Summary
Listing detail pages (`/property/listing/[id]`) render different copy for authenticated students vs anonymous visitors (gated contact info). Pinning them to `PRIVATE_CACHE_HEADERS` in `next.config.mjs` kept them correct but uncacheable — every visit hit the Worker plus Supabase.

A previous attempt to flip the static rule to `PUBLIC_CACHE_HEADERS` (PR "fix(perf): edge-cache anonymous listing detail GETs") was reverted because authenticated requests inherited the public header.

This PR does the split **per-request in middleware**:

- `middleware.js` wraps next-intl's middleware. On listing detail paths it inspects the raw `Cookie` header for `sb-access-token` and sets `Cache-Control` to `public, s-maxage=300, stale-while-revalidate=86400` (anon) or `private, no-cache, no-store, must-revalidate` (authed).
- `next.config.mjs` drops the listing-private static rules so middleware is the sole arbiter of `Cache-Control`. `Vary: Cookie` is set as a static header for the same paths because Next's response pipeline replaces middleware-set Vary headers in `next start`; setting via config survives.
- The synthetic canary (`/api/cron/synthetic-en-listing`) is updated in the same PR — it previously asserted `public, s-maxage=` was forbidden on this route, which would have inverted into a constant alarm on every cron tick after deploy. It now runs **two** fetches (anon + synthetic-stub cookie) and asserts the correct shape for each.

This is fix 3 of 4 from the perf review (after [#103](https://github.com/MichaelChar/StudentX/pull/103) and [#104](https://github.com/MichaelChar/StudentX/pull/104)).

## Verification on `npm run preview` (OpenNext + Wrangler local Worker)

```
GET  /property/listing/0106001                             → 200
  Cache-Control: public, s-maxage=300, stale-while-revalidate=86400
  Vary: Cookie

GET  /property/listing/0106001  [Cookie: sb-access-token=…] → 200
  Cache-Control: private, no-cache, no-store, must-revalidate
  Vary: Cookie

GET  /en/property/listing/0106001                          → 200
  Cache-Control: public, s-maxage=300, stale-while-revalidate=86400
  Vary: Cookie
```

## Post-deploy verification plan

Run **all six** against `https://studentx.uk` immediately after this lands, before walking away:

```bash
# 1. Anon, default Greek path → public
curl -sI https://studentx.uk/property/listing/0100006 | grep -iE 'cache-control|^vary'
# expect: Cache-Control: public, s-maxage=300, stale-while-revalidate=86400 + Vary: Cookie

# 2. Anon, /en path → public
curl -sI https://studentx.uk/en/property/listing/0100006 | grep -iE 'cache-control|^vary'
# expect: same as #1

# 3. Authed (synthetic stub cookie) → private
curl -sI -H 'Cookie: sb-access-token=any-value' https://studentx.uk/property/listing/0100006 | grep -iE 'cache-control'
# expect: Cache-Control: private, no-cache, no-store, must-revalidate

# 4. Cloudflare actually caching the anon variant. Run TWICE.
curl -sI https://studentx.uk/property/listing/0100006 | grep -i cf-cache-status
curl -sI https://studentx.uk/property/listing/0100006 | grep -i cf-cache-status
# expect: second response shows cf-cache-status: HIT (or DYNAMIC if CF strips cookies/Vary)

# 5. Synthetic canary runs every 15 min — confirm 2-3 ticks pass post-deploy.
#    The canary now runs all three checks (locale, anon-cache, authed-cache)
#    and emails on any failure. Watch wrangler tail for the first tick:
wrangler tail --name studentx | grep synthetic
```

**6. Manual two-tab session-leak test (do this once, by hand).** Open Tab 1, sign in as a student, view a listing. Open Tab 2 in incognito (no cookie), view the same listing. Confirm Tab 2 shows the AuthGate, NOT the gated contact-info body. Repeat with the user signed-in in Tab 1, then **sign out**, then refresh — confirm the page does not still show the gated body from cache.

## Cloudflare Cache Rule (post-deploy contingency)

If verification step #4 shows `cf-cache-status: DYNAMIC` instead of `HIT` on the second call, or step #6 shows a session leak, Cloudflare's free tier is not honouring `Vary: Cookie` at the edge. Add a Cache Rule in the dashboard:

> "Bypass cache when Cookie contains `sb-access-token`"

This sacrifices the perf win for authed users (small fraction of traffic on a directory site) but keeps the cache-share-across-anons benefit intact. Document the change in `docs/runbooks/synthetic-en-listing.md` if it ends up needed (the runbook already mentions this contingency in its "Known limitations" section).

## Test plan
- [x] `npm run lint` clean
- [x] `npm run test` — 92/92 passing (added 9 new for the new evaluators, kept 4 body-only tests)
- [x] `npm run build` clean
- [x] `npm run preview` — verified on real OpenNext+Workers runtime (curl output above)
- [ ] Post-deploy: six checks above against `https://studentx.uk`
- [ ] Post-deploy: synthetic-en-listing canary green for 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)