### PR TITLE
fix(synthetic): route /en/property/* page checks through CDN, not service binding

### DIFF
--- a/docs/runbooks/synthetic-en-listing.md
+++ b/docs/runbooks/synthetic-en-listing.md
@@ -38,6 +38,13 @@ Any failed assertion (or non-200, or fetch timeout) attempts to send an email vi
 
 > **Status (2026-05-03):** Resend is verified for `studentx.uk` and `RESEND_API_KEY` is set as a Worker secret — the alert path is live. On failure the route emails `SYNTHETIC_ALERT_EMAIL` from `alerts@studentx.uk`. Failures still surface in `wrangler tail` regardless. The route's email send is wrapped in try/catch, so a Resend hiccup doesn't break the check itself.
 
+### Fetch strategy: service binding vs. global fetch
+
+The route uses two fetch paths depending on the check:
+
+- **Service binding (`env.WORKER_SELF_REFERENCE`)** — used by the listing-detail body + cache-header checks and the API checks (`/api/listings/<id>`, `/api/landlord/listings`, `/og-default.png`, `/en` missing-message). Bypasses DNS/CDN/asset-binding interception, so it gives a deterministic origin response (required for the cache-header assertions and avoids the workers.dev asset-binding 404 on `/api/*`).
+- **Global `fetch()` (CDN path)** — used by the three `/en/property/*` page-locale checks (`en-cityhub-locale`, `en-homepage-locale`, `en-quiz-locale`). Service-binding sub-fetches force fresh SSR for these heavy property pages (HubBackground 240k particles, HubDiagram, StripeGradientMesh WebGL) and exceed Worker resource limits when 8 checks run concurrently — symptom is 503/timeout in the alert email despite the pages serving 200 to real users. The locale checks only need HTML marker presence, so a CDN-cached response satisfies them; a real i18n regression surfaces within the CDN TTL on the first cache miss after deploy.
+
 ## Configuration
 
 Vars in [`wrangler.jsonc`](../../wrangler.jsonc):

--- a/docs/runbooks/synthetic-en-listing.md
+++ b/docs/runbooks/synthetic-en-listing.md
@@ -65,7 +65,7 @@ Subject: `[StudentX synthetic] N check(s) failed`
 
 Body includes the failing check name, reason, and the first 500 chars of the anon HTML response. Possible reasons:
 
-- `non-200 status: <code>` — the page errored or redirected. Check the Worker logs.
+- `non-200 status: <code>` — the page errored or redirected. Check the Worker logs. **For the three `/en/property/*` page-locale checks**, these go via the CDN (see [Fetch strategy](#fetch-strategy-service-binding-vs-global-fetch)), so a non-200 means the CDN itself is failing or the origin is genuinely down — try the user-facing curl first before assuming the Worker is broken.
 - `missing required EN marker: <marker>` — page returned 200 but the English copy disappeared. Either the gate copy was edited (update marker constants in `route.js`) or the i18n regression class from PR #48 is back.
 - `forbidden EL marker present: <marker>` — Greek leaked onto the EN page. **i18n regression** — investigate `getTranslations` calls in any recently-changed server component.
 - `anon listing detail must serve public, s-maxage=...` — the middleware-set per-request cache header (PR #105) regressed for anon visitors. Either middleware.js stopped matching the path, or `next.config.mjs` re-introduced a static `private` rule that's overriding it. Run the curl commands in the [Manual cache-header probe](#manual-cache-header-probe) section to localise.

--- a/src/app/[locale]/property/[city]/landlord/login/page.js
+++ b/src/app/[locale]/property/[city]/landlord/login/page.js
@@ -32,7 +32,7 @@ function LandlordLoginInner() {
       // Clear any stale session first — a hung _recoverAndRefresh on the
       // cached browser client can saturate the HTTP/2 connection to Supabase
       // and queue the login POST behind a stuck token-refresh request.
-      await supabase.auth.signOut().catch(() => {});
+      await withTimeout(supabase.auth.signOut(), 5000).catch(() => {});
 
       let lastErr;
       for (let attempt = 0; attempt < 2; attempt++) {

--- a/src/app/api/cron/synthetic-en-listing/route.js
+++ b/src/app/api/cron/synthetic-en-listing/route.js
@@ -47,6 +47,18 @@ const SYNTHETIC_AUTH_COOKIE = 'sb-access-token=synthetic-canary-stub';
 // Worker directly, bypassing DNS/CDN/asset-binding interception. Returns
 // null when running outside the Cloudflare runtime (local dev, unit tests),
 // in which case fetchUrl falls back to global fetch.
+//
+// Heads-up for future maintainers: the three /en/property/* page-locale
+// checks deliberately opt out of this binding via useGlobalFetch=true. The
+// service binding bypasses the CDN cache and forces fresh SSR on every
+// probe — which is fine for the AuthGate listing detail (cheap render)
+// and for API routes (no SSR), but tips the heavy property pages over
+// the Worker's resource limits when the 8 checks run concurrently
+// (HubBackground 240k particles + HubDiagram + StripeGradientMesh
+// WebGL all SSR-walking at once → 503/timeout). Those checks only need
+// HTML marker presence, so a CDN-cached response is fine; please don't
+// "unify" them back onto the service binding without rethinking the
+// concurrency model.
 async function getSelfFetcher() {
   try {
     const { env } = await getCloudflareContext({ async: true });
@@ -56,7 +68,7 @@ async function getSelfFetcher() {
   }
 }
 
-async function fetchUrl(url, { method = 'GET', cookie = '' } = {}) {
+async function fetchUrl(url, { method = 'GET', cookie = '', useGlobalFetch = false } = {}) {
   const headers = { 'user-agent': 'StudentX-synthetic/1.0' };
   if (cookie) headers.cookie = cookie;
   const init = {
@@ -65,6 +77,7 @@ async function fetchUrl(url, { method = 'GET', cookie = '' } = {}) {
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     redirect: 'manual',
   };
+  if (useGlobalFetch) return fetch(url, init);
   const self = await getSelfFetcher();
   return self ? self.fetch(url, init) : fetch(url, init);
 }
@@ -281,9 +294,9 @@ async function checkNoMissingMessage(appUrl) {
 // and no EL-only marker leaks through. Caller passes a list of EN markers
 // any of which is sufficient (forgiving against copy tweaks) and a list of
 // EL forbidden markers all of which must be absent.
-async function checkEnLocale({ name, url, anyEnMarker, forbidElMarkers }) {
+async function checkEnLocale({ name, url, anyEnMarker, forbidElMarkers, useGlobalFetch = false }) {
   try {
-    const res = await fetchUrl(url);
+    const res = await fetchUrl(url, { useGlobalFetch });
     if (res.status !== 200) {
       return { name, ok: false, reason: `expected 200, got ${res.status} from ${url}` };
     }
@@ -381,9 +394,16 @@ export async function POST(request) {
     // back to default-locale rendering somewhere in the layout chain.
     // City-hub landing (post Phase-1 multi-city refactor) — distinct from
     // the per-city Propylaea landing checked below.
+    // These three checks use global fetch (CDN path) instead of the
+    // self service-binding — see the comment on getSelfFetcher above.
+    // The locale assertions only need HTML marker presence, so a
+    // CDN-cached response satisfies them; routing them through the
+    // service binding triggers concurrent fresh SSR of the heavy
+    // property pages and 503s the Worker.
     checkEnLocale({
       name: 'en-cityhub-locale',
       url: `${appUrl}/en/property`,
+      useGlobalFetch: true,
       anyEnMarker: [
         'Hover over your city',
         'Global students empowered',
@@ -398,12 +418,14 @@ export async function POST(request) {
     checkEnLocale({
       name: 'en-homepage-locale',
       url: `${appUrl}/en/property/thessaloniki`,
+      useGlobalFetch: true,
       anyEnMarker: ['Take the quiz', 'See all listings', 'How it works'],
       forbidElMarkers: ['Κάνε το κουίζ', 'Δες όλες τις αγγελίες'],
     }),
     checkEnLocale({
       name: 'en-quiz-locale',
       url: `${appUrl}/en/property/thessaloniki/quiz`,
+      useGlobalFetch: true,
       anyEnMarker: ['One minute', "That's it"],
       forbidElMarkers: ['Ένα λεπτό', 'Συνέχεια'],
     }),

--- a/src/app/api/cron/synthetic-en-listing/route.js
+++ b/src/app/api/cron/synthetic-en-listing/route.js
@@ -293,7 +293,9 @@ async function checkNoMissingMessage(appUrl) {
 // Generic /en/* locale check: assert at least one EN-only marker is present
 // and no EL-only marker leaks through. Caller passes a list of EN markers
 // any of which is sufficient (forgiving against copy tweaks) and a list of
-// EL forbidden markers all of which must be absent.
+// EL forbidden markers all of which must be absent. Pass useGlobalFetch=true
+// to route via the CDN instead of the self service-binding — see the comment
+// on getSelfFetcher above for when (and why) you'd want that.
 async function checkEnLocale({ name, url, anyEnMarker, forbidElMarkers, useGlobalFetch = false }) {
   try {
     const res = await fetchUrl(url, { useGlobalFetch });


### PR DESCRIPTION
## Summary

- Three synthetic canaries (`en-cityhub-locale`, `en-homepage-locale`, `en-quiz-locale`) have been alerting every 15 min since the [#134](https://github.com/MichaelChar/StudentX/pull/134) self-binding deploy. Externally the URLs are healthy (200 to real users); the failure is Worker-internal — service-binding sub-fetches bypass the CDN and force fresh SSR of the heavy `/en/property/*` pages (`HubBackground` + `HubDiagram` + `StripeGradientMesh`), which tips the Worker over its resource limits when the 8 `Promise.all` checks run concurrently.
- Adds a `useGlobalFetch` opt-out on `fetchUrl` / `checkEnLocale` and sets it on the three page-locale checks so they go via the CDN. Listing-detail and API checks keep the service binding — they assert specific cache headers or dodge the workers.dev `/api/*` 404, both of which need a direct origin response.
- Updates [`docs/runbooks/synthetic-en-listing.md`](docs/runbooks/synthetic-en-listing.md) with a Fetch-strategy section, cross-links it from the alert-triage section, and adds an inline comment above `getSelfFetcher` so the split is explicit for future maintainers.

**Also picked up on this branch (parallel session, 1-line fix):** `fix(landlord-login): wrap pre-login signOut in withTimeout` — twin of the student-login deadlock fix already on `fix/student-login-stuck-signin`. Orthogonal to the synthetic change but reviewed separately and reasonable to ride along.

## Why this is safe

The page-locale checks only assert HTML marker presence (English text present, no Greek leakage). A CDN-cached page with correct markers means no regression has occurred. A real i18n regression (the bug class from [#48](https://github.com/MichaelChar/StudentX/pull/48)) will surface on the next CDN miss after deploy.

**Detection window caveat (reviewer-flagged):** `s-maxage=300` plus `stale-while-revalidate=86400` on these marketing routes means up to one tick (~15 min) of stale-correct response could mask a fresh regression while Cloudflare revalidates in the background. Bounded detection lag is ~20 min worst case; for the secondary-audience `/en/*` surface this is acceptable. Tracked for a follow-up (cache-bust query param + post-deploy synthetic kick).

The 522 issue that originally motivated [#134](https://github.com/MichaelChar/StudentX/pull/134)'s service-binding switch is resolved — `curl https://studentx.uk/en/property/thessaloniki` returns 200 from outside. `global fetch()` from inside the Worker is safe to use again for these specific checks.

## Test plan

- [x] \`npm run lint\` — clean on PR-diff files (one pre-existing warning in \`cf/worker-entry.mjs\` is unrelated)
- [x] \`npm run test\` — 103/103 pass
- [ ] After deploy: \`curl -X POST -H \"x-cron-secret: \$CRON_SECRET\" https://studentx.studentx-gr.workers.dev/api/cron/synthetic-en-listing\` returns \`{\"ok\":true,...}\` with all 11 checks passing
- [ ] No synthetic alert email at the next 15-minute tick
- [ ] Landlord-login: open \`/property/thessaloniki/landlord/login\` with a stale supabase token in cookies, confirm signOut times out after 5s instead of hanging the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)