### PR TITLE
fix(cron): split CRON_DISPATCH_URL so scheduled handler can reach itself

### DIFF
--- a/cf/worker-entry.mjs
+++ b/cf/worker-entry.mjs
@@ -34,11 +34,17 @@ async function runCron(event, env) {
     return;
   }
 
-  const appUrl = env.NEXT_PUBLIC_APP_URL;
+  // Prefer CRON_DISPATCH_URL for self-fetch — NEXT_PUBLIC_APP_URL points at
+  // the canonical public domain (studentx.uk), which currently 522s when the
+  // Worker fetches it because the custom-domain route binding isn't fully
+  // wired yet. CRON_DISPATCH_URL points at the always-live workers.dev URL.
+  // Falls back to NEXT_PUBLIC_APP_URL so local `wrangler dev` still works
+  // without a second var.
+  const appUrl = env.CRON_DISPATCH_URL || env.NEXT_PUBLIC_APP_URL;
   const secret = env.CRON_SECRET;
   if (!appUrl || !secret) {
     console.error(
-      `[cron] ${route.name}: missing NEXT_PUBLIC_APP_URL or CRON_SECRET — cannot dispatch`,
+      `[cron] ${route.name}: missing CRON_DISPATCH_URL/NEXT_PUBLIC_APP_URL or CRON_SECRET — cannot dispatch`,
     );
     return;
   }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -30,6 +30,16 @@
     // explicitly at build (or the Worker is built from CI with no .env.local).
     "NEXT_PUBLIC_SITE_URL": "https://studentx.uk",
     "NEXT_PUBLIC_APP_URL": "https://studentx.uk",
+    // Worker self-fetch URL for cf/worker-entry.mjs's scheduled handler.
+    // Distinct from NEXT_PUBLIC_APP_URL because the custom-domain route
+    // for studentx.uk isn't yet serving HTTP traffic to this Worker — a
+    // self-fetch to https://studentx.uk/api/cron/* returns HTTP 522 in
+    // ~15ms and silently breaks every cron. Pointing the dispatcher at
+    // the always-live workers.dev URL unblocks the crons without
+    // changing canonical/sitemap/og:url, which still resolve from
+    // NEXT_PUBLIC_APP_URL above. Drop this var once studentx.uk DNS is
+    // fully wired (docs/runbooks/domain-setup.md).
+    "CRON_DISPATCH_URL": "https://studentx.studentx-gr.workers.dev",
     // Synthetic uptime check — guards against the i18n regression class fixed
     // in PR #48 (Greek copy leaking onto /en/listing/<id>). The */15 cron POSTs
     // to /api/cron/synthetic-en-listing, which fetches /en/listing/<id> and


### PR DESCRIPTION
## What this fixes

The Worker scheduled handler was self-fetching `${NEXT_PUBLIC_APP_URL}/api/cron/*` (= `https://studentx.uk/...`), which 522'd in ~15ms because the custom-domain route binding for studentx.uk isn't yet serving HTTP traffic to this Worker. **Every cron** going through the dispatcher silently dropped: landlord-message-digest, student-message-digest, saved-searches-digest, recompute-distances, synthetic-en-listing.

Fix: introduce `CRON_DISPATCH_URL` Worker var pointing at the always-live `studentx.studentx-gr.workers.dev` URL; `cf/worker-entry.mjs` prefers it for self-fetch with `NEXT_PUBLIC_APP_URL` as fallback so local `wrangler dev` keeps working. Canonical/sitemap/og:url and email CTAs continue to resolve from `NEXT_PUBLIC_APP_URL` — public surface unchanged.

## ⚠️ What this does NOT fix — read before re-testing

After deploy, **if you re-test the way you tested before, you will still see no email**. The chat thread auto-marks messages as read on mount and on every realtime echo (`ChatThread.js`). Looking at the existing message history with landlord 0106, every message was read within seconds-to-minutes. The 5-min cron tick never had a chance to catch a non-zero unread count.

**To verify the fix actually works, you must close the receiving tab/browser entirely for ≥5 min after sending the message.**

The mark-read race is a separate, intentional design (digests are a "you weren't there" nudge, not a per-message notification) — not addressed by this PR.

## Evidence

`wrangler tail studentx`:

```
"*/5 * * * *" @ 5/9/2026, 6:25:14 AM — Ok
  (error) [cron] landlord-message-digest failed: 522 <none> (15ms) — error code: 522
```

DB confirms no cron has ever completed:

```sql
SELECT count(*) FROM landlord_message_notifications;  -- 0
SELECT count(*) FROM student_message_notifications;   -- 0
```

Both tables get a row inserted on every successful claim, so empty = the route never executed.

## Retroactive-digest behavior

Worth knowing: any inquiry currently sitting at `unread_count > 0` with a valid recipient email **will** fire a digest on the first post-fix tick. Today exactly one inquiry is in that state (landlord_unread_count=2, last message 2026-05-08), but it's for landlord 0100 who has `email IS NULL`, so it's filtered by the RPC — no surprise email. If a real landlord-with-email had a sitting unread, they'd get a digest covering messages up to ~24h old. Acceptable.

## Test plan

### Pre-deploy sanity check
- [ ] `curl -X POST -H "x-cron-secret: $CRON_SECRET" https://studentx.studentx-gr.workers.dev/api/cron/landlord-message-digest` — confirm route responds 200 with `{processed, emailsSent, alreadyClaimed}` JSON (proves the destination is reachable before we flip the dispatcher).

### Post-deploy
- [ ] Watch `wrangler tail studentx` on next `*/5` tick — error line should become `[cron] landlord-message-digest ok: processed=N sent=M claimed=K (Xms)`.
- [ ] Confirm the **other crons recover too**, not just the digest — should see `ok` lines for `student-message-digest` (`2-58/5`), `synthetic-en-listing` (`*/15`). The daily ones (`saved-searches`, `recompute-distances`) won't fire until 9am, but no longer 522.

### Positive E2E (proves digest fires when expected)
- [ ] New student inquires on a listing belonging to landlord 0106 (has email + auth).
- [ ] Send a message.
- [ ] **Close the landlord-side browser/tab entirely.** Do not let `mark_messages_read` fire.
- [ ] Wait ≥5 min.
- [ ] Confirm `michaelcharlesg@icloud.com` receives a "Νέο μήνυμα από <student> · StudentX" email (NOT "Νέο αίτημα από..." which is the legacy inquiry-creation email).

### Negative E2E (proves the mark-read race still works as designed)
- [ ] With both tabs open, send another message.
- [ ] Wait ≥10 min.
- [ ] Confirm **no** digest email arrives (mark-read fired immediately, unread counter zero, RPC returns nothing — correct behavior).

### Mirror for student side
- [ ] Repeat the positive E2E with landlord replying and the student tab closed.
- [ ] Sanity-check DB: `SELECT * FROM landlord_message_notifications ORDER BY last_notified_at DESC LIMIT 5;` and `SELECT * FROM student_message_notifications ORDER BY last_notified_at DESC LIMIT 5;` should each show fresh rows after the corresponding test.

## Rollback

Revert this PR (or unset `CRON_DISPATCH_URL` from the Worker dashboard). Behavior reverts to pre-fix 522 — no regression beyond what was already broken.

## Out of scope

- Finishing studentx.uk DNS so the custom domain serves HTTP traffic to the Worker (`docs/runbooks/domain-setup.md`). Long-term right answer; once done, this var can be deleted.
- The mark-read race itself (intentional design).
- Two curated landlords with `email IS NULL` (0100, 0101) — unrelated product issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)