### PR TITLE
fix(cron): direct-invoke OpenNext fetch handler (404 follow-up to #132)

### DIFF
--- a/cf/worker-entry.mjs
+++ b/cf/worker-entry.mjs
@@ -27,41 +27,42 @@ const CRON_ROUTES = {
   "*/15 * * * *": { name: "synthetic-en-listing",   path: "/api/cron/synthetic-en-listing",    query: null },
 };
 
-async function runCron(event, env) {
+async function runCron(event, env, ctx) {
   const route = CRON_ROUTES[event.cron];
   if (!route) {
     console.error(`[cron] unknown cron expression: ${event.cron}`);
     return;
   }
 
-  // Prefer CRON_DISPATCH_URL for self-fetch — NEXT_PUBLIC_APP_URL points at
-  // the canonical public domain (studentx.uk), which currently 522s when the
-  // Worker fetches it because the custom-domain route binding isn't fully
-  // wired yet. CRON_DISPATCH_URL points at the always-live workers.dev URL.
-  // Falls back to NEXT_PUBLIC_APP_URL so local `wrangler dev` still works
-  // without a second var.
-  const appUrl = env.CRON_DISPATCH_URL || env.NEXT_PUBLIC_APP_URL;
   const secret = env.CRON_SECRET;
-  if (!appUrl || !secret) {
-    console.error(
-      `[cron] ${route.name}: missing CRON_DISPATCH_URL/NEXT_PUBLIC_APP_URL or CRON_SECRET — cannot dispatch`,
-    );
+  if (!secret) {
+    console.error(`[cron] ${route.name}: missing CRON_SECRET — cannot dispatch`);
     return;
   }
 
+  // Invoke OpenNext's fetch handler directly instead of HTTP self-fetching.
+  // Worker→own-Worker self-fetches don't follow the same routing path as
+  // external traffic on Cloudflare: the assets binding intercepts and
+  // returns 404 for /api/* paths before the Next.js handler runs (external
+  // curl returns 401, internal fetch returns 404). Direct invocation
+  // skips the network and the asset binding entirely, so the request lands
+  // straight in the Next.js route handler. Bonus: no URL config needed.
+  // The Request URL host is only used by Next.js for canonical/routing
+  // decisions; we use NEXT_PUBLIC_APP_URL (with a safe fallback) to keep
+  // those resolutions consistent with normal traffic.
+  const baseUrl = env.NEXT_PUBLIC_APP_URL || "https://studentx.uk";
   const url = route.query
-    ? `${appUrl}${route.path}?${route.query}`
-    : `${appUrl}${route.path}`;
+    ? `${baseUrl}${route.path}?${route.query}`
+    : `${baseUrl}${route.path}`;
   const startedAt = Date.now();
 
   try {
-    // Abort before CF's ~30s scheduled-handler limit so we get a logged
-    // timeout instead of a silent kill. ctx.waitUntil still respects this.
-    const res = await fetch(url, {
+    const request = new Request(url, {
       method: "POST",
       headers: { "x-cron-secret": secret },
       signal: AbortSignal.timeout(25_000),
     });
+    const res = await openNextWorker.fetch(request, env, ctx);
     const elapsed = Date.now() - startedAt;
     if (!res.ok) {
       const body = await res.text().catch(() => "");
@@ -83,7 +84,7 @@ export default {
   fetch: openNextWorker.fetch,
   async scheduled(event, env, ctx) {
     // ctx.waitUntil keeps the worker alive past the synchronous handler return
-    // until the cron POST completes.
-    ctx.waitUntil(runCron(event, env));
+    // until the direct invocation resolves.
+    ctx.waitUntil(runCron(event, env, ctx));
   },
 };

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -30,16 +30,6 @@
     // explicitly at build (or the Worker is built from CI with no .env.local).
     "NEXT_PUBLIC_SITE_URL": "https://studentx.uk",
     "NEXT_PUBLIC_APP_URL": "https://studentx.uk",
-    // Worker self-fetch URL for cf/worker-entry.mjs's scheduled handler.
-    // Distinct from NEXT_PUBLIC_APP_URL because the custom-domain route
-    // for studentx.uk isn't yet serving HTTP traffic to this Worker — a
-    // self-fetch to https://studentx.uk/api/cron/* returns HTTP 522 in
-    // ~15ms and silently breaks every cron. Pointing the dispatcher at
-    // the always-live workers.dev URL unblocks the crons without
-    // changing canonical/sitemap/og:url, which still resolve from
-    // NEXT_PUBLIC_APP_URL above. Drop this var once studentx.uk DNS is
-    // fully wired (docs/runbooks/domain-setup.md).
-    "CRON_DISPATCH_URL": "https://studentx.studentx-gr.workers.dev",
     // Synthetic uptime check — guards against the i18n regression class fixed
     // in PR #48 (Greek copy leaking onto /en/listing/<id>). The */15 cron POSTs
     // to /api/cron/synthetic-en-listing, which fetches /en/listing/<id> and


### PR DESCRIPTION
## What this fixes (the 404 follow-up to #132)

After [#132](https://github.com/MichaelChar/StudentX/pull/132), the Worker stopped 522'ing but started 404'ing on every cron tick:

```
"*/15 * * * *" @ 5/9/2026, 7:15:11 AM — Ok
  (error) [cron] synthetic-en-listing failed: 404 Not Found (3ms)
"*/5 * * * *" @ 5/9/2026, 7:15:11 AM — Ok
  (error) [cron] landlord-message-digest failed: 404 Not Found (4ms)
"*/5 * * * *" @ 5/9/2026, 7:20:11 AM — Ok
  (error) [cron] landlord-message-digest failed: 404 Not Found (8ms)
```

External `curl` returns **401** at both `studentx.uk` and `studentx.studentx-gr.workers.dev`:

```
curl -X POST https://studentx.studentx-gr.workers.dev/api/cron/landlord-message-digest
{"error":"Unauthorized"}
```

So the route exists and runs for external traffic. But Worker → own-Worker self-fetch hits a different path on Cloudflare — most likely the assets binding intercepts `/api/*` paths and 404s before the Next.js handler can run.

## The fix

Skip the network entirely. Call `openNextWorker.fetch(request, env, ctx)` directly from the scheduled handler. Same module already exported as the Worker's fetch handler — invoking it directly delivers the request straight to the Next.js routing layer with no asset binding in the middle.

Side benefit: drops the `CRON_DISPATCH_URL` var added in #132 (no longer needed) and removes any dependency on URL/DNS state. The Request URL host is only used by Next.js for canonical/locale resolution; falls back to `https://studentx.uk` if `NEXT_PUBLIC_APP_URL` is unset.

## Test plan

### Post-deploy
- [ ] `wrangler tail studentx --format pretty` — next `*/5` tick should show `[cron] landlord-message-digest ok: processed=N sent=M claimed=K (Xms)` instead of 404. Same for `*/15` synthetic-en-listing.
- [ ] All four dispatched crons should recover (landlord/student message digests every 5 min, synthetic every 15 min, daily ones tomorrow at 9am).

### Positive E2E (proves digest fires)
- [ ] New student inquires on a listing belonging to landlord 0106 (has email + auth).
- [ ] Send a message.
- [ ] **Close the landlord-side browser/tab entirely.** Wait at least one full `*/5` cycle past the next tick (≥6 min to be safe).
- [ ] Confirm `michaelcharlesg@icloud.com` receives a "Νέο μήνυμα από <student> · StudentX" email (NOT "Νέο αίτημα από...", which is the legacy inquiry-creation email that already worked).

### Negative E2E (proves mark-read race still works as designed)
- [ ] With both tabs open, send another message; wait ≥12 min; confirm no email arrives.

### Mirror for student side
- [ ] Landlord replies; student tab closed; wait ≥6 min; check student inbox.
- [ ] Sanity-check DB:
  ```sql
  SELECT * FROM landlord_message_notifications ORDER BY last_notified_at DESC LIMIT 5;
  SELECT * FROM student_message_notifications  ORDER BY last_notified_at DESC LIMIT 5;
  ```
  Should each show fresh rows after the corresponding test.

## Rollback

Revert. The pre-#132 522 state was no worse than the post-#132 404 state — both fail-closed, no email duplication risk.

## Out of scope

- Mark-read race (intentional design).
- Two curated landlords with `email IS NULL` (0100, 0101) — separate product issue.
- Finishing studentx.uk DNS / route binding so external traffic also hits the Worker via the canonical domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)