### PR TITLE
fix(emails): drop redundant footnote lines from founding welcome templates

### DIFF
--- a/src/templates/email/foundingCohortWelcome.js
+++ b/src/templates/email/foundingCohortWelcome.js
@@ -56,9 +56,6 @@ export function foundingCohortWelcomeHtml({
                   </td>
                 </tr>
               </table>
-              <p style="margin:0;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#999;line-height:1.5;">
-                ${copy.footnote}
-              </p>
             </td>
           </tr>
           <tr>
@@ -95,8 +92,6 @@ const COPY = {
     unlockBody:
       'Ενεργοποίησε τη συνδρομή SuperLandlord και ολοκλήρωσε την ταυτοποίηση. Όσο και τα δύο είναι ενεργά, οι αγγελίες σου θα φέρουν το σήμα Founding Member — αναγνωρίσιμο από κάθε φοιτητή που μας επισκέπτεται.',
     cta: 'Ενεργοποίησε SuperLandlord',
-    footnote:
-      'Το σήμα Founding Member απονέμεται στους πρώτους πενήντα επαληθευμένους ιδιοκτήτες και διατηρείται όσο η συνδρομή σου είναι ενεργή.',
     subject: 'Καλώς ήρθες στην ιδρυτική ομάδα — είσαι ο #{rank}',
   },
   en: {
@@ -112,8 +107,6 @@ const COPY = {
     unlockBody:
       'Activate a SuperLandlord subscription and complete identity verification. While both are active, your listings will display the Founding Member badge — visible to every student who browses StudentX.',
     cta: 'Activate SuperLandlord',
-    footnote:
-      'The Founding Member badge is awarded to the first fifty verified landlords and stays as long as your subscription remains active.',
     subject: "Welcome to the founding cohort — you're member #{rank}",
   },
 };

--- a/src/templates/email/foundingFiveWelcome.js
+++ b/src/templates/email/foundingFiveWelcome.js
@@ -56,7 +56,6 @@ export function foundingFiveWelcomeHtml({
                   <td style="padding:20px 24px;text-align:center;">
                     <p style="margin:0 0 4px;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:11px;font-weight:700;letter-spacing:0.18em;text-transform:uppercase;color:#B8860B;">${copy.codeLabel}</p>
                     <p style="margin:0;font-family:'EB Garamond',Garamond,Georgia,'Times New Roman',serif;font-size:28px;font-weight:600;color:#FAF8F3;letter-spacing:0.04em;">${promoCode}</p>
-                    <p style="margin:8px 0 0;font-family:'Source Sans 3','Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#FAF8F3B3;line-height:1.5;">${copy.codeBody}</p>
                   </td>
                 </tr>
               </table>
@@ -105,7 +104,6 @@ const COPY = {
     body2:
       'Ως μέλος της Founding Five, η συνδρομή σου SuperLandlord για τον πρώτο χρόνο γίνεται από €49 → €9,80 με τον παρακάτω κωδικό. Πέρασέ τον στο πεδίο "Add promotion code" κατά το checkout.',
     codeLabel: 'Κωδικός Founding Five',
-    codeBody: 'Εφαρμόζεται μόνο στην πρώτη χρονιά. Ανανέωση στην πλήρη τιμή κατόπιν.',
     cta: 'Ενεργοποίησε SuperLandlord',
     footnote:
       'Μετά την ενεργοποίηση, ανέβασε ταυτότητα στο Verification για να ξεκλειδώσεις το σήμα Founding Member πάνω από τις αγγελίες σου.',
@@ -123,7 +121,6 @@ const COPY = {
     body2:
       "As a Founding Five member, your first-year SuperLandlord subscription drops from €49 → €9.80 with the code below. Paste it into the \"Add promotion code\" field at checkout.",
     codeLabel: 'Founding Five code',
-    codeBody: "Applies to your first year only. Renews at full price after that.",
     cta: 'Activate SuperLandlord',
     footnote:
       'After activation, upload an ID on the Verification page to unlock the Founding Member badge on your listings.',


### PR DESCRIPTION
## Summary

- Removes "Applies to your first year only. Renews at full price after that." from the Founding Five welcome email (EL + EN).
- Removes "The Founding Member badge is awarded to the first fifty verified landlords and stays as long as your subscription remains active." from the Founding Cohort welcome email (EL + EN).

Per stakeholder direction — the body copy already covers what the recipient needs to act on, and these closing lines weakened the tone.

## Diff scope

10 lines deleted across 2 files (`src/templates/email/founding{Five,Cohort}Welcome.js`). No logic changes — just copy + the corresponding `<p>` removal. Subject lines, body copy, CTAs, and the Founding Five "After activation, upload an ID..." footnote (different line) are all preserved.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test` — 101/101 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)