### PR TITLE
perf(listings-api): push amenity filter + verified-tier sort to SQL

### DIFF
--- a/src/app/api/listings/route.js
+++ b/src/app/api/listings/route.js
@@ -13,7 +13,7 @@ const LISTING_SELECT = `
   rent!inner ( monthly_price, currency, bills_included, deposit ),
   location!inner ( address, neighborhood, lat, lng ),
   property_types!inner ( name ),
-  landlords!inner ( name, contact_info, verified_tier, is_verified ),
+  landlords!inner ( name, contact_info, verified_tier, is_verified, verified_tier_rank ),
   listing_amenities ( amenities ( amenity_id, name ) ),
   faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
 `;
@@ -112,8 +112,37 @@ export async function GET(request) {
       );
     }
 
+    // Amenity AND-filter: resolve qualifying listing_ids via SQL RPC
+    let amenityListingIds = null;
+    let amenityRpcFailed = false;
+
+    if (excludeAmenities) {
+      const required = excludeAmenities.split(",").map((a) => a.trim());
+      const { data: rows, error: rpcErr } = await getSupabase()
+        .rpc("listings_with_all_amenities", { p_amenity_names: required });
+
+      if (rpcErr) {
+        console.warn("listings_with_all_amenities RPC unavailable, falling back to JS:", rpcErr.message);
+        amenityRpcFailed = true;
+      } else if (!rows || rows.length === 0) {
+        const response = NextResponse.json({ listings: [] });
+        response.headers.set(
+          "Cache-Control",
+          "public, s-maxage=300, stale-while-revalidate=600"
+        );
+        return response;
+      } else {
+        amenityListingIds = rows.map((r) => r.listing_id);
+      }
+    }
+
     // Build query
+    let usedFallback = false;
     let query = getSupabase().from("listings").select(LISTING_SELECT);
+
+    if (amenityListingIds) {
+      query = query.in("listing_id", amenityListingIds);
+    }
 
     // Filter: min budget
     if (minBudget) {
@@ -189,13 +218,27 @@ export async function GET(request) {
       query = query.or("floor.is.null,floor.neq.0");
     }
 
+    // SQL-level sort: tier rank → featured → user-chosen metric
+    query = query
+      .order('landlords(verified_tier_rank)', { ascending: true })
+      .order('is_featured', { ascending: false });
+
+    if (sortBy === 'price') {
+      query = query.order('rent(monthly_price)', {
+        ascending: sortOrder === 'asc',
+        nullsFirst: false,
+      });
+    }
+
     let { data, error } = await query;
 
-    // If query fails (e.g. verified_tier column not yet migrated), retry without it
+    // If query fails (e.g. verified_tier_rank column not yet migrated), retry without it
     if (error) {
       console.warn("Listings query failed, retrying without verified_tier:", error.message);
+      usedFallback = true;
       let fallbackQuery = getSupabase().from("listings").select(LISTING_SELECT_FALLBACK);
 
+      if (amenityListingIds) fallbackQuery = fallbackQuery.in("listing_id", amenityListingIds);
       if (minBudget) fallbackQuery = fallbackQuery.gte("rent.monthly_price", Number(minBudget));
       if (maxBudget) fallbackQuery = fallbackQuery.lte("rent.monthly_price", Number(maxBudget));
       if (neighborhoods) {
@@ -233,9 +276,8 @@ export async function GET(request) {
       });
     }
 
-    // Post-query filter: exclude listings missing required amenities (dealbreakers)
-    // e.g. exclude_amenities=AC,Elevator → only keep listings that have ALL of these
-    if (excludeAmenities) {
+    // Amenity AND-filter fallback: only needed when the SQL RPC was unavailable
+    if (excludeAmenities && amenityRpcFailed) {
       const required = excludeAmenities.split(",").map((a) => a.trim().toLowerCase());
       results = results.filter((listing) => {
         const has = listing.amenities.map((a) => a.toLowerCase());
@@ -243,37 +285,39 @@ export async function GET(request) {
       });
     }
 
-    // Sort: verified_pro first, then verified, then free; within each tier by chosen sort field
-    const tierRank = { verified_pro: 0, verified: 1, none: 2 };
-    results.sort((a, b) => {
-      // Verified tier takes priority
-      const rankA = tierRank[a.verified_tier] ?? 2;
-      const rankB = tierRank[b.verified_tier] ?? 2;
-      if (rankA !== rankB) return rankA - rankB;
+    // Sort: SQL handles tier rank → featured → price for sortBy=price.
+    // Walk/transit need JS because faculty_distances is a to-many join.
+    // Fallback path always needs JS (no .order() was applied).
+    if (usedFallback || sortBy !== "price") {
+      const tierRank = { verified_pro: 0, verified: 1, none: 2 };
+      results.sort((a, b) => {
+        const rankA = tierRank[a.verified_tier] ?? 2;
+        const rankB = tierRank[b.verified_tier] ?? 2;
+        if (rankA !== rankB) return rankA - rankB;
 
-      // Featured listings next
-      if (a.is_featured && !b.is_featured) return -1;
-      if (!a.is_featured && b.is_featured) return 1;
+        if (a.is_featured && !b.is_featured) return -1;
+        if (!a.is_featured && b.is_featured) return 1;
 
-      let valA, valB;
+        let valA, valB;
 
-      if (sortBy === "price") {
-        valA = a.monthly_price;
-        valB = b.monthly_price;
-      } else if (sortBy === "walk_minutes") {
-        valA = a.faculty_distances[0]?.walk_minutes ?? null;
-        valB = b.faculty_distances[0]?.walk_minutes ?? null;
-      } else if (sortBy === "transit_minutes") {
-        valA = a.faculty_distances[0]?.transit_minutes ?? null;
-        valB = b.faculty_distances[0]?.transit_minutes ?? null;
-      }
+        if (sortBy === "price") {
+          valA = a.monthly_price;
+          valB = b.monthly_price;
+        } else if (sortBy === "walk_minutes") {
+          valA = a.faculty_distances[0]?.walk_minutes ?? null;
+          valB = b.faculty_distances[0]?.walk_minutes ?? null;
+        } else if (sortBy === "transit_minutes") {
+          valA = a.faculty_distances[0]?.transit_minutes ?? null;
+          valB = b.faculty_distances[0]?.transit_minutes ?? null;
+        }
 
-      if (valA == null && valB == null) return 0;
-      if (valA == null) return 1;
-      if (valB == null) return -1;
+        if (valA == null && valB == null) return 0;
+        if (valA == null) return 1;
+        if (valB == null) return -1;
 
-      return sortOrder === "desc" ? valB - valA : valA - valB;
-    });
+        return sortOrder === "desc" ? valB - valA : valA - valB;
+      });
+    }
 
     const response = NextResponse.json({ listings: results });
     response.headers.set(

--- a/supabase/migrations/041_amenity_filter_rpc.sql
+++ b/supabase/migrations/041_amenity_filter_rpc.sql
@@ -1,0 +1,30 @@
+-- 041: RPC for AND-filtering listings by amenity names
+--
+-- Pushes the "has ALL of these amenities" filter from JS post-fetch
+-- into a SQL function callable via supabase.rpc(). The route chains
+-- the returned listing_id set with .in() on the existing PostgREST
+-- query, so only qualifying rows are fetched.
+
+CREATE OR REPLACE FUNCTION public.listings_with_all_amenities(
+  p_amenity_names TEXT[]
+)
+RETURNS TABLE (listing_id TEXT)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+  SELECT la.listing_id
+  FROM listing_amenities la
+  JOIN amenities a ON a.amenity_id = la.amenity_id
+  WHERE lower(a.name) = ANY (
+    SELECT lower(unnest) FROM unnest(p_amenity_names)
+  )
+  GROUP BY la.listing_id
+  HAVING count(DISTINCT lower(a.name)) = (
+    SELECT count(DISTINCT lower(unnest)) FROM unnest(p_amenity_names)
+  )
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.listings_with_all_amenities(TEXT[])
+  TO anon, authenticated;

--- a/supabase/migrations/042_verified_tier_rank.sql
+++ b/supabase/migrations/042_verified_tier_rank.sql
@@ -1,0 +1,18 @@
+-- 042: Add verified_tier_rank generated column to landlords
+--
+-- Enables SQL-level sorting by verification tier via PostgREST's
+-- referenced_table(col) ordering syntax. Auto-computes from
+-- verified_tier on INSERT/UPDATE.
+
+ALTER TABLE landlords
+  ADD COLUMN IF NOT EXISTS verified_tier_rank SMALLINT
+  GENERATED ALWAYS AS (
+    CASE verified_tier
+      WHEN 'verified_pro' THEN 0
+      WHEN 'verified'     THEN 1
+      ELSE 2
+    END
+  ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_landlords_tier_rank
+  ON landlords (verified_tier_rank ASC);

--- a/supabase/migrations/042_verified_tier_rank.sql
+++ b/supabase/migrations/042_verified_tier_rank.sql
@@ -4,6 +4,14 @@
 -- referenced_table(col) ordering syntax. Auto-computes from
 -- verified_tier on INSERT/UPDATE.
 
+-- Ensure verified_tier exists. Production has it via APPLY_004_to_012.sql,
+-- but CI's local Supabase stack skips that file (filename does not match
+-- the numbered <prefix>_name.sql pattern), so the column would be absent
+-- when this migration runs against a fresh CI database.
+ALTER TABLE landlords
+  ADD COLUMN IF NOT EXISTS verified_tier TEXT DEFAULT 'none'
+    CHECK (verified_tier IN ('none', 'verified', 'verified_pro'));
+
 ALTER TABLE landlords
   ADD COLUMN IF NOT EXISTS verified_tier_rank SMALLINT
   GENERATED ALWAYS AS (


### PR DESCRIPTION
## Summary

- **Amenity AND-filter → SQL RPC** (migration 041): new `listings_with_all_amenities` function resolves qualifying `listing_id` values in Postgres via relational division (`GROUP BY / HAVING COUNT`), then chains `.in("listing_id", ids)` on the PostgREST query. Only matching rows are fetched instead of filtering all rows in JS post-fetch. Falls back to the existing JS filter if the RPC is not yet deployed.
- **Verified-tier sort → SQL** (migration 042): new `verified_tier_rank SMALLINT GENERATED ALWAYS AS (CASE ...)` column on `landlords` enables PostgREST `.order()` via the `referenced_table(col)` syntax. For `sort_by=price`, all three sort levels (tier rank → featured → price) are handled in SQL. Walk/transit sorts keep a JS tiebreaker because `faculty_distances` is a to-many join.

Closes the deferred work from the earlier perf pass.

## Migrations

Both migrations must be applied to prod **before** merging (per CLAUDE.md convention):
- `041_amenity_filter_rpc.sql` — RPC function + GRANT
- `042_verified_tier_rank.sql` — generated column + index

## Test plan

- [ ] Apply migrations to prod
- [ ] `curl /api/listings?exclude_amenities=AC,Furnished` — verify only listings with both amenities are returned
- [ ] `curl /api/listings?exclude_amenities=NonexistentAmenity` — verify empty `{ listings: [] }`
- [ ] `curl /api/listings?sort_by=price&sort_order=asc` — verify tier-rank → featured → price ordering
- [ ] `curl /api/listings?sort_by=walk_minutes&faculty=auth-library` — verify distance tiebreaker
- [ ] Verify fallback path works when migrations are not applied (tested locally — logs show graceful degradation)
- [ ] `npm run test` — 101 tests pass
- [ ] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)