### PR TITLE
feat(chat): student-side message digest emails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,7 @@ Current crons (verified against `wrangler.jsonc` and `cf/worker-entry.mjs`):
 | `0 9 * * 1`     | `/api/cron/saved-searches-digest?frequency=weekly` | Weekly saved-search digest (Monday) |
 | `15 9 * * *`    | `/api/cron/recompute-distances`                    | Heal missing `faculty_distances` rows (PR #60) |
 | `*/5 * * * *`   | `/api/cron/landlord-message-digest`                | Per-message landlord digest |
+| `2-58/5 * * * *` | `/api/cron/student-message-digest`               | Per-message student digest (mirror of landlord, offset 2 min) |
 | `*/15 * * * *`  | `/api/cron/synthetic-en-listing`                   | i18n regression guard (issue #49) |
 
 Adding a new cron is a one-line entry in each table.
@@ -257,6 +258,7 @@ Outbound paths sending from `alerts@studentx.uk`:
 - Synthetic check alerts (`/api/cron/synthetic-en-listing`)
 - Saved-searches digest (`/api/cron/saved-searches-digest`)
 - Landlord message digest (`/api/cron/landlord-message-digest`)
+- Student message digest (`/api/cron/student-message-digest`)
 - Inquiry notifications (`src/lib/inquiryEmail.js`)
 - Subscription welcome (`src/lib/subscriptionEmail.js`)
 

--- a/cf/worker-entry.mjs
+++ b/cf/worker-entry.mjs
@@ -23,6 +23,7 @@ const CRON_ROUTES = {
   "0 9 * * 1":    { name: "saved-searches-weekly",  path: "/api/cron/saved-searches-digest",   query: "frequency=weekly" },
   "15 9 * * *":   { name: "recompute-distances",    path: "/api/cron/recompute-distances",     query: null },
   "*/5 * * * *":  { name: "landlord-message-digest", path: "/api/cron/landlord-message-digest", query: null },
+  "2-58/5 * * * *": { name: "student-message-digest", path: "/api/cron/student-message-digest", query: null },
   "*/15 * * * *": { name: "synthetic-en-listing",   path: "/api/cron/synthetic-en-listing",    query: null },
 };
 

--- a/src/app/api/cron/student-message-digest/route.js
+++ b/src/app/api/cron/student-message-digest/route.js
@@ -1,0 +1,154 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { getResend } from '@/lib/resend';
+import { isEmailSuppressed } from '@/lib/emailSuppressions';
+import {
+  studentMessageDigestHtml,
+  studentMessageDigestSubject,
+} from '@/templates/email/studentMessageDigest';
+
+// Service-role client: the digest RPCs are SECURITY DEFINER and granted
+// to anon/authenticated, but we use the service-role key here to keep
+// the cron context off the auth cookie path entirely. Mirrors the
+// landlord-message-digest route.
+function getServiceSupabase() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+    { auth: { persistSession: false } },
+  );
+}
+
+// Debounce window. One email per inquiry per this interval. Slightly
+// tighter than the cron tick (5 min) so a tick that runs a few seconds
+// late doesn't get rejected by its own previous run, but wide enough
+// to absorb a burst of landlord messages into a single email.
+const MIN_INTERVAL = '4 minutes 30 seconds';
+
+const FROM_ADDRESS = 'StudentX <alerts@studentx.uk>';
+
+function isCronAuthorized(request) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  const headerSecret = request.headers.get('x-cron-secret');
+  if (headerSecret === secret) return true;
+  const { searchParams } = new URL(request.url);
+  return searchParams.get('secret') === secret;
+}
+
+function resolveLocale(studentLocale) {
+  if (studentLocale === 'el' || studentLocale === 'en') return studentLocale;
+  return 'el';
+}
+
+export async function POST(request) {
+  if (!isCronAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Kill switch: deploy-time disable without removing the cron trigger.
+  if (process.env.STUDENT_DIGEST_ENABLED === 'false') {
+    return NextResponse.json({ skipped: 'disabled' });
+  }
+
+  const supabase = getServiceSupabase();
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://studentx.uk';
+
+  const { data: pending, error: fetchError } = await supabase.rpc(
+    'get_pending_student_notifications',
+    { p_min_interval: MIN_INTERVAL },
+  );
+
+  if (fetchError) {
+    console.error('[student-digest] failed to fetch pending notifications:', fetchError);
+    return NextResponse.json({ error: 'Failed to fetch pending notifications' }, { status: 500 });
+  }
+
+  if (!pending || pending.length === 0) {
+    return NextResponse.json({ processed: 0, emailsSent: 0, alreadyClaimed: 0 });
+  }
+
+  const resend = getResend();
+  let emailsSent = 0;
+  let alreadyClaimed = 0;
+  let failures = 0;
+
+  for (const row of pending) {
+    try {
+      // Claim BEFORE Resend send: conditional UPSERT, only one caller
+      // per (inquiry, period) advances last_notified_at. Concurrent /
+      // retried callers get false and skip silently.
+      const { data: claimed, error: claimError } = await supabase.rpc(
+        'claim_student_message_notification',
+        {
+          p_inquiry_id: row.inquiry_id,
+          p_min_interval: MIN_INTERVAL,
+          p_unread_count: row.unread_count,
+        },
+      );
+
+      if (claimError) {
+        console.error(
+          `[student-digest] claim_student_message_notification failed for ${row.inquiry_id}:`,
+          claimError,
+        );
+        failures++;
+        continue;
+      }
+      if (!claimed) {
+        alreadyClaimed++;
+        continue;
+      }
+
+      // From here on the claim is committed: a Resend failure means
+      // this digest is lost for this period. Same tradeoff as the
+      // landlord digest — missing one email beats double-sending.
+      const locale = resolveLocale(row.student_locale);
+
+      if (await isEmailSuppressed(row.student_email)) {
+        console.warn(
+          `[student-digest] skipping send — ${row.student_email} is suppressed`,
+        );
+        continue;
+      }
+
+      await resend.emails.send({
+        from: FROM_ADDRESS,
+        to: row.student_email,
+        subject: studentMessageDigestSubject(
+          row.landlord_display_name,
+          row.unread_count,
+          locale,
+        ),
+        html: studentMessageDigestHtml({
+          studentName: row.student_name,
+          landlordName: row.landlord_display_name,
+          listing: {
+            listing_id: row.listing_id,
+            address: row.listing_address,
+            neighborhood: row.listing_neighborhood,
+            monthly_price: row.listing_monthly_price,
+          },
+          unreadCount: row.unread_count,
+          snippet: row.latest_message_body,
+          appUrl,
+          inquiryId: row.inquiry_id,
+          locale,
+        }),
+      });
+
+      emailsSent++;
+    } catch (err) {
+      console.error(`[student-digest] error processing inquiry ${row?.inquiry_id}:`, err);
+      failures++;
+      // Continue with next inquiry — one bad row must not abort the run.
+    }
+  }
+
+  return NextResponse.json({
+    processed: pending.length,
+    emailsSent,
+    alreadyClaimed,
+    failures,
+  });
+}

--- a/src/templates/email/studentMessageDigest.js
+++ b/src/templates/email/studentMessageDigest.js
@@ -1,0 +1,230 @@
+/**
+ * Email sent to a student when one or more unread chat messages from
+ * a landlord have been waiting past the debounce window. One email per
+ * inquiry per N minutes (see /api/cron/student-message-digest).
+ *
+ * Mirror of landlordMessageDigest.js, inverted: that one notifies the
+ * landlord about student messages; this one notifies the student about
+ * landlord replies. Strings live under `landlord.notifications.*` —
+ * the namespace tracks the *actor* writing the message (the landlord
+ * here), not the recipient. Same convention as the landlord-bound
+ * template using `student.notifications.*`.
+ *
+ * @param {object} params
+ * @param {string} params.studentName
+ * @param {string} params.landlordName
+ * @param {object} params.listing - { listing_id, address?, neighborhood?, monthly_price? }
+ * @param {number} params.unreadCount
+ * @param {string} params.snippet - Most recent unread message body
+ * @param {string} params.appUrl
+ * @param {string} params.inquiryId
+ * @param {'el'|'en'} [params.locale='el']
+ */
+
+const STRINGS = {
+  el: {
+    htmlLang: 'el',
+    'landlord.notifications.titleTag': 'Νέα μηνύματα στη συνομιλία σου',
+    'landlord.notifications.headerTagline': 'Φοιτητική στέγαση · Θεσσαλονίκη',
+    'landlord.notifications.heading': (count, name) =>
+      count === 1
+        ? `Νέο μήνυμα από ${name}`
+        : `${count} νέα μηνύματα από ${name}`,
+    'landlord.notifications.greetingFallback': 'εσένα',
+    'landlord.notifications.intro': (greeting, count, name, summary) => {
+      const noun = count === 1 ? 'ένα αδιάβαστο μήνυμα' : `${count} αδιάβαστα μηνύματα`;
+      const tail = summary
+        ? ` σχετικά με την αγγελία <strong style="color:#0a2540;">${summary}</strong>`
+        : '';
+      return `Γεια ${greeting}, έχεις ${noun} από τον/την ιδιοκτήτη/τρια ${name}${tail}.`;
+    },
+    'landlord.notifications.snippetLabel': 'Πιο πρόσφατο μήνυμα',
+    'landlord.notifications.cta': 'Άνοιγμα συνομιλίας',
+    'landlord.notifications.inboxButton': 'Όλες οι συνομιλίες μου',
+    'landlord.notifications.viewListing': 'Δες την αγγελία →',
+    'landlord.notifications.footerLine1':
+      'StudentX · Κατάλογος φοιτητικής στέγης για τη Θεσσαλονίκη',
+    'landlord.notifications.footerLine2':
+      'Λαμβάνεις αυτό το email επειδή ένας ιδιοκτήτης σου απάντησε στο StudentX.',
+    'landlord.notifications.footerLine3':
+      'Ανοίγουμε ένα email κάθε λίγα λεπτά όταν έχεις αδιάβαστα μηνύματα — όχι ένα ανά μήνυμα.',
+    'landlord.notifications.subjectOne': (name) => `Νέο μήνυμα από ${name} · StudentX`,
+    'landlord.notifications.subjectMany': (count, name) =>
+      `${count} νέα μηνύματα από ${name} · StudentX`,
+    'landlord.notifications.subjectFallbackName': 'τον ιδιοκτήτη',
+    'landlord.notifications.pricePerMonth': (n) => `€${n}/μήνα`,
+  },
+  en: {
+    htmlLang: 'en',
+    'landlord.notifications.titleTag': 'New messages in your conversation',
+    'landlord.notifications.headerTagline': 'Student Housing · Thessaloniki',
+    'landlord.notifications.heading': (count, name) =>
+      count === 1
+        ? `New message from ${name}`
+        : `${count} new messages from ${name}`,
+    'landlord.notifications.greetingFallback': 'there',
+    'landlord.notifications.intro': (greeting, count, name, summary) => {
+      const noun = count === 1 ? 'one unread message' : `${count} unread messages`;
+      const tail = summary
+        ? ` about <strong style="color:#0a2540;">${summary}</strong>`
+        : '';
+      return `Hi ${greeting}, you have ${noun} from your landlord ${name}${tail}.`;
+    },
+    'landlord.notifications.snippetLabel': 'Latest message',
+    'landlord.notifications.cta': 'Open conversation',
+    'landlord.notifications.inboxButton': 'All my inquiries',
+    'landlord.notifications.viewListing': 'View listing →',
+    'landlord.notifications.footerLine1':
+      'StudentX · Student housing directory for Thessaloniki, Greece',
+    'landlord.notifications.footerLine2':
+      "You're receiving this because a landlord replied to you on StudentX.",
+    'landlord.notifications.footerLine3':
+      'We bundle messages into one email every few minutes instead of one per message.',
+    'landlord.notifications.subjectOne': (name) => `New message from ${name} · StudentX`,
+    'landlord.notifications.subjectMany': (count, name) =>
+      `${count} new messages from ${name} · StudentX`,
+    'landlord.notifications.subjectFallbackName': 'your landlord',
+    'landlord.notifications.pricePerMonth': (n) => `€${n}/mo`,
+  },
+};
+
+function pickStrings(locale) {
+  return STRINGS[locale] || STRINGS.el;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function localePrefix(locale) {
+  return locale === 'en' ? '/en' : '';
+}
+
+export function studentMessageDigestSubject(landlordName, unreadCount, locale = 'el') {
+  const s = pickStrings(locale);
+  const trimmed = (landlordName || '').trim() || s['landlord.notifications.subjectFallbackName'];
+  return unreadCount === 1
+    ? s['landlord.notifications.subjectOne'](trimmed)
+    : s['landlord.notifications.subjectMany'](unreadCount, trimmed);
+}
+
+export function studentMessageDigestHtml({
+  studentName,
+  landlordName,
+  listing,
+  unreadCount,
+  snippet,
+  appUrl,
+  inquiryId,
+  locale = 'el',
+}) {
+  const s = pickStrings(locale);
+  const safeLandlord = escapeHtml(landlordName || s['landlord.notifications.subjectFallbackName']);
+  const safeGreeting = studentName
+    ? escapeHtml(studentName)
+    : s['landlord.notifications.greetingFallback'];
+  const safeAddress = listing?.address ? escapeHtml(listing.address) : '';
+  const safeNeighborhood = listing?.neighborhood ? escapeHtml(listing.neighborhood) : '';
+  const safePrice = listing?.monthly_price
+    ? s['landlord.notifications.pricePerMonth'](Number(listing.monthly_price))
+    : '';
+  const listingSummary = [safeAddress, safeNeighborhood, safePrice].filter(Boolean).join(' · ');
+  const safeSnippet = snippet ? escapeHtml(snippet).replace(/\n/g, '<br/>') : '';
+
+  const prefix = localePrefix(locale);
+  const chatUrl = `${appUrl}${prefix}/student/inquiries/${inquiryId}`;
+  const inboxUrl = `${appUrl}${prefix}/student/account`;
+  const listingUrl = listing?.listing_id
+    ? `${appUrl}${prefix}/property/thessaloniki/listing/${listing.listing_id}`
+    : null;
+
+  const heading = s['landlord.notifications.heading'](unreadCount, safeLandlord);
+  const intro = s['landlord.notifications.intro'](
+    safeGreeting,
+    unreadCount,
+    safeLandlord,
+    listingSummary,
+  );
+
+  return `<!DOCTYPE html>
+<html lang="${s.htmlLang}">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${s['landlord.notifications.titleTag']}</title>
+</head>
+<body style="margin:0;padding:0;background:#f6f4ff;font-family:Georgia,serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f6f4ff;padding:40px 16px;">
+    <tr>
+      <td align="center">
+        <table width="560" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;border:1px solid #e6eaef;">
+          <!-- Header -->
+          <tr>
+            <td style="background:#0a2540;padding:24px 32px;">
+              <p style="margin:0;font-family:'Helvetica Neue',sans-serif;font-size:11px;font-weight:700;letter-spacing:0.15em;text-transform:uppercase;color:#ffcb57;">StudentX</p>
+              <p style="margin:4px 0 0;font-family:'Helvetica Neue',sans-serif;font-size:11px;color:#ffffff80;">${s['landlord.notifications.headerTagline']}</p>
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding:32px;">
+              <h1 style="margin:0 0 8px;font-family:'Helvetica Neue',sans-serif;font-size:22px;font-weight:700;color:#0a2540;">${heading}</h1>
+              <p style="margin:0 0 24px;font-size:15px;color:#0a2540;line-height:1.6;">
+                ${intro}
+              </p>
+
+              ${
+                safeSnippet
+                  ? `
+              <!-- Snippet -->
+              <p style="margin:0 0 6px;font-family:'Helvetica Neue',sans-serif;font-size:11px;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;color:#7a8595;">${s['landlord.notifications.snippetLabel']}</p>
+              <div style="font-size:15px;color:#0a2540;line-height:1.6;border-left:3px solid #ffcb57;padding:4px 16px;margin-bottom:24px;">
+                ${safeSnippet}
+              </div>`
+                  : ''
+              }
+
+              <!-- CTAs -->
+              <table cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background:#0a2540;border-radius:8px;padding:0;">
+                    <a href="${chatUrl}" style="display:inline-block;padding:12px 22px;font-family:'Helvetica Neue',sans-serif;font-size:14px;font-weight:700;color:#ffffff;text-decoration:none;">${s['landlord.notifications.cta']}</a>
+                  </td>
+                  <td style="width:8px;"></td>
+                  <td style="border:1px solid #0a2540;border-radius:8px;padding:0;">
+                    <a href="${inboxUrl}" style="display:inline-block;padding:11px 22px;font-family:'Helvetica Neue',sans-serif;font-size:14px;font-weight:700;color:#0a2540;text-decoration:none;">${s['landlord.notifications.inboxButton']}</a>
+                  </td>
+                </tr>
+              </table>
+
+              ${
+                listingUrl
+                  ? `<p style="margin:24px 0 0;font-size:13px;color:#7a8595;">
+                <a href="${listingUrl}" style="color:#7a8595;">${s['landlord.notifications.viewListing']}</a>
+              </p>`
+                  : ''
+              }
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td style="background:#f6f4ff;padding:20px 32px;border-top:1px solid #e6eaef;">
+              <p style="margin:0;font-size:12px;color:#7a8595;">
+                ${s['landlord.notifications.footerLine1']}<br/>
+                ${s['landlord.notifications.footerLine2']}<br/>
+                ${s['landlord.notifications.footerLine3']}
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}

--- a/supabase/migrations/044_student_message_notifications.sql
+++ b/supabase/migrations/044_student_message_notifications.sql
@@ -1,0 +1,137 @@
+-- ============================================================
+-- Migration 044: Per-message email digest tracking for students.
+-- ============================================================
+--
+-- Mirror of migration 032 (landlord_message_notifications), inverted:
+-- 032 emails the landlord when a student sends a chat message; this
+-- emails the student when the landlord replies. Without this, students
+-- start a conversation and have no out-of-app signal that the landlord
+-- ever responded — they only see the reply if they happen to be in the
+-- chat or check the inbox manually.
+--
+-- The bookkeeping column inquiries.student_unread_count already exists
+-- (migration 026) and is maintained by the trigger from 027/028, so no
+-- schema change there. This migration adds only the notifications table
+-- + RPCs paralleling the landlord side.
+--
+-- Cron wiring lives in wrangler.jsonc + cf/worker-entry.mjs:
+-- 2-58/5 * * * *  → /api/cron/student-message-digest (offset 2 min from
+-- the landlord cron at */5 to spread scheduled-handler load).
+--
+-- Server-side-only table with RLS disabled, mutated only via SECURITY
+-- DEFINER RPCs. Same shape as landlord_message_notifications (032) and
+-- saved_searches' claim_digest_send (022).
+
+CREATE TABLE student_message_notifications (
+  inquiry_id            UUID PRIMARY KEY REFERENCES inquiries(inquiry_id) ON DELETE CASCADE,
+  last_notified_at      TIMESTAMPTZ,
+  unread_count_snapshot INT NOT NULL DEFAULT 0,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE student_message_notifications DISABLE ROW LEVEL SECURITY;
+
+-- ---- get_pending_student_notifications -----------------------------
+-- Returns one row per inquiry that has unread *landlord* messages and
+-- either has never been notified or was last notified longer than
+-- p_min_interval ago. Bundles the recipient student's email/name/locale,
+-- the actor landlord's display name, the listing summary, and the latest
+-- unread landlord message body so the cron route can build the email in
+-- a single round trip.
+--
+-- The bundled SELECTs span students + inquiry_messages, both of which
+-- are RLS-restricted to thread participants — the service-role cron
+-- client bypasses RLS, but the SECURITY DEFINER context keeps this
+-- working from any caller (anon, authenticated) that is granted EXECUTE.
+CREATE OR REPLACE FUNCTION public.get_pending_student_notifications(
+  p_min_interval interval
+) RETURNS TABLE (
+  inquiry_id              UUID,
+  listing_id              TEXT,
+  student_email           TEXT,
+  student_name            TEXT,
+  student_locale          TEXT,
+  landlord_display_name   TEXT,
+  unread_count            INT,
+  last_message_at         TIMESTAMPTZ,
+  latest_message_body     TEXT,
+  listing_address         TEXT,
+  listing_neighborhood    TEXT,
+  listing_monthly_price   NUMERIC
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+  SELECT i.inquiry_id,
+         i.listing_id,
+         st.email,
+         st.display_name,
+         st.preferred_locale,
+         ll.name,
+         i.student_unread_count,
+         i.last_message_at,
+         (SELECT m.body
+            FROM inquiry_messages m
+           WHERE m.inquiry_id = i.inquiry_id
+             AND m.sender_role = 'landlord'
+             AND m.read_at IS NULL
+           ORDER BY m.created_at DESC
+           LIMIT 1) AS latest_message_body,
+         loc.address,
+         loc.neighborhood,
+         r.monthly_price
+    FROM inquiries i
+    JOIN students  st ON st.auth_user_id = i.student_user_id
+    JOIN listings  l  ON l.listing_id    = i.listing_id
+    JOIN landlords ll ON ll.landlord_id  = l.landlord_id
+    LEFT JOIN location loc ON loc.location_id = l.location_id
+    LEFT JOIN rent     r   ON r.rent_id       = l.rent_id
+    LEFT JOIN student_message_notifications n
+           ON n.inquiry_id = i.inquiry_id
+   WHERE i.student_unread_count > 0
+     AND st.email IS NOT NULL
+     AND (n.last_notified_at IS NULL
+          OR n.last_notified_at < now() - p_min_interval);
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_pending_student_notifications(interval)
+  TO anon, authenticated;
+
+-- ---- claim_student_message_notification ----------------------------
+-- Conditional UPSERT mirroring claim_landlord_message_notification (032)
+-- and claim_digest_send (022): the cron route calls this BEFORE
+-- dispatching to Resend. First caller advances last_notified_at and
+-- gets true; concurrent / retried callers within p_min_interval get
+-- false and skip silently. This is the per-inquiry debounce.
+--
+-- p_unread_count is the snapshot at claim time, kept for observability.
+CREATE OR REPLACE FUNCTION public.claim_student_message_notification(
+  p_inquiry_id   uuid,
+  p_min_interval interval,
+  p_unread_count int
+) RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_updated int;
+BEGIN
+  INSERT INTO student_message_notifications
+              (inquiry_id, last_notified_at, unread_count_snapshot)
+       VALUES (p_inquiry_id, now(), p_unread_count)
+  ON CONFLICT (inquiry_id) DO UPDATE
+     SET last_notified_at      = now(),
+         unread_count_snapshot = EXCLUDED.unread_count_snapshot
+   WHERE student_message_notifications.last_notified_at IS NULL
+      OR student_message_notifications.last_notified_at
+         < now() - p_min_interval;
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated > 0;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.claim_student_message_notification(uuid, interval, int)
+  TO anon, authenticated;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -49,6 +49,8 @@
   //                    no-op when fully populated)
   //   */5 * * * *    → /api/cron/landlord-message-digest (per-message digest;
   //                    debounced server-side via claim_landlord_message_notification)
+  //   2-58/5 * * * * → /api/cron/student-message-digest (mirror of the landlord
+  //                    digest, offset 2 min so the two never share a tick)
   //   */15 * * * *   → /api/cron/synthetic-en-listing (i18n regression guard, #49)
   // Custom-domain routes. Wrangler creates the apex A record and www CNAME
   // automatically (both proxied). Requires the CF zone to be Active first
@@ -63,6 +65,7 @@
       "0 9 * * 1",    // weekly saved-searches digest (Mondays)
       "15 9 * * *",   // nightly faculty_distances backfill
       "*/5 * * * *",  // landlord message digest (every 5 min)
+      "2-58/5 * * * *", // student message digest (every 5 min, offset 2 min from landlord)
       "*/15 * * * *"  // synthetic /en/listing locale check (#49)
     ]
   }


### PR DESCRIPTION
## Summary

Closes a gap surfaced while reviewing PR #122: when a landlord replies to a student's inquiry, the student gets **no email** — only the *first* student-to-landlord message triggers a notification, and only the landlord side has a follow-up digest cron. Students were starting conversations and going dark.

This PR adds the symmetric student-side digest. Mechanically identical to the landlord side (#38 / migration 032), with landlord ↔ student inverted.

## What's in here

- **Migration 044** (`student_message_notifications` table + `get_pending_student_notifications` + `claim_student_message_notification` RPCs). Reads the existing `inquiries.student_unread_count` column — no new bookkeeping on the message path.
- **`studentMessageDigest.js`** email template, EL + EN, mirroring `landlordMessageDigest.js` styling. Strings under `landlord.notifications.*` (namespace tracks the actor).
- **`/api/cron/student-message-digest`** route — same claim-before-send shape as the landlord digest, with `MIN_INTERVAL = '4 minutes 30 seconds'` and a `STUDENT_DIGEST_ENABLED=false` kill switch.
- **Cron schedule** `2-58/5 * * * *` — every 5 min, offset 2 min from the landlord `*/5` so the two never share a tick. Wired in `wrangler.jsonc` + `cf/worker-entry.mjs`.
- **CLAUDE.md** cron table + email outbound list updated.

## Migration applied to prod

Migration 044 was applied to the linked Supabase project via the Supabase MCP **before** opening this PR (per CLAUDE.md ordering — Cloudflare auto-deploys on push to main, and the cron route would 500 if it ran before the RPC existed). Confirmed via `list_migrations` and a `routines` introspection — both functions present, return types match.

## Test plan

- [x] `npm run lint` clean (only pre-existing warning)
- [x] `npm run test` 101/101 pass
- [x] `npm run build` registers `/api/cron/student-message-digest`
- [x] Migration applied + RPCs verified in prod
- [ ] Manual: `curl -X POST -H "x-cron-secret: $CRON_SECRET" https://studentx.uk/api/cron/student-message-digest` returns `{"processed":0,"emailsSent":0,"alreadyClaimed":0}` initially
- [ ] Manual end-to-end: student starts inquiry → landlord replies → student receives digest within ≤5 min, locale + snippet + CTA correct
- [ ] Manual debounce: second landlord reply within 4.5 min → no second email
- [ ] Manual kill switch: set `STUDENT_DIGEST_ENABLED=false`, trigger cron → `{"skipped":"disabled"}`

## Out of scope

- **Email opt-out for both sides** — neither students nor landlords have an opt-out today; symmetric for now, separate UX/settings PR.
- **Tighter cadence for first reply vs. follow-ups** — polish, not a gap.
- **RLS denormalization on `inquiry_messages`** — still tracked from PR #122, separate next-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)