### PR TITLE
fix(i18n): /en/* rendering Greek + results filter labels hardcoded EN

### DIFF
--- a/src/app/[locale]/property/quiz/layout.js
+++ b/src/app/[locale]/property/quiz/layout.js
@@ -1,4 +1,4 @@
-import { getTranslations } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://studentx.uk';
 
@@ -28,6 +28,8 @@ export async function generateMetadata({ params }) {
   };
 }
 
-export default function QuizLayout({ children }) {
+export default async function QuizLayout({ children, params }) {
+  const { locale } = await params;
+  setRequestLocale(locale);
   return children;
 }

--- a/src/app/[locale]/property/results/page.js
+++ b/src/app/[locale]/property/results/page.js
@@ -21,9 +21,9 @@ import GlobeLoader from '@/components/GlobeLoader';
 */
 
 const PROPERTY_TYPE_GROUPS = [
-  { label: 'Studio / 1-bed', values: ['Studio', '1-Bedroom'] },
-  { label: '2-bed', values: ['2-Bedroom'] },
-  { label: 'Private room', values: ['Room in shared apartment'] },
+  { labelKey: 'typeStudio1Bed', values: ['Studio', '1-Bedroom'] },
+  { labelKey: 'type2Bed', values: ['2-Bedroom'] },
+  { labelKey: 'typePrivateRoom', values: ['Room in shared apartment'] },
 ];
 const BUDGET_MIN = 150;
 const BUDGET_MAX = 1200;
@@ -562,7 +562,7 @@ function FilterPanel({
             const active = group.values.every((v) => filters.selectedTypes.includes(v));
             return (
               <button
-                key={group.label}
+                key={group.labelKey}
                 type="button"
                 onClick={() => onToggleType(group.values)}
                 aria-pressed={active}
@@ -572,7 +572,7 @@ function FilterPanel({
                     : 'border-night/20 text-night/70 hover:border-blue'
                 }`}
               >
-                {group.label}
+                {tQuiz(group.labelKey)}
               </button>
             );
           })}

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,5 +1,5 @@
 import { EB_Garamond, Source_Sans_3 } from "next/font/google";
-import { getLocale } from "next-intl/server";
+import LangSync from "@/components/LangSync";
 import "./globals.css";
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://studentx.uk";
@@ -31,15 +31,20 @@ const sourceSans = Source_Sans_3({
   display: "swap",
 });
 
-export default async function RootLayout({ children }) {
-  const locale = await getLocale().catch(() => "el");
+// Hardcode lang to the default locale. Calling next-intl's getLocale() here
+// poisons the per-request config cache before any child layout has had a
+// chance to call setRequestLocale(locale), which makes every t()/getMessages()
+// in /en/* render Greek. <LangSync> updates document.documentElement.lang
+// client-side once next-intl's provider has the real locale.
+export default function RootLayout({ children }) {
   return (
     <html
-      lang={locale}
+      lang="el"
       suppressHydrationWarning
       className={`${ebGaramond.variable} ${sourceSans.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col font-sans bg-stone text-night">
+        <LangSync />
         {children}
       </body>
     </html>

--- a/src/components/LangSync.js
+++ b/src/components/LangSync.js
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+// Updates <html lang> based on the URL pathname. Lives in the root layout
+// (above the next-intl provider), so it can't use useLocale() — reading the
+// pathname directly is fine since the locale is encoded in the URL itself
+// (defaultLocale 'el' has no prefix, 'en' lives at /en/*). Keeps the lang
+// attribute correct for screen readers and SEO crawlers that execute JS.
+// The root layout hardcodes lang="el" because using next-intl's getLocale()
+// there poisons the per-request config cache and makes /en/* render Greek.
+export default function LangSync() {
+  const pathname = usePathname();
+  useEffect(() => {
+    const locale = pathname?.startsWith('/en') ? 'en' : 'el';
+    if (document.documentElement.lang !== locale) {
+      document.documentElement.lang = locale;
+    }
+  }, [pathname]);
+  return null;
+}


### PR DESCRIPTION
## Summary

Two related fixes:

### 1. `/en/*` was rendering Greek (sitewide bug)

The root layout (`src/app/layout.js`) called `next-intl`'s `getLocale()` to set `<html lang>`. That call triggers `getRequestConfig` **before** any child layout has called `setRequestLocale(locale)`, so the per-request config cache was populated with the default locale (`el`) and never updated. Every `t()` / `getMessages()` in `/en/*` returned Greek messages even though `params.locale === 'en'`.

Confirmed with debug log:
\`\`\`
[DBG] params.locale= en  heading= Ένα λεπτό.   ← should be "One minute."
\`\`\`

**Fix:** stop calling `getLocale()` in the root layout. Hardcode `lang="el"` (the default) and add a tiny client component (`LangSync`) that updates `document.documentElement.lang` based on the URL pathname after hydration. Keeps lang correct for screen readers and JS-executing crawlers without touching next-intl's request scope.

Also added `setRequestLocale(locale)` to the quiz layout — matches the canonical pattern other layouts already use.

### 2. Results page filter labels hardcoded in English (regression from [#108](https://github.com/MichaelChar/StudentX/pull/108))

[#108](https://github.com/MichaelChar/StudentX/pull/108) introduced `PROPERTY_TYPE_GROUPS` with raw English labels (`Studio / 1-bed`, `2-bed`, `Private room`) instead of translation keys, so the Greek site showed English chip labels. Switched to `labelKey` referencing the existing `propylaea.quiz.type*` keys and `tQuiz(group.labelKey)` at render — same pattern the dealbreakers section already uses.

## Verified end-to-end

- `/property/quiz`, `/el/property/quiz` → Greek heading, Greek chips, `lang="el"` ✓
- `/en/property/quiz` → English heading, English chips, `lang="en"` ✓
- `/property/results`, `/el/property/results` → `Γκαρσονιέρα / Δυάρι` etc., `lang="el"` ✓
- `/en/property/results` → `Studio / 1-bed`, `2-bed`, `Private room`, `lang="en"` ✓
- Lint clean, 101 tests pass

## Test plan

- [ ] CI green
- [ ] Smoke `/en/property/quiz` on prod after deploy — heading should be "One minute. That's it."
- [ ] Smoke `/property/results` on prod — chip labels should be Greek

## Notes

- This sitewide `/en/*` bug appears to be the same class of issue the synthetic canary `/api/cron/synthetic-en-listing` was built to catch — but the canary only checks the listing detail page. The canary should likely be extended to cover at least one other locale-aware page (worth a follow-up).
- The lang=el → lang=en swap on `/en/*` happens after JS hydration. This is acceptable for screen readers and JS-aware crawlers (Googlebot). Pure-HTTP scrapers will see lang=el on /en/ pages, but the hreflang metadata (set in `[locale]/layout.js`) and OG locale tags remain correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)