### PR TITLE
fix(student-login): wrap pre-login signOut in withTimeout

### DIFF
--- a/src/app/[locale]/student/login/page.js
+++ b/src/app/[locale]/student/login/page.js
@@ -38,7 +38,7 @@ function StudentLoginInner() {
       // Clear any stale session first — a hung _recoverAndRefresh on the
       // cached browser client can saturate the HTTP/2 connection to Supabase
       // and queue the login POST behind a stuck token-refresh request.
-      await supabase.auth.signOut().catch(() => {});
+      await withTimeout(supabase.auth.signOut(), 5000).catch(() => {});
 
       let lastErr;
       for (let attempt = 0; attempt < 2; attempt++) {

--- a/src/app/[locale]/student/login/page.js
+++ b/src/app/[locale]/student/login/page.js
@@ -38,6 +38,8 @@ function StudentLoginInner() {
       // Clear any stale session first — a hung _recoverAndRefresh on the
       // cached browser client can saturate the HTTP/2 connection to Supabase
       // and queue the login POST behind a stuck token-refresh request.
+      // Short 5s timeout (vs. the 15s default elsewhere): this is best-effort
+      // cleanup; if it hangs we shouldn't block the actual login on it.
       await withTimeout(supabase.auth.signOut(), 5000).catch(() => {});
 
       let lastErr;


### PR DESCRIPTION
## Summary

- Bounded the pre-login `supabase.auth.signOut()` call in `withTimeout(..., 5000)` so it can no longer deadlock the student sign-in flow.

## Background

A student reported being stuck on "SIGNING IN…" indefinitely with no error message. Tracing `handleSubmit` in [src/app/[locale]/student/login/page.js](src/app/[locale]/student/login/page.js) revealed that every async call was wrapped in `withTimeout(promise, 15000)` — except line 41:

\`\`\`js
await supabase.auth.signOut().catch(() => {});
\`\`\`

The comment above explains this `signOut()` exists specifically to clear the broken-client state (\"a hung \_recoverAndRefresh on the cached browser client can saturate the HTTP/2 connection\"), but the cleanup call itself is unbounded. If the `/auth/v1/logout` request hangs — exactly the scenario this line was added to recover from — the `await` blocks forever. `.catch()` only handles rejections, not promises that never settle, so the user sees no error and the loading state never clears.

5s timeout chosen because this is best-effort cleanup, not critical path; if it times out we just proceed straight to `signInWithPassword`.

## Test plan

- [x] `npm run lint` — no new warnings/errors
- [x] Renders cleanly in dev preview at `/student/login`
- [ ] Manual verification in prod after merge: sign in completes (or shows an error) within ~20s in all cases, never hangs indefinitely
- [ ] Optional: simulate broken state by setting garbage in `localStorage` for `sb-<project>-auth-token` before login — should still proceed after ~5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)