### PR TITLE
fix(synthetic): self-bind probes, guard cache evaluators on non-200

### DIFF
--- a/__tests__/api/syntheticEnListing.test.js
+++ b/__tests__/api/syntheticEnListing.test.js
@@ -55,29 +55,39 @@ describe('evaluateBody', () => {
 
 describe('evaluateAnonCacheHeader', () => {
   it('passes when anon response includes public, s-maxage=...', () => {
-    expect(evaluateAnonCacheHeader(PUBLIC_CC)).toEqual({ ok: true });
+    expect(evaluateAnonCacheHeader({ status: 200, cacheControl: PUBLIC_CC })).toEqual({ ok: true });
   });
 
   it('passes on the comma-spaceless variant', () => {
-    expect(evaluateAnonCacheHeader('public,s-maxage=60')).toEqual({ ok: true });
+    expect(evaluateAnonCacheHeader({ status: 200, cacheControl: 'public,s-maxage=60' })).toEqual({ ok: true });
   });
 
   it('fails when middleware drops back to private (anon perf regression)', () => {
-    const result = evaluateAnonCacheHeader(PRIVATE_CC);
+    const result = evaluateAnonCacheHeader({ status: 200, cacheControl: PRIVATE_CC });
     expect(result.ok).toBe(false);
     expect(result.reason).toMatch(/anon listing detail must serve public/);
   });
 
   it('fails when the header is missing entirely', () => {
-    const result = evaluateAnonCacheHeader('');
+    const result = evaluateAnonCacheHeader({ status: 200, cacheControl: '' });
     expect(result.ok).toBe(false);
     expect(result.reason).toMatch(/anon listing detail must serve public/);
+  });
+
+  // Non-200 short-circuit: a 522 / 5xx error page has its own cache-control
+  // (Cloudflare's `private, max-age=0, no-store, no-cache, must-revalidate,
+  // post-check=0, pre-check=0`) which has nothing to do with our middleware.
+  // evaluateBody already reports the status problem; the cache check has
+  // nothing useful to add and must not double-flag.
+  it('passes silently on non-200 responses (defers to evaluateBody)', () => {
+    expect(evaluateAnonCacheHeader({ status: 522, cacheControl: PRIVATE_CC })).toEqual({ ok: true });
+    expect(evaluateAnonCacheHeader({ status: 500, cacheControl: '' })).toEqual({ ok: true });
   });
 });
 
 describe('evaluateAuthedCacheHeader', () => {
   it('passes when authed response is private/no-store', () => {
-    expect(evaluateAuthedCacheHeader(PRIVATE_CC)).toEqual({ ok: true });
+    expect(evaluateAuthedCacheHeader({ status: 200, cacheControl: PRIVATE_CC })).toEqual({ ok: true });
   });
 
   // Session-leak guard. If the authed branch ever returns public, s-maxage=...
@@ -85,18 +95,22 @@ describe('evaluateAuthedCacheHeader', () => {
   // caches the gated body and serves it to other users. This is the original
   // failure mode that made the pre-PR-105 cache attempt unsafe to ship.
   it('fails when authed route returns public, s-maxage=... (session-leak)', () => {
-    const result = evaluateAuthedCacheHeader(PUBLIC_CC);
+    const result = evaluateAuthedCacheHeader({ status: 200, cacheControl: PUBLIC_CC });
     expect(result.ok).toBe(false);
     expect(result.reason).toMatch(/session-leak/);
   });
 
   it('also catches s-maxage with no comma-space (defensive regex)', () => {
-    const result = evaluateAuthedCacheHeader('public,s-maxage=60');
+    const result = evaluateAuthedCacheHeader({ status: 200, cacheControl: 'public,s-maxage=60' });
     expect(result.ok).toBe(false);
     expect(result.reason).toMatch(/session-leak/);
   });
 
   it('treats empty cacheControl as ok (no public, s-maxage=)', () => {
-    expect(evaluateAuthedCacheHeader('')).toEqual({ ok: true });
+    expect(evaluateAuthedCacheHeader({ status: 200, cacheControl: '' })).toEqual({ ok: true });
+  });
+
+  it('passes silently on non-200 responses (defers to evaluateBody)', () => {
+    expect(evaluateAuthedCacheHeader({ status: 522, cacheControl: PUBLIC_CC })).toEqual({ ok: true });
   });
 });

--- a/src/app/api/cron/synthetic-en-listing/route.js
+++ b/src/app/api/cron/synthetic-en-listing/route.js
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { getResend } from '@/lib/resend';
 
 // Synthetic uptime check guarding against the regression class fixed in PR #48
@@ -42,16 +43,30 @@ function isCronAuthorized(request) {
 // and we can verify the server-side split without holding a real JWT.
 const SYNTHETIC_AUTH_COOKIE = 'sb-access-token=synthetic-canary-stub';
 
+// Resolve the self-fetcher (env.WORKER_SELF_REFERENCE) so probes hit the
+// Worker directly, bypassing DNS/CDN/asset-binding interception. Returns
+// null when running outside the Cloudflare runtime (local dev, unit tests),
+// in which case fetchUrl falls back to global fetch.
+async function getSelfFetcher() {
+  try {
+    const { env } = await getCloudflareContext({ async: true });
+    return env?.WORKER_SELF_REFERENCE ?? null;
+  } catch {
+    return null;
+  }
+}
+
 async function fetchUrl(url, { method = 'GET', cookie = '' } = {}) {
   const headers = { 'user-agent': 'StudentX-synthetic/1.0' };
   if (cookie) headers.cookie = cookie;
-  const res = await fetch(url, {
+  const init = {
     method,
     headers,
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     redirect: 'manual',
-  });
-  return res;
+  };
+  const self = await getSelfFetcher();
+  return self ? self.fetch(url, init) : fetch(url, init);
 }
 
 async function fetchListingHtml(url, { cookie } = {}) {
@@ -94,7 +109,18 @@ export function evaluateBody({ status, body }) {
   return { ok: true };
 }
 
-export function evaluateAnonCacheHeader(cacheControl) {
+// Cache-header evaluators take { status, cacheControl } and short-circuit
+// on non-200 responses: a 522 / 5xx error page has its own (Cloudflare /
+// upstream) cache-control header that has nothing to do with our middleware,
+// and evaluateBody already flags the underlying status problem. Without
+// this guard the synthetic alert double-flagged a single 522 as both
+// "non-200 status" AND "anon must serve public, s-maxage=..." — the latter
+// reading CF's error-page header (`private, max-age=0, no-store, no-cache,
+// must-revalidate, post-check=0, pre-check=0`).
+export function evaluateAnonCacheHeader({ status, cacheControl }) {
+  if (status != null && status !== 200) {
+    return { ok: true };
+  }
   if (!PUBLIC_CACHE_RE.test(cacheControl || '')) {
     return {
       ok: false,
@@ -104,7 +130,10 @@ export function evaluateAnonCacheHeader(cacheControl) {
   return { ok: true };
 }
 
-export function evaluateAuthedCacheHeader(cacheControl) {
+export function evaluateAuthedCacheHeader({ status, cacheControl }) {
+  if (status != null && status !== 200) {
+    return { ok: true };
+  }
   if (PUBLIC_CACHE_RE.test(cacheControl || '')) {
     return {
       ok: false,
@@ -296,7 +325,10 @@ export async function POST(request) {
   try {
     const fetched = await fetchListingHtml(enListingUrl);
     record('en-listing-locale', evaluateBody(fetched));
-    record('en-listing-anon-cache', evaluateAnonCacheHeader(fetched.cacheControl));
+    record(
+      'en-listing-anon-cache',
+      evaluateAnonCacheHeader({ status: fetched.status, cacheControl: fetched.cacheControl }),
+    );
     if (fetched.status !== 200 || !checks.find((c) => c.name === 'en-listing-locale')?.ok) {
       enListingExcerpt = (fetched.body || '').slice(0, 500);
     }
@@ -312,7 +344,10 @@ export async function POST(request) {
   // branch, so we can verify the per-request split without a real JWT.)
   try {
     const fetched = await fetchListingHtml(enListingUrl, { cookie: SYNTHETIC_AUTH_COOKIE });
-    record('en-listing-authed-cache', evaluateAuthedCacheHeader(fetched.cacheControl));
+    record(
+      'en-listing-authed-cache',
+      evaluateAuthedCacheHeader({ status: fetched.status, cacheControl: fetched.cacheControl }),
+    );
   } catch (err) {
     const reason = `fetch threw: ${err.name || 'Error'} ${err.message || ''}`.trim();
     record('en-listing-authed-cache', { ok: false, reason });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,6 +16,19 @@
     "directory": ".open-next/assets",
     "binding": "ASSETS"
   },
+  // Self service-binding so the Worker can invoke its own routes without
+  // going through the network. Used by the synthetic-en-listing cron to
+  // dodge the Worker self-fetch issues observed on both studentx.uk
+  // (returns 522 — see PR #133's findings) and the workers.dev URL
+  // (asset binding intercepts /api/* with 404). With this binding,
+  // env.WORKER_SELF_REFERENCE.fetch(url) bypasses the network entirely
+  // and goes straight to the Worker's fetch handler — same response
+  // body and headers, no DNS or asset-binding fragility. Name follows
+  // OpenNext's typed convention (CloudflareEnv["WORKER_SELF_REFERENCE"]
+  // in @opennextjs/cloudflare).
+  "services": [
+    { "binding": "WORKER_SELF_REFERENCE", "service": "studentx" }
+  ],
   // Public Supabase config — these are also inlined into the client bundle
   // via NEXT_PUBLIC_*, but server-side route handlers (e.g. /api/listings)
   // read them from process.env at runtime in the Worker. Without these,


### PR DESCRIPTION
## What this fixes

Follow-up to [#132](https://github.com/MichaelChar/StudentX/pull/132) / [#133](https://github.com/MichaelChar/StudentX/pull/133). After those PRs unblocked the cron dispatcher, the `*/15 * * * *` synthetic-en-listing cron started actually running — and immediately started emailing 9-failure alerts every tick. Investigation showed:

- **Category A (9 of 10 failures): 522 from `https://studentx.uk/...`.** Worker self-fetches to its own custom-domain URL get 522 because the route binding for studentx.uk isn't fully serving HTTP traffic to this Worker. End-user traffic to studentx.uk works fine — only Worker-internal self-fetches fail.
- **Category B (1 of 10 failures): `en-listing-anon-cache` claiming a cache regression.** False positive — the synthetic was reading Cloudflare's 522-error-page `cache-control` header (`private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0`), not anything OpenNext or middleware emitted. External `curl` confirms anon traffic gets `public, s-maxage=300, stale-while-revalidate=86400` exactly as designed.

## Two changes

### 1. Self service-binding for probes

Add a self service-binding in `wrangler.jsonc`:
\`\`\`jsonc
\"services\": [
  { \"binding\": \"WORKER_SELF_REFERENCE\", \"service\": \"studentx\" }
]
\`\`\`

Use it in the synthetic via OpenNext's typed accessor:
\`\`\`js
import { getCloudflareContext } from '@opennextjs/cloudflare';
const { env } = await getCloudflareContext({ async: true });
const res = await env.WORKER_SELF_REFERENCE.fetch(url, init);
\`\`\`

Service bindings invoke the Worker directly — no network, no DNS, no custom-domain routing, no asset-binding interception. Same response body and headers as external traffic, so probe coverage is unchanged. `WORKER_SELF_REFERENCE` is the name OpenNext already declares in `CloudflareEnv` ([@opennextjs/cloudflare/api/cloudflare-context.d.ts:12](https://github.com/opennextjs/opennextjs-cloudflare/blob/main/packages/cloudflare/src/api/cloudflare-context.ts)) so no new convention.

Falls back to global `fetch` when the binding is absent (local dev, unit tests).

### 2. Non-200 short-circuit on cache evaluators

`evaluateAnonCacheHeader` / `evaluateAuthedCacheHeader` now take `{ status, cacheControl }` and return `{ ok: true }` on any non-200 status. Reasoning:

- A 522 / 5xx / etc. error page has its own (Cloudflare or upstream) `cache-control` that has nothing to do with our middleware.
- `evaluateBody` already flags the underlying status problem.
- Cache check has nothing useful to add and must not double-flag.

Defense-in-depth against any future probe returning non-200, even after the self-binding is in place.

## Coverage trade-off (small, acknowledged)

The synthetic no longer tests:
- DNS resolution for studentx.uk
- TLS termination
- Cloudflare custom-domain route binding (whether requests to studentx.uk reach the Worker at all)
- Whether the CDN actually honors `s-maxage=300`

It still tests, on every probe path the synthetic exercises:
- Worker route handler responses (status, body, headers)
- Middleware cache-control split (anon vs cookied)
- next-intl locale resolution + Greek-leak guard
- API route 401-vs-5xx behavior
- Static asset MIME types (og-default.png)

The lost coverage is true-CDN/edge concerns, which were already hard to test from inside the same Worker that's broken. External uptime tooling (Pingdom, Better Uptime) is the right tool there if needed.

## Test plan

### Pre-deploy
- [x] Lint clean (1 pre-existing warning, unchanged).
- [x] `npm run test` — 103/103 pass (was 101 + 2 new non-200 short-circuit cases).

### Post-deploy
- [ ] Watch `wrangler tail studentx --format pretty` on the next `*/15` tick (8:15, 8:30, etc.). The 9-failure alert email should stop.
- [ ] Confirm in tail: synthetic now logs `[cron] synthetic-en-listing ok` (or returns clean JSON via the cron entry's success-path log).
- [ ] If a real regression genuinely fires, the alert email should now have 1 failure with a useful reason, not 10.

### Sanity
- [ ] Manual external curl of the synthetic route still returns 401:
  \`\`\`
  curl -X POST https://studentx.studentx-gr.workers.dev/api/cron/synthetic-en-listing
  -> {\"error\":\"Unauthorized\"}
  \`\`\`
- [ ] No regression on the now-working message digests (#132/#133) — they don't share code with this change.

## Rollback

Revert. The synthetic returns to 9-failure-emails-per-tick state, no other regression.

## Out of scope

- Finishing studentx.uk DNS / route binding — separate runbook task. Once done, the self-binding becomes redundant and can be reverted.
- The legitimate Category-B-shaped regressions the cache-header check was originally designed to catch (post-PR #105 split). The check still catches them on actual 200 responses; the only thing it stops doing is *false-flagging on error pages*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)