### PR TITLE
perf(images): browser-side resize to thumb/card/full variants on upload

### DIFF
--- a/__tests__/lib/photoVariants.test.js
+++ b/__tests__/lib/photoVariants.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { variantUrl } from '@/lib/photoVariants';
+
+const SUPABASE_BASE = 'https://ecluqurlfbvkxrnoyhaq.supabase.co/storage/v1/object/public/listing-photos';
+
+describe('variantUrl', () => {
+  it('swaps __card → __thumb on a card URL', () => {
+    const url = `${SUPABASE_BASE}/abc/123-rand__card.webp`;
+    expect(variantUrl(url, 'thumb')).toBe(`${SUPABASE_BASE}/abc/123-rand__thumb.webp`);
+  });
+
+  it('swaps __card → __full on a card URL', () => {
+    const url = `${SUPABASE_BASE}/abc/123-rand__card.webp`;
+    expect(variantUrl(url, 'full')).toBe(`${SUPABASE_BASE}/abc/123-rand__full.webp`);
+  });
+
+  it('returns the same URL when requesting the size already encoded', () => {
+    const url = `${SUPABASE_BASE}/abc/123-rand__card.webp`;
+    expect(variantUrl(url, 'card')).toBe(url);
+  });
+
+  it('preserves jpg extension when present', () => {
+    const url = `${SUPABASE_BASE}/abc/123-rand__card.jpg`;
+    expect(variantUrl(url, 'thumb')).toBe(`${SUPABASE_BASE}/abc/123-rand__thumb.jpg`);
+  });
+
+  it('preserves jpeg extension when present', () => {
+    const url = `${SUPABASE_BASE}/abc/123-rand__card.jpeg`;
+    expect(variantUrl(url, 'full')).toBe(`${SUPABASE_BASE}/abc/123-rand__full.jpeg`);
+  });
+
+  it('returns legacy Wixstatic URLs unchanged (no variant suffix)', () => {
+    const url = 'https://static.wixstatic.com/media/abc123.jpg';
+    expect(variantUrl(url, 'thumb')).toBe(url);
+    expect(variantUrl(url, 'full')).toBe(url);
+  });
+
+  it('returns pre-variant Supabase URLs unchanged', () => {
+    const url = `${SUPABASE_BASE}/abc/legacy.jpg`;
+    expect(variantUrl(url, 'thumb')).toBe(url);
+  });
+
+  it('returns non-string input unchanged', () => {
+    expect(variantUrl(null, 'card')).toBe(null);
+    expect(variantUrl(undefined, 'card')).toBe(undefined);
+  });
+
+  it('defaults to card when size omitted', () => {
+    const url = `${SUPABASE_BASE}/abc/123__thumb.webp`;
+    expect(variantUrl(url)).toBe(`${SUPABASE_BASE}/abc/123__card.webp`);
+  });
+});

--- a/src/app/[locale]/property/landlord/dashboard/page.js
+++ b/src/app/[locale]/property/landlord/dashboard/page.js
@@ -8,6 +8,7 @@ import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 
 import LandlordShell from '@/components/landlord/LandlordShell';
 import Button from '@/components/ui/Button';
+import { variantUrl } from '@/lib/photoVariants';
 import Card from '@/components/ui/Card';
 import Pill from '@/components/ui/Pill';
 import Icon from '@/components/ui/Icon';
@@ -282,7 +283,7 @@ function ListingRow({ listing }) {
       <div className="relative w-16 h-16 rounded-sm bg-parchment overflow-hidden shrink-0">
         {photo ? (
           <Image
-            src={photo}
+            src={variantUrl(photo, 'thumb')}
             alt={address}
             fill
             className="object-cover"

--- a/src/app/[locale]/property/landlord/listings/page.js
+++ b/src/app/[locale]/property/landlord/listings/page.js
@@ -8,6 +8,7 @@ import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 import { useAccessToken } from '@/lib/useAccessToken';
 
 import LandlordShell from '@/components/landlord/LandlordShell';
+import { variantUrl } from '@/lib/photoVariants';
 import Button from '@/components/ui/Button';
 import Card from '@/components/ui/Card';
 import Pill from '@/components/ui/Pill';
@@ -138,7 +139,7 @@ function ListingRow({ listing, deleting, onDelete, t }) {
       <div className="relative w-full md:w-20 aspect-[4/3] md:aspect-square rounded-sm bg-parchment overflow-hidden shrink-0">
         {photo ? (
           <Image
-            src={photo}
+            src={variantUrl(photo, 'thumb')}
             alt={address}
             fill
             className="object-cover"

--- a/src/app/[locale]/property/listing/[id]/page.js
+++ b/src/app/[locale]/property/listing/[id]/page.js
@@ -13,6 +13,7 @@ import Pill from '@/components/ui/Pill';
 import Card from '@/components/ui/Card';
 import Icon from '@/components/ui/Icon';
 import VerifiedSeal from '@/components/ui/VerifiedSeal';
+import { variantUrl } from '@/lib/photoVariants';
 import OrnamentRule from '@/components/ui/OrnamentRule';
 
 // Cap on the untrusted ?from= URL param. Real /results querystrings are
@@ -253,7 +254,7 @@ function PhotoTile({ src, alt, priority = false }) {
   return (
     <div className="relative aspect-[4/3] rounded-sm overflow-hidden bg-parchment">
       <Image
-        src={src}
+        src={variantUrl(src, 'full')}
         alt={alt}
         fill
         className="object-cover"

--- a/src/components/ListingCard.js
+++ b/src/components/ListingCard.js
@@ -3,6 +3,7 @@ import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/navigation';
 import Pill from '@/components/ui/Pill';
 import Icon from '@/components/ui/Icon';
+import { variantUrl } from '@/lib/photoVariants';
 
 /*
   Propylaea listing card — matches page 06 of the reference design.
@@ -48,7 +49,7 @@ export default function ListingCard({ listing, fromQuery = '' }) {
         )}
         {photo ? (
           <Image
-            src={photo}
+            src={variantUrl(photo, 'card')}
             alt={listing.address}
             fill
             className="object-cover"

--- a/src/components/ListingForm.js
+++ b/src/components/ListingForm.js
@@ -7,6 +7,8 @@ import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 import BauhausLoader from '@/components/BauhausLoader';
 import { TITLE_MAX_LENGTH, codepointLength } from '@/lib/listingTitle';
 import { arrayMove } from '@/lib/arrayMove';
+import { resizeToVariants } from '@/lib/imageResize';
+import { variantUrl } from '@/lib/photoVariants';
 
 const NEIGHBORHOODS_FALLBACK = [
   'Ano Poli', 'Center', 'Faliro', 'Kalamaria', 'Kentro',
@@ -154,19 +156,49 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
 
       const uploaded = [];
       for (const file of toUpload) {
-        const ext = file.name.split('.').pop();
-        const path = `${userId}/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
-        const { error: uploadError } = await supabase.storage
-          .from('listing-photos')
-          .upload(path, file, { upsert: false });
-        if (uploadError) {
+        // Generate three variants (thumb/card/full) in the browser before
+        // upload so the public site can pick a small file for thumbnails
+        // and a larger one for the listing-detail hero. The CARD url is
+        // what we store in `photos`; thumb/full are derived at display
+        // time via variantUrl(). See src/lib/photoVariants.js.
+        let variants;
+        try {
+          variants = await resizeToVariants(file);
+        } catch (err) {
+          console.error('[ListingForm] image resize failed:', err);
           setPhotoError(t('photosError'));
           continue;
         }
-        const { data: { publicUrl } } = supabase.storage
-          .from('listing-photos')
-          .getPublicUrl(path);
-        uploaded.push(publicUrl);
+
+        const stem = `${userId}/${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const contentType = variants.ext === 'webp' ? 'image/webp' : 'image/jpeg';
+        const targets = [
+          { size: 'thumb', blob: variants.thumb },
+          { size: 'card', blob: variants.card },
+          { size: 'full', blob: variants.full },
+        ];
+
+        let cardUrl = null;
+        let failed = false;
+        for (const { size, blob } of targets) {
+          const path = `${stem}__${size}.${variants.ext}`;
+          const { error: uploadError } = await supabase.storage
+            .from('listing-photos')
+            .upload(path, blob, { upsert: false, contentType });
+          if (uploadError) {
+            failed = true;
+            break;
+          }
+          if (size === 'card') {
+            const { data } = supabase.storage.from('listing-photos').getPublicUrl(path);
+            cardUrl = data.publicUrl;
+          }
+        }
+        if (failed || !cardUrl) {
+          setPhotoError(t('photosError'));
+          continue;
+        }
+        uploaded.push(cardUrl);
       }
 
       if (uploaded.length > 0) {
@@ -189,10 +221,17 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
       const supabase = getSupabaseBrowser();
       const marker = '/listing-photos/';
       const idx = url.indexOf(marker);
-      if (idx !== -1) {
-        const path = url.slice(idx + marker.length);
-        await supabase.storage.from('listing-photos').remove([path]);
-      }
+      if (idx === -1) return;
+      const path = url.slice(idx + marker.length);
+      // For variant URLs, remove all three sibling files at once (we stored
+      // only the CARD URL but uploaded thumb/card/full together). Legacy
+      // paths without the __<size> suffix fall through and get removed
+      // as a single file.
+      const variantMatch = path.match(/^(.*)__(thumb|card|full)\.(webp|jpe?g)$/i);
+      const paths = variantMatch
+        ? ['thumb', 'card', 'full'].map((s) => `${variantMatch[1]}__${s}.${variantMatch[3]}`)
+        : [path];
+      await supabase.storage.from('listing-photos').remove(paths);
     } catch {
       // best-effort: UI already updated, storage cleanup failure is non-blocking
     }
@@ -552,7 +591,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
                       }`}
                     >
                       <Image
-                        src={url}
+                        src={variantUrl(url, i === 0 ? 'card' : 'thumb')}
                         alt={`Photo ${i + 1}`}
                         fill
                         className="object-cover pointer-events-none"

--- a/src/lib/imageResize.js
+++ b/src/lib/imageResize.js
@@ -1,0 +1,82 @@
+// Browser-side image resizer used by ListingForm before uploading to
+// Supabase Storage. Generates three variants (thumb / card / full) so
+// the public site can pick the right size for the surface — listing
+// cards don't need a 4 MB hero image.
+//
+// Output format is WebP at 0.82 quality, ~70-80% smaller than the
+// JPEGs phones produce while staying visually lossless. Modern
+// browsers (last ~5 years) all encode WebP via canvas; if encoding
+// fails we fall through to JPEG so uploads never silently break.
+
+const VARIANT_LONGEST_EDGE = {
+  thumb: 400,
+  card: 800,
+  full: 1600,
+};
+
+const QUALITY = 0.82;
+
+/**
+ * @param {File} file - the user-selected image file
+ * @returns {Promise<{ thumb: Blob, card: Blob, full: Blob, ext: 'webp' | 'jpg' }>}
+ */
+export async function resizeToVariants(file) {
+  const bitmap = await createImageBitmap(file);
+  try {
+    // Probe encoding once on the first variant; reuse the chosen format
+    // for the others so a single source can't end up with mixed
+    // extensions (which would defeat the suffix-swap variant URL scheme).
+    const probe = await encode(bitmap, sizeFor(bitmap, VARIANT_LONGEST_EDGE.card));
+    const ext = probe.type === 'image/webp' ? 'webp' : 'jpg';
+    const mime = probe.type;
+    const card = probe;
+    const [thumb, full] = await Promise.all([
+      encode(bitmap, sizeFor(bitmap, VARIANT_LONGEST_EDGE.thumb), mime),
+      encode(bitmap, sizeFor(bitmap, VARIANT_LONGEST_EDGE.full), mime),
+    ]);
+    return { thumb, card, full, ext };
+  } finally {
+    bitmap.close?.();
+  }
+}
+
+function sizeFor(bitmap, target) {
+  const longest = Math.max(bitmap.width, bitmap.height);
+  if (longest <= target) {
+    // Don't upscale — re-encode at source dimensions for format conversion.
+    return { w: bitmap.width, h: bitmap.height };
+  }
+  const scale = target / longest;
+  return {
+    w: Math.max(1, Math.round(bitmap.width * scale)),
+    h: Math.max(1, Math.round(bitmap.height * scale)),
+  };
+}
+
+async function encode(bitmap, { w, h }, preferredMime) {
+  const canvas =
+    typeof OffscreenCanvas !== 'undefined'
+      ? new OffscreenCanvas(w, h)
+      : Object.assign(document.createElement('canvas'), { width: w, height: h });
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(bitmap, 0, 0, w, h);
+
+  // Prefer WebP; fall back to JPEG if the browser refuses.
+  const tryMime = preferredMime || 'image/webp';
+  const blob = await canvasToBlob(canvas, tryMime, QUALITY);
+  if (blob && blob.size > 0 && blob.type.startsWith('image/')) return blob;
+  return canvasToBlob(canvas, 'image/jpeg', QUALITY);
+}
+
+function canvasToBlob(canvas, type, quality) {
+  if (canvas.convertToBlob) {
+    return canvas.convertToBlob({ type, quality });
+  }
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (b) => (b ? resolve(b) : reject(new Error('canvas.toBlob returned null'))),
+      type,
+      quality
+    );
+  });
+}

--- a/src/lib/photoVariants.js
+++ b/src/lib/photoVariants.js
@@ -1,0 +1,28 @@
+// Resolves the right size variant for a stored listing photo URL.
+//
+// New uploads (post-variant rollout) save three sized files alongside
+// each other:  <stem>__thumb.<ext>, <stem>__card.<ext>, <stem>__full.<ext>.
+// The URL stored in `listings.photos` is the CARD variant, since that's
+// the most common display size and keeps any consumer that doesn't
+// know about variants working with a sensible default.
+//
+// Legacy URLs — Wixstatic photos imported before the variant rollout,
+// and Supabase uploads that predate it — don't carry the suffix and
+// fall through unchanged. That makes this safe to roll out without a
+// backfill: `variantUrl(legacyUrl, 'thumb')` returns the original URL,
+// and the surface renders the original photo at full size.
+
+const VARIANT_RE = /__(thumb|card|full)\.(webp|jpe?g)$/i;
+
+/**
+ * @param {string} url - the URL stored in listings.photos
+ * @param {'thumb' | 'card' | 'full'} size
+ * @returns {string} - the variant URL, or the original if not a known variant URL
+ */
+export function variantUrl(url, size = 'card') {
+  if (typeof url !== 'string') return url;
+  const match = url.match(VARIANT_RE);
+  if (!match) return url;
+  const [, , ext] = match;
+  return url.replace(VARIANT_RE, `__${size}.${ext}`);
+}


### PR DESCRIPTION
## Summary
Photos uploaded via ListingForm currently land in Supabase Storage at their original size (post-[#83](https://github.com/MichaelChar/StudentX/pull/83) the cap is 10 MB). With `unoptimized: true` in `next.config.mjs`, every surface serves those originals — so a 4 MB phone shot gets downloaded for 80 px landlord-dashboard thumbnails.

This PR resizes in the browser before upload (no new infra; Cloudflare Workers can't run sharp, Cloudflare Images is paid). Three variants per photo: thumb 400 px, card 800 px, full 1600 px — all WebP at 0.82 quality.

> ⚠️ **Existing listings still serve full-size originals on every surface.** This PR's win is realised for *new* uploads only — the `variantUrl` fallback returns legacy URLs unchanged so nothing breaks, but every photo uploaded before this lands keeps shipping at original size until a backfill runs. **Backfill follow-up: [#107](https://github.com/MichaelChar/StudentX/issues/107).**

This is fix 4 of 4 from the perf review (after [#103](https://github.com/MichaelChar/StudentX/pull/103), [#104](https://github.com/MichaelChar/StudentX/pull/104), [#105](https://github.com/MichaelChar/StudentX/pull/105)).

## What's new

| File | Purpose |
|---|---|
| `src/lib/imageResize.js` | `resizeToVariants(file)` → `{ thumb, card, full, ext }`. Uses `createImageBitmap` + Canvas, prefers WebP, falls back to JPEG if encoding refuses. Single probe encode shared across variants so they always have the same extension (defends the suffix-swap scheme). |
| `src/lib/photoVariants.js` | `variantUrl(url, size)` swaps the `__<size>` suffix on variant URLs; legacy Wixstatic and pre-variant Supabase URLs fall through unchanged. **No backfill needed for this PR to be safe** — old photos still display via the original URL. |

## Wire-up

- **`ListingForm.js`** — generate three variants per file, upload all three with `__thumb`/`__card`/`__full` suffixes, store the CARD URL in `photos`. `removePhoto` now deletes sibling variants when present; legacy paths still work as single-file removes.
- **Display sites** swap to the right size:
  - `ListingCard` → `variantUrl(photo, 'card')`
  - `listing/[id]` `PhotoTile` → `variantUrl(src, 'full')`
  - `landlord/listings` and `landlord/dashboard` rows → `variantUrl(photo, 'thumb')`
  - `ListingForm` preview → `'card'` for hero, `'thumb'` for siblings

## Out of scope (note)

- **Re-flipping `unoptimized: false`** — not needed. We're serving pre-resized files; Next/Image is just an `<img>` wrapper.
- **Wixstatic legacy migration** — handled by graceful fallback in `variantUrl`.
- **Verification photo upload** (`src/app/api/landlord/verification/route.js`) — admin-only ID document, no variants needed.
- **Backfilling existing Supabase photos** — tracked in [#107](https://github.com/MichaelChar/StudentX/issues/107). Existing listings keep serving the original on every surface until that script runs. ~14 listings × ~5 photos each ≈ 70 originals, ~30-min job.

## Known UX nit (non-blocker)

The resize loop in `ListingForm.handlePhotoFiles` is sequential — a landlord uploading 8 photos at once does 8 sequential resizes. On a low-end Android each can take ~1-2 sec, so worst case is a multi-second blocking operation with no per-file progress feedback. The form's existing spinner masks it. Trivial future fix: `Promise.all` the per-file resize step (browsers handle 1-2 concurrent canvas encodes efficiently). Flagging here so the founder knows to look at this if a landlord support ticket mentions it.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run test` — **96/96** passing (added 9 new for `variantUrl`)
- [x] `npm run build` clean
- [x] Local dev: `/property/results` renders all 14 listing card images via `variantUrl('card')`. Legacy Supabase URLs (no `__size` suffix) fall through unchanged — `naturalWidth` reads source dimensions, no 404s, no console errors.
- [ ] Post-deploy: upload a 4 MB photo as a landlord, confirm Supabase Storage UI shows three variant files, network panel shows the `__card.webp` (~tens of KB) loading on `/property/results`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)