### PR TITLE
fix(seo): make listing pages partially public for Google indexing

### DIFF
--- a/__tests__/api/syntheticEnListing.test.js
+++ b/__tests__/api/syntheticEnListing.test.js
@@ -20,13 +20,9 @@ import {
 const PRIVATE_CC = 'private, no-cache, no-store, must-revalidate';
 const PUBLIC_CC = 'public, s-maxage=300, stale-while-revalidate=86400';
 
-const VALID_BODY = '<html lang="en"><body>Sign in to view this listing</body></html>';
-// Includes the required English marker so we trip the EL check, not the
-// missing-EN check. (evaluateBody runs required-EN-markers BEFORE
-// forbidden-EL-markers; a real Greek leak in production would have both
-// signals because the page renders the el namespace's title verbatim.)
+const VALID_BODY = '<html lang="en"><body>Sign in to message this landlord</body></html>';
 const GREEK_LEAK_BODY =
-  '<html lang="en"><body>Sign in to view this listing — Συνδέσου για να δεις την αγγελία</body></html>';
+  '<html lang="en"><body>Sign in to message this landlord — Συνδέσου για να επικοινωνήσεις με τον ιδιοκτήτη</body></html>';
 const MISSING_MARKER_BODY = '<html lang="en"><body>Welcome</body></html>';
 
 describe('evaluateBody', () => {

--- a/src/app/[locale]/property/[city]/listing/[id]/layout.js
+++ b/src/app/[locale]/property/[city]/listing/[id]/layout.js
@@ -1,46 +1,18 @@
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { getListingForRender } from "@/lib/listingForRender";
-import { requireStudent } from "@/lib/requireStudent";
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://studentx.uk";
 
 export async function generateMetadata({ params }) {
   const { id, locale } = await params;
-  const [listing, auth] = await Promise.all([
-    getListingForRender(id),
-    requireStudent(),
-  ]);
+  const listing = await getListingForRender(id);
 
   if (!listing) {
     const t = await getTranslations({ locale, namespace: 'propylaea.listing.notFound' });
     return {
       title: t('title'),
       description: t('description'),
-    };
-  }
-
-  // SEO cloaking guard: when the page body will render the auth gate
-  // instead of the listing, also strip the rich preview metadata down
-  // to a noindex stub. Otherwise Google sees structured data + OG
-  // images for content the user is gated out of, which trips the
-  // cloaking heuristic. requireStudent is React.cache()'d so the
-  // page-level call below shares this round-trip.
-  // Wrong-role auth (e.g. landlord) is treated the same as a guest:
-  // they'll see the gate, so the rich metadata must be stripped too.
-  //
-  // The bare string form gets templated by the parent locale layout
-  // ('%s — StudentX' in src/app/[locale]/layout.js), so the title here
-  // must NOT include '— StudentX' itself or it doubles. Use the same
-  // student.gate.* translations that AuthGate renders in the body so
-  // the meta title and the visible heading stay in lockstep.
-  if (!auth || auth.kind === 'wrong-role') {
-    const t = await getTranslations({ locale, namespace: 'student.gate' });
-    return {
-      title: t('title'),
-      description: t('subtitle'),
-      robots: { index: false, follow: false },
-      alternates: undefined,
     };
   }
 
@@ -127,24 +99,14 @@ export async function generateMetadata({ params }) {
 
 export default async function ListingLayout({ children, params }) {
   const { id, locale } = await params;
-  const [listing, auth] = await Promise.all([
-    getListingForRender(id),
-    requireStudent(),
-  ]);
+  const listing = await getListingForRender(id);
 
-  // Surface a real 404 when the listing doesn't exist instead of letting the
-  // client-side page render a soft "Listing not found" body with HTTP 200.
   if (!listing) {
     notFound();
   }
 
-  // Skip JSON-LD when the page body is the auth gate. We already set
-  // robots:noindex above for the same reason, so emitting structured
-  // data here would actively contradict the directive and expose the
-  // listing to crawlers under a sign-in wall. Wrong-role auth lands on
-  // the gate too, so JSON-LD must be skipped for them as well.
   let jsonLd = null;
-  if (listing && auth && auth.kind !== 'wrong-role') {
+  if (listing) {
     const address = listing.address ?? "";
     const neighborhood = listing.neighborhood ?? "Thessaloniki";
     const price = listing.monthly_price;

--- a/src/app/[locale]/property/[city]/listing/[id]/page.js
+++ b/src/app/[locale]/property/[city]/listing/[id]/page.js
@@ -6,8 +6,8 @@ import { Link } from '@/i18n/navigation';
 import { getListingForRender } from '@/lib/listingForRender';
 import { requireStudent } from '@/lib/requireStudent';
 
-import AuthGate from '@/components/AuthGate';
 import ContactRail from '@/components/listing/ContactRail';
+import ContactGate from '@/components/listing/ContactGate';
 import ViewTracker from '@/components/listing/ViewTracker';
 import Pill from '@/components/ui/Pill';
 import Card from '@/components/ui/Card';
@@ -27,35 +27,14 @@ export default async function ListingPage({ params, searchParams }) {
   const sp = (await searchParams) || {};
   setRequestLocale(locale);
 
-  // ?from=<urlencoded querystring> threads the user's prior /results
-  // filter state into the back-link so it returns to the same filtered
-  // view they came from. Plain ?from= param (or missing) → bare /results.
-  // Drop oversized values (length cap above) — fall through to bare
-  // /results rather than echoing untrusted bytes into the rendered href.
   const fromRawInput = typeof sp.from === 'string' ? sp.from : '';
   const fromRaw =
     fromRawInput && fromRawInput.length <= MAX_FROM_LENGTH ? fromRawInput : '';
   const backHref = fromRaw ? `/property/thessaloniki/results?${fromRaw}` : '/property/thessaloniki/results';
 
-  // Auth gate — only authenticated students view listing detail. The
-  // SEO metadata + JSON-LD live in the layout and still get served to
-  // crawlers; this only replaces the page body.
   const auth = await requireStudent();
-  if (!auth || auth.kind === 'wrong-role') {
-    const fromQs = fromRaw ? `?from=${encodeURIComponent(fromRaw)}` : '';
-    const localePrefix = locale === 'el' ? '' : `/${locale}`;
-    const nextPath = `${localePrefix}/property/thessaloniki/listing/${id}${fromQs}`;
-    return (
-      <AuthGate
-        next={nextPath}
-        locale={locale}
-        mode={auth?.kind === 'wrong-role' ? 'wrong-role' : 'guest'}
-      />
-    );
-  }
+  const isAuthed = auth && auth.kind !== 'wrong-role';
 
-  // React.cache() de-dupes this with the layout's fetch — one Supabase
-  // round-trip per request instead of two.
   const listing = await getListingForRender(id);
   if (!listing) notFound();
 
@@ -74,7 +53,7 @@ export default async function ListingPage({ params, searchParams }) {
 
   return (
     <div className="mx-auto max-w-6xl px-5 py-8 md:py-12">
-      <ViewTracker listingId={listing.listing_id} />
+      {isAuthed && <ViewTracker listingId={listing.listing_id} />}
 
       {/* Back link — server-rendered Link. Threads the prior /results
           filter state via ?from= so the back nav lands on the same
@@ -245,7 +224,11 @@ export default async function ListingPage({ params, searchParams }) {
         </div>
 
         {/* Right column — sticky inquiry rail (client-side for modal state) */}
-        <ContactRail listing={listing} />
+        {isAuthed ? (
+          <ContactRail listing={listing} />
+        ) : (
+          <ContactGate listing={listing} locale={locale} fromRaw={fromRaw} />
+        )}
       </div>
     </div>
   );

--- a/src/app/api/cron/synthetic-en-listing/route.js
+++ b/src/app/api/cron/synthetic-en-listing/route.js
@@ -21,11 +21,11 @@ const FETCH_TIMEOUT_MS = 10_000;
 
 const EN_MARKERS_REQUIRED = [
   '<html lang="en"',
-  'Sign in to view this listing',
+  'Sign in to message this landlord',
 ];
 const EL_MARKERS_FORBIDDEN = [
   'lang="el"',
-  'Συνδέσου',
+  'Συνδέσου για να επικοινωνήσεις',
 ];
 
 function isCronAuthorized(request) {

--- a/src/components/listing/ContactGate.js
+++ b/src/components/listing/ContactGate.js
@@ -1,0 +1,79 @@
+import { getTranslations } from 'next-intl/server';
+import { Link } from '@/i18n/navigation';
+import Card from '@/components/ui/Card';
+import Icon from '@/components/ui/Icon';
+import Pill from '@/components/ui/Pill';
+
+export default async function ContactGate({ listing, locale, fromRaw }) {
+  const t = await getTranslations({ locale, namespace: 'propylaea.listing' });
+  const tListing = await getTranslations({ locale, namespace: 'listing' });
+  const tContact = await getTranslations({ locale, namespace: 'student.contact' });
+  const tGate = await getTranslations({ locale, namespace: 'student.gate' });
+
+  const fromQs = fromRaw ? `?from=${encodeURIComponent(fromRaw)}` : '';
+  const localePrefix = locale === 'el' ? '' : `/${locale}`;
+  const nextPath = `${localePrefix}/property/thessaloniki/listing/${listing.listing_id}${fromQs}`;
+  const nextQuery = `?next=${encodeURIComponent(nextPath)}`;
+
+  return (
+    <aside>
+      <div className="lg:sticky lg:top-6">
+        <Card tone="white" className="p-6">
+          <p className="font-display text-3xl text-blue">
+            {listing.monthly_price != null ? (
+              <>
+                €{listing.monthly_price}
+                <span className="text-base text-night/50">/mo</span>
+              </>
+            ) : (
+              <span className="text-base text-night/50">
+                {tListing('priceOnRequest')}
+              </span>
+            )}
+          </p>
+          <div className="mt-2">
+            <Pill variant="programme">{t('authMedicalProgramme')}</Pill>
+          </div>
+          <p className="mt-5 text-night/70 text-sm leading-relaxed">
+            {t('directTagline')}
+          </p>
+
+          <div className="mt-5 space-y-3">
+            <div className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-yellow/15 mx-auto">
+              <Icon name="shield" className="w-4 h-4 text-yellow" />
+            </div>
+            <p className="font-display text-lg text-night leading-tight">
+              {tContact('guestTitle')}
+            </p>
+            <p className="text-night/60 text-sm leading-relaxed">
+              {tContact('guestBody')}
+            </p>
+
+            <Link
+              href={`/student/signup${nextQuery}`}
+              className="inline-flex items-center justify-center w-full bg-blue text-white font-sans font-semibold uppercase tracking-[0.08em] text-xs px-5 py-3 rounded hover:bg-night transition-colors"
+            >
+              {tGate('signUp')}
+            </Link>
+            <Link
+              href={`/student/login${nextQuery}`}
+              className="inline-flex items-center justify-center w-full border border-blue text-blue font-sans font-semibold uppercase tracking-[0.08em] text-xs px-5 py-3 rounded hover:bg-blue hover:text-white transition-colors"
+            >
+              {tGate('signIn')}
+            </Link>
+          </div>
+
+          <p className="mt-5 text-xs text-night/40 text-center">
+            {tGate('landlordHint')}{' '}
+            <Link
+              href="/property/thessaloniki/landlord/login"
+              className="text-blue hover:text-night font-medium"
+            >
+              {tGate('landlordLink')} →
+            </Link>
+          </p>
+        </Card>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary

- Listing detail pages were excluded from Google's index (GSC: "Excluded by noindex tag") because the layout's cloaking guard set `robots: noindex` for unauthenticated visitors while the sitemap advertised those URLs
- Now the full listing body (photos, price, description, amenities, distances) renders for **all visitors** — only the contact/inquiry sidebar is gated behind student auth via a new `ContactGate` component
- Rich metadata (OG tags, hreflang alternates) and JSON-LD (`RealEstateListing`) are served unconditionally — no more noindex for Googlebot
- Synthetic monitor markers updated to match the new unauthenticated page body

**Other GSC reasons (no action needed):** "Alternative page with proper canonical tag" (expected hreflang behavior), "Page with redirect" (intentional legacy URL 301s), "Not found (404)" (deleted listings in crawl queue)

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run test` passes (103/103)
- [ ] Visit `/property/thessaloniki/listing/<id>` unauthenticated — full listing content visible, ContactGate sidebar with signup/signin CTAs
- [ ] Visit same URL authenticated — ContactRail (inquiry composer) appears instead
- [ ] View source on unauthenticated page — `robots: index, follow`, rich OG tags, JSON-LD present
- [ ] `/en/property/thessaloniki/listing/<id>` — English markers present, no Greek leakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)