### PR TITLE
docs(runbook): align cache-header probe URLs with canonical city-prefix

### DIFF
--- a/docs/runbooks/synthetic-en-listing.md
+++ b/docs/runbooks/synthetic-en-listing.md
@@ -16,7 +16,7 @@ The bug can recur whenever a new locale-aware server component is added or a sub
 | Cron dispatch (cron expr → route) | [`cf/worker-entry.mjs`](../../cf/worker-entry.mjs) `CRON_ROUTES` |
 | Check logic + alerting | [`src/app/api/cron/synthetic-en-listing/route.js`](../../src/app/api/cron/synthetic-en-listing/route.js) |
 
-Every 15 min, the Worker's `scheduled` handler POSTs to `/api/cron/synthetic-en-listing` with the `x-cron-secret` header. The route fetches `${NEXT_PUBLIC_APP_URL}/en/property/listing/${SYNTHETIC_LISTING_ID}` and asserts:
+Every 15 min, the Worker's `scheduled` handler POSTs to `/api/cron/synthetic-en-listing` with the `x-cron-secret` header. The route fetches `${NEXT_PUBLIC_APP_URL}/en/property/thessaloniki/listing/${SYNTHETIC_LISTING_ID}` (the city-prefixed canonical path; `/en/property/listing/<id>` 301s to it via `src/middleware.js`) and asserts:
 
 **Body (anon fetch — `en-listing-locale`):**
 
@@ -99,16 +99,16 @@ When investigating a `*-cache` failure, the same two requests the canary makes c
 
 ```bash
 # Anon — must include `cache-control: public, s-maxage=300, ...`
-curl -sI https://studentx.uk/en/property/listing/0100006 | grep -i cache-control
+curl -sI https://studentx.uk/en/property/thessaloniki/listing/0100006 | grep -i cache-control
 
 # Authed — must NOT include `public, s-maxage=...` (private/no-store is fine)
 curl -sI -H 'Cookie: sb-access-token=any-non-empty-value' \
-  https://studentx.uk/en/property/listing/0100006 | grep -i cache-control
+  https://studentx.uk/en/property/thessaloniki/listing/0100006 | grep -i cache-control
 
 # Bonus — confirm Cloudflare is actually caching the anon variant.
 # Run twice; second call should show `cf-cache-status: HIT`.
-curl -sI https://studentx.uk/en/property/listing/0100006 | grep -i cf-cache-status
-curl -sI https://studentx.uk/en/property/listing/0100006 | grep -i cf-cache-status
+curl -sI https://studentx.uk/en/property/thessaloniki/listing/0100006 | grep -i cf-cache-status
+curl -sI https://studentx.uk/en/property/thessaloniki/listing/0100006 | grep -i cf-cache-status
 ```
 
 If the anon request returns `private` or the authed request returns `public, s-maxage=`, the middleware split has broken — start with `git log middleware.js next.config.mjs` to find the offending change.
@@ -117,4 +117,5 @@ If the anon request returns `private` or the authed request returns `public, s-m
 
 - **Same-network probe.** The cron runs inside the same Cloudflare Worker that serves the page, so it sees the origin response, not what a different PoP returns from cache. The header check is still meaningful (it confirms the Worker is sending the right `cache-control` for both branches), but a real session-leak across PoPs would only surface via the manual two-tab browser test in `docs/runbooks/`. Worth running that test by hand once a week post-PR-#105 deploy until the design is settled.
 - **`Vary: Cookie` may not split CDN keys on Cloudflare free tier.** If a session leak is observed despite the canary passing, add a Cloudflare Cache Rule in the dashboard: "Bypass cache when Cookie contains `sb-access-token`". This sacrifices the perf win for authed users (small fraction of traffic on a directory site) and keeps anon caching intact.
+- **Path-prefix gotcha — the rule must match the canonical city-prefixed URL.** The deployed Cloudflare Cache Rule's match expression must reference `/property/thessaloniki/listing/...` (and `/en/...`), not `/property/listing/...`. Cloudflare's rule fires on the *request* URL **before** the middleware-driven 301 redirect happens, so a rule matching the legacy path only caches the 301 itself — not the actual page response. If the canary `*-cache` checks pass but `cf-cache-status` is absent on the canonical URL, this is the most likely cause.
 - **No alert dedupe.** A sustained outage emails every 15 min. If this becomes annoying, add a `synthetic_alert_state(check_name, last_alert_at)` Supabase row and gate the email on `now() - last_alert_at > 1 hour`.


### PR DESCRIPTION
## Summary

While scoping the Cache Rule extension to `/property/thessaloniki/*` I noticed a quiet bug in the deployed Cloudflare Cache Rule:

- **Rule expression matches:** `/property/listing/*` and `/en/property/listing/*`
- **Actual page URL:** `/property/thessaloniki/listing/<id>` (and `/en/property/thessaloniki/listing/<id>`)
- The legacy URL **301-redirects** to the city-prefixed canonical path via `src/middleware.js` (`OLD_PROPERTY_PATH`)
- Cloudflare's rule fires on the *request* URL **before** the middleware redirect happens
- Net effect: the rule caches the 301 redirect (small win) but **not** the actual page response (the win we wanted)

The synthetic canary's `enListingUrl` already correctly uses the city-prefixed path (`${appUrl}/en/property/thessaloniki/listing/${listingId}`) — that part was fine. But the runbook's "How it works" and "Manual cache-header probe" sections were still showing the legacy URL, so anyone investigating a `*-cache` failure with the documented curl commands would be examining the 301 redirect, not the page.

## Why this is the smaller of the two fixes

There's also a **dashboard change** the user needs to make to actually realise the perf win — extend the Cache Rule expression to match `/property/thessaloniki/listing/*` plus other anon-cacheable surfaces under `/property/*`. That's separate from this PR — pure dashboard work, no code involved. This PR just makes sure the docs and reproducers match what the code actually does.

## Pure docs change

- `docs/runbooks/synthetic-en-listing.md`:
  - "How it works" section: call out the city-prefixed canonical URL and the 301 from the legacy shape
  - Manual cache-header probe: four curl examples updated to the canonical URL
  - New "Known limitations" bullet documenting the path-prefix gotcha for anyone configuring or debugging the Cache Rule

No source code touched. Canary URL and middleware regex are both already correct on `main`.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run test` — 101/101 passing
- [x] `git diff` reviewed; only the runbook is modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)