### PR TITLE
docs(claude.md): update i18n section after #110 root-cause fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,37 +84,43 @@ unprefixed Greek-default entry points the middleware rewrites into the
 
 ## i18n calling convention (READ THIS BEFORE TOUCHING SERVER COMPONENTS)
 
-**Always pass `locale` explicitly to `getTranslations`:**
+The `<html>` element lives in `src/app/[locale]/layout.js` (not the root
+`src/app/layout.js`) so `lang={locale}` is set from `params` rather than from
+`getLocale()`. Calling `getLocale()` in the root layout poisoned next-intl's
+per-request config cache and made every `/en/*` route render Greek (PR #110;
+fixed at the root cause, replacing the band-aid in #109). The root layout is
+a minimal pass-through.
 
-```js
-const t = await getTranslations({ locale, namespace: 'student.gate' });
-```
+Conventions still in force:
 
-The bare form `getTranslations('namespace')` reads from next-intl's request
-scope, which under OpenNext on Workers can fall through to `defaultLocale: 'el'`
-when the component renders inside a redirect/guard branch — producing Greek
-copy on `/en/` routes. PR #48 fixed every known instance; #52 and #54 cleaned
-up two more. Synthetic check (#50) guards against recurrence.
+- **Always pass `locale` explicitly to `getTranslations`** in server
+  components, even though the request-scope path is now reliable:
 
-`AuthGate` takes `locale` as an explicit prop. Its JSDoc is the canonical
-explanation — copying verbatim from `src/components/AuthGate.js`:
+  ```js
+  const t = await getTranslations({ locale, namespace: 'student.gate' });
+  ```
 
-> `locale` must be passed explicitly by the caller. Bare
-> `getTranslations('namespace')` reads from next-intl's request scope, which
-> under OpenNext on Workers can fall through to `defaultLocale` ('el') for
-> components rendered inside a redirect/guard branch — producing Greek copy
-> on /en/ routes. The explicit `{ locale, namespace }` form is authoritative.
+  The explicit form is self-documenting at the call site and avoids
+  re-introducing dependence on the request scope. PR #48/#52/#54 fixed
+  every known leak of the bare form.
 
-When a server component receives `params`, also call `setRequestLocale(locale)`
-near the top — see `src/app/[locale]/listing/[id]/page.js` for the canonical
-pattern.
+- **`AuthGate` takes `locale` as an explicit prop.** Its JSDoc explains why
+  in detail — the short version: any component rendered inside a redirect
+  or guard branch should not assume request scope.
+
+- **When a server component receives `params`, call `setRequestLocale(locale)`
+  near the top** — see `src/app/[locale]/property/listing/[id]/page.js` for
+  the canonical pattern. With `<html>` now in `[locale]/layout.js`, this is
+  belt-and-braces rather than load-bearing, but stay in the habit.
+
+- **Synthetic canary `/api/cron/synthetic-en-listing` guards `/en` against
+  Greek leakage** on the listing detail page, the property homepage, and
+  the matching quiz (extended in PR #110). Add a check there if you build
+  a new locale-sensitive surface.
 
 ## OpenNext-on-Workers quirks
 
-1. **next-intl request scope is unreliable inside redirect/guard branches.**
-   See above. Always pass `{ locale, namespace }` explicitly.
-
-2. **Auth-touching pages don't get CDN caching, regardless of `next.config.mjs`.**
+1. **Auth-touching pages don't get CDN caching, regardless of `next.config.mjs`.**
    `next.config.mjs` declares `public, s-maxage=300, stale-while-revalidate=86400`
    for marketing routes and `private, no-cache, no-store, must-revalidate` for
    `/landlord/*`, `/listing/*`, `/student/*` (and their `/en/` counterparts).
@@ -123,7 +129,7 @@ pattern.
    config — OpenNext / Workers force-private any response from a route that
    touches request-scoped APIs (cookies, headers).
 
-3. **OpenNext v1.x doesn't ship a `scheduled` handler.** `cf/worker-entry.mjs`
+2. **OpenNext v1.x doesn't ship a `scheduled` handler.** `cf/worker-entry.mjs`
    wraps `.open-next/worker.js` to add one and re-exports the Durable Object
    classes (`DOQueueHandler`, `DOShardedTagCache`, `BucketCachePurge`) that
    Cloudflare requires at module top level.


### PR DESCRIPTION
## Summary

PR [#110](https://github.com/MichaelChar/StudentX/pull/110) moved \`<html>\` into \`[locale]/layout.js\`, eliminating the next-intl request-scope quirk that the previous CLAUDE.md guidance was working around. This update keeps the doc accurate so future sessions get correct mental models.

### Changes

- Replace the *"request scope is unreliable inside redirect/guard branches"* framing — the cause was \`getLocale()\` in the root layout, which is no longer present.
- Document the new structural fact: \`<html>\` lives in \`[locale]/layout.js\` so \`lang={locale}\` is sourced from \`params\`.
- Document the synthetic canary's expanded coverage (now also guards \`/en\` homepage and \`/en/property/quiz\`, not just \`/en/listing/[id]\`).
- Keep the *"always pass \`{locale, namespace}\` explicitly"* + AuthGate + \`setRequestLocale\` habits as belt-and-braces, but explain they're no longer load-bearing.
- Renumber the OpenNext quirks list (used to be 3 items, now 2 since #1 is fixed).

## Verification

Smoke-tested prod \`/en/*\` after #110 deployed:
- \`https://studentx.uk/en/property/listing/0100006\` → \`<html lang="en">\`, EN copy, no Greek leakage
- \`https://studentx.uk/en/property/quiz\` → \`<html lang="en">\`, "One minute", no \"Ένα λεπτό\"
- \`https://studentx.uk/en/property\` → \`<html lang="en">\`, \"Take the quiz\"

The fix is fully live in prod.

## Test plan

- [ ] CI green (lint + tests + build — no code changes, should pass trivially)

🤖 Generated with [Claude Code](https://claude.com/claude-code)