### PR TITLE
fix(csp): allow wss:// to Supabase Realtime in connect-src

### DIFF
--- a/docs/runbooks/synthetic-en-listing.md
+++ b/docs/runbooks/synthetic-en-listing.md
@@ -16,7 +16,7 @@ The bug can recur whenever a new locale-aware server component is added or a sub
 | Cron dispatch (cron expr → route) | [`cf/worker-entry.mjs`](../../cf/worker-entry.mjs) `CRON_ROUTES` |
 | Check logic + alerting | [`src/app/api/cron/synthetic-en-listing/route.js`](../../src/app/api/cron/synthetic-en-listing/route.js) |
 
-Every 15 min, the Worker's `scheduled` handler POSTs to `/api/cron/synthetic-en-listing` with the `x-cron-secret` header. The route fetches `${NEXT_PUBLIC_APP_URL}/en/property/listing/${SYNTHETIC_LISTING_ID}` and asserts:
+Every 15 min, the Worker's `scheduled` handler POSTs to `/api/cron/synthetic-en-listing` with the `x-cron-secret` header. The route fetches `${NEXT_PUBLIC_APP_URL}/en/property/thessaloniki/listing/${SYNTHETIC_LISTING_ID}` (the city-prefixed canonical path; `/en/property/listing/<id>` 301s to it via `src/middleware.js`) and asserts:
 
 **Body (anon fetch — `en-listing-locale`):**
 
@@ -99,16 +99,16 @@ When investigating a `*-cache` failure, the same two requests the canary makes c
 
 ```bash
 # Anon — must include `cache-control: public, s-maxage=300, ...`
-curl -sI https://studentx.uk/en/property/listing/0100006 | grep -i cache-control
+curl -sI https://studentx.uk/en/property/thessaloniki/listing/0100006 | grep -i cache-control
 
 # Authed — must NOT include `public, s-maxage=...` (private/no-store is fine)
 curl -sI -H 'Cookie: sb-access-token=any-non-empty-value' \
-  https://studentx.uk/en/property/listing/0100006 | grep -i cache-control
+  https://studentx.uk/en/property/thessaloniki/listing/0100006 | grep -i cache-control
 
 # Bonus — confirm Cloudflare is actually caching the anon variant.
 # Run twice; second call should show `cf-cache-status: HIT`.
-curl -sI https://studentx.uk/en/property/listing/0100006 | grep -i cf-cache-status
-curl -sI https://studentx.uk/en/property/listing/0100006 | grep -i cf-cache-status
+curl -sI https://studentx.uk/en/property/thessaloniki/listing/0100006 | grep -i cf-cache-status
+curl -sI https://studentx.uk/en/property/thessaloniki/listing/0100006 | grep -i cf-cache-status
 ```
 
 If the anon request returns `private` or the authed request returns `public, s-maxage=`, the middleware split has broken — start with `git log middleware.js next.config.mjs` to find the offending change.
@@ -117,4 +117,5 @@ If the anon request returns `private` or the authed request returns `public, s-m
 
 - **Same-network probe.** The cron runs inside the same Cloudflare Worker that serves the page, so it sees the origin response, not what a different PoP returns from cache. The header check is still meaningful (it confirms the Worker is sending the right `cache-control` for both branches), but a real session-leak across PoPs would only surface via the manual two-tab browser test in `docs/runbooks/`. Worth running that test by hand once a week post-PR-#105 deploy until the design is settled.
 - **`Vary: Cookie` may not split CDN keys on Cloudflare free tier.** If a session leak is observed despite the canary passing, add a Cloudflare Cache Rule in the dashboard: "Bypass cache when Cookie contains `sb-access-token`". This sacrifices the perf win for authed users (small fraction of traffic on a directory site) and keeps anon caching intact.
+- **Path-prefix gotcha — the rule must match the canonical city-prefixed URL.** The deployed Cloudflare Cache Rule's match expression must reference `/property/thessaloniki/listing/...` (and `/en/...`), not `/property/listing/...`. Cloudflare's rule fires on the *request* URL **before** the middleware-driven 301 redirect happens, so a rule matching the legacy path only caches the 301 itself — not the actual page response. If the canary `*-cache` checks pass but `cf-cache-status` is absent on the canonical URL, this is the most likely cause.
 - **No alert dedupe.** A sustained outage emails every 15 min. If this becomes annoying, add a `synthetic_alert_state(check_name, last_alert_at)` Supabase row and gate the email on `now() - last_alert_at > 1 hour`.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,7 +15,12 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.js');
 //   - img-src: static.wixstatic.com (listing photos), Supabase storage
 //     (uploaded photos), *.tile.openstreetmap.org (map tiles), unpkg.com
 //     (Leaflet marker PNGs); all listed below.
-//   - connect-src: only Supabase.
+//   - connect-src: Supabase REST/Auth (https) + Realtime (wss). The wss
+//     scheme is required separately — Safari (and CSP3 spec) treat
+//     `https://x` as scheme-pinned and block `wss://x` without an explicit
+//     entry. Symptom was Safari users hitting `SecurityError: The
+//     operation is insecure.` and Safari's fallback "This page couldn't
+//     load" UI when ChatThread tried to subscribe.
 //   - font-src: next/font/google self-hosts at build time; fonts.gstatic.com
 //     kept defensively in case any subset still pulls there.
 const SECURITY_HEADERS = [
@@ -38,7 +43,7 @@ const SECURITY_HEADERS = [
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob: https://static.wixstatic.com https://ecluqurlfbvkxrnoyhaq.supabase.co https://*.tile.openstreetmap.org https://unpkg.com",
       "font-src 'self' data: https://fonts.gstatic.com",
-      "connect-src 'self' https://ecluqurlfbvkxrnoyhaq.supabase.co",
+      "connect-src 'self' https://ecluqurlfbvkxrnoyhaq.supabase.co wss://ecluqurlfbvkxrnoyhaq.supabase.co",
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'",


### PR DESCRIPTION
## Summary

Real-time chat has been silently broken for **Safari users** since the CSP was flipped from Report-Only to enforced (PR #28). CSP3 strict-matches schemes — `https://...supabase.co` does NOT cover `wss://...supabase.co` — and Safari/CSP3 spec block the WebSocket. Chrome has historically been lenient, which is why this didn't surface earlier.

After PR #122's reconnection logic, the previously-silent failure became visible: ChatThread now catches the WSS-blocked-by-CSP as a `CHANNEL_ERROR`, and Safari's synchronous `SecurityError` from the WebSocket constructor crashes the chat tab into Safari's fallback "This page couldn't load" UI.

## Repro from a reporter

Safari console at the time of the error (confirmed by the reporting landlord):

```
Refused to connect to wss://ecluqurlfbvkxrnoyhaq.supabase.co/realtime/v1/websocket?...
because it does not appear in the connect-src directive of the Content Security Policy.
Error: WebSocket not available: The operation is insecure.
SecurityError: The operation is insecure.
```

## Fix

One line in [next.config.mjs](next.config.mjs): add `wss://ecluqurlfbvkxrnoyhaq.supabase.co` next to the existing `https://...` entry in `connect-src`. Doc comment updated to flag the scheme-pinning gotcha for the next person.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test` 101/101 pass
- [x] `npm run build` succeeds
- [ ] Manual: after deploy, reporter reloads the chat page in Safari → no error UI, no console SecurityError, ChatThread connects.
- [ ] Manual: also verify in Chrome (regression check — should still work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)