### PR TITLE
refactor(ui): move globe animation to hub→thessaloniki; BauhausLoader after quiz

### DIFF
--- a/src/app/[locale]/property/[city]/results/page.js
+++ b/src/app/[locale]/property/[city]/results/page.js
@@ -11,7 +11,7 @@ import SaveSearchModal from '@/components/SaveSearchModal';
 import Button from '@/components/ui/Button';
 import Pill from '@/components/ui/Pill';
 import Icon from '@/components/ui/Icon';
-import GlobeLoader from '@/components/GlobeLoader';
+import BauhausLoader from '@/components/BauhausLoader';
 
 /*
   Propylaea results page — matches page 06 of the reference design.
@@ -67,24 +67,12 @@ function ResultsContent() {
   const [listings, setListings] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
-  // Globe loader (post-quiz transition). Shown only when arriving with quiz
-  // params (budget/types/neighborhoods present) on first mount of the page —
-  // never on filter-driven re-fetches. Sequence runs ~6.5s; we hide the
-  // loader only after the animation completes AND listings are loaded so
-  // there's no jarring skeleton flash mid-zoom. We resolve `showLoader` in
-  // an effect (not the initializer) so SSR doesn't lock us into `false`.
-  const [loaderDone, setLoaderDone] = useState(false);
+  // Post-quiz loader. Shown only when arriving with quiz params
+  // (budget/types/neighborhoods) on first mount — never on filter re-fetches.
   const [showLoader, setShowLoader] = useState(false);
   const loaderDecidedRef = useRef(false);
-  // One-time loader-gate decision based on URL params at mount. We
-  // INTENTIONALLY don't use a `useState(() => ...)` lazy initializer
-  // here because that would run server-side too — `typeof window` is
-  // undefined during SSR, so the lazy init returns `false`, but the
-  // client run returns `true` for users coming from the quiz, causing
-  // a hydration mismatch warning + layout flash. useEffect defers the
-  // decision to AFTER hydration, so SSR + first client paint agree on
-  // `false` and the loader fades in cleanly. See the line-72 comment
-  // above for the broader sequencing rationale.
+  // Deferred to useEffect (not useState initializer) to avoid SSR/client
+  // hydration mismatch — see loaderDecidedRef guard.
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (loaderDecidedRef.current) return;
@@ -225,15 +213,17 @@ function ResultsContent() {
     }));
   }
 
-  // Show loader as a full-screen overlay until BOTH animation completes
-  // AND the initial listings fetch has finished. Both conditions guard
-  // against jank: the loader hides only when there's something legible
-  // to reveal beneath it.
-  const loaderVisible = showLoader && (!loaderDone || loading);
+  const loaderVisible = showLoader && loading;
 
   return (
     <div className="mx-auto max-w-7xl px-5 py-10 md:py-14">
-      {loaderVisible && <GlobeLoader onComplete={() => setLoaderDone(true)} />}
+      {loaderVisible && (
+        <BauhausLoader
+          mode="overlay"
+          eyebrow={t('eyebrow')}
+          statuses={[t('titleLoading')]}
+        />
+      )}
       {/* Header row */}
       <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 mb-10">
         <div>

--- a/src/components/property/HubDiagram.js
+++ b/src/components/property/HubDiagram.js
@@ -1,9 +1,12 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRouter } from '@/i18n/navigation';
+import dynamic from 'next/dynamic';
 import { COUNTRIES, propertyHref } from '@/lib/cityRoutes';
+
+const GlobeLoader = dynamic(() => import('@/components/GlobeLoader'), { ssr: false });
 
 // Multi-country hub diagram — port of `NeuralNetLanding` (stripe theme
 // only) from the Claude Design wireframe bundle. Renders the
@@ -69,6 +72,7 @@ export default function HubDiagram() {
   const router = useRouter();
   const [hovered, setHovered] = useState(null);
   const [search, setSearch] = useState('');
+  const [globeLoading, setGlobeLoading] = useState(false);
 
   // Order countries; append per-country ghost row ("coming soon…") for
   // any non-Greek country with no second city yet. Ghost rows are
@@ -145,9 +149,17 @@ export default function HubDiagram() {
   const isCountryCityActive = (cc, slug) =>
     activeCity && activeCity.country.code === cc && activeCity.slug === slug;
 
+  const handleGlobeComplete = useCallback(() => {
+    router.push(propertyHref('thessaloniki'));
+  }, [router]);
+
   const onCityClick = (city) => {
     if (!city.clickable && city.clickable !== undefined) return;
     if (city.ghost) return;
+    if (city.slug === 'thessaloniki') {
+      setGlobeLoading(true);
+      return;
+    }
     router.push(propertyHref(city.slug));
   };
 
@@ -533,6 +545,7 @@ export default function HubDiagram() {
           )}
         </div>
       </div>
+      {globeLoading && <GlobeLoader onComplete={handleGlobeComplete} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Moves the globe spin/zoom-to-Thessaloniki animation from the post-quiz results page to the hub → Thessaloniki transition (thematic fit: "arriving at the city")
- Post-quiz results now use the standard `BauhausLoader` overlay, which dismisses as soon as listings load instead of holding for a fixed ~8s

## Changes

**`src/components/property/HubDiagram.js`**
- Thessaloniki click → show `GlobeLoader` overlay → `router.push` on completion. Other cities navigate immediately.
- `GlobeLoader` is `dynamic()`-imported so the ~105KB topojson and D3 code stay out of the hub bundle.

**`src/app/[locale]/property/[city]/results/page.js`**
- Swap `GlobeLoader` → `BauhausLoader` (overlay mode, eyebrow `"YOUR MATCHES"`, status `"Finding your matches"`)
- Drop `loaderDone` state and the `(!loaderDone || loading)` gate — `BauhausLoader` loops indefinitely, so visibility now keys off `loading` alone.
- Quiz-param detection (`loaderDecidedRef`, `showLoader`) unchanged.

## Test plan

- [x] `/property` → click Thessaloniki → globe animates → navigates to `/property/thessaloniki`
- [x] `/property/thessaloniki/results?budget=500&types=Studio` → `BauhausLoader` overlay shows then dismisses on fetch completion
- [x] `/property/thessaloniki/results` (no quiz params) → no loader, listings render directly
- [x] `npm run lint` passes
- [ ] Coming-soon city click (Athens/London/Dublin) — still navigates instantly (unchanged code path)
- [ ] `prefers-reduced-motion: reduce` on hub click → near-instant navigation (handled by `GlobeLoader`'s existing 200ms reduced-motion path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)