### PR TITLE
fix(cron): consolidate saved-searches digest under one trigger so student-message-digest can register

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,17 +161,41 @@ Conventions still in force:
 
 ## Cron architecture
 
-Two pieces must stay in sync:
+Three pieces must stay in sync:
 
 | Piece | File | What it holds |
 |---|---|---|
 | Cron triggers | `wrangler.jsonc` `triggers.crons` | Cron expressions Cloudflare fires |
 | Cron dispatch | `cf/worker-entry.mjs` `CRON_ROUTES` | Cron expression → `{ name, path, query }` |
+| Live schedules | Cloudflare API `/workers/scripts/studentx/schedules` | What CF actually fires (deploy pipeline doesn't sync this — see PR #150) |
 
-The `scheduled` handler looks up `event.cron` in `CRON_ROUTES`, then POSTs
-to `${NEXT_PUBLIC_APP_URL}${path}?${query}` with the `x-cron-secret` header.
+The `scheduled` handler looks up `event.cron` in `CRON_ROUTES`, then invokes
+OpenNext's `fetch` directly (no network self-call — see PR #133's findings).
 25-second `AbortSignal.timeout` (under CF's ~30 s scheduled-handler limit).
 `ctx.waitUntil()` keeps the Worker alive past the synchronous return.
+
+**Cloudflare Free plan caps a Worker at 5 cron triggers** — the 6th is
+silently rejected at registration time with API error 10072 (confirmed in
+PR #150 after the student-message-digest trigger had been silently dropped
+for 3 days). Keep `triggers.crons` at ≤5; if you need more, either upgrade
+to Workers Paid ($5/mo, 250-trigger cap) or consolidate cadences into a
+single trigger with day-of-week branching inside the route (saved-searches
+is the canonical example — see `frequenciesToProcess` in
+`src/app/api/cron/saved-searches-digest/route.js`).
+
+**The deploy pipeline does NOT sync trigger changes.**
+`opennextjs-cloudflare deploy` pushes the script bundle but leaves
+`/schedules` untouched. After any edit to `wrangler.jsonc.triggers.crons`,
+re-PUT the live schedules array via the CF API or
+`wrangler deploy`. Verify drift with:
+
+```bash
+curl -sS -H "Authorization: Bearer $TOKEN" \
+  "https://api.cloudflare.com/client/v4/accounts/<acct>/workers/scripts/studentx/schedules" \
+  | jq -r '.result.schedules[].cron' | sort
+```
+
+against the `triggers.crons` array in `wrangler.jsonc`. They must match.
 
 **All cron routes auth via `CRON_SECRET`** — accepted via either the
 `x-cron-secret` header OR `?secret=` query param. `CRON_SECRET` is a Worker
@@ -181,14 +205,17 @@ Current crons (verified against `wrangler.jsonc` and `cf/worker-entry.mjs`):
 
 | Cron expression | Route | Purpose |
 |---|---|---|
-| `0 9 * * *`     | `/api/cron/saved-searches-digest?frequency=daily`  | Daily saved-search digest |
-| `0 9 * * 1`     | `/api/cron/saved-searches-digest?frequency=weekly` | Weekly saved-search digest (Monday) |
-| `15 9 * * *`    | `/api/cron/recompute-distances`                    | Heal missing `faculty_distances` rows (PR #60) |
-| `*/5 * * * *`   | `/api/cron/landlord-message-digest`                | Per-message landlord digest |
-| `2-58/5 * * * *` | `/api/cron/student-message-digest`               | Per-message student digest (mirror of landlord, offset 2 min) |
-| `*/15 * * * *`  | `/api/cron/synthetic-en-listing`                   | i18n regression guard (issue #49) |
+| `0 9 * * *`     | `/api/cron/saved-searches-digest`                  | Saved-search digest. Daily every day; weekly subscribers are also processed on Mondays via `getUTCDay() === 1` inside the route (consolidated in PR #150 to free a trigger slot under CF's 5-trigger cap). Explicit `?frequency=daily\|weekly` still works for manual curl. |
+| `15 9 * * *`    | `/api/cron/recompute-distances`                    | Heal missing `faculty_distances` rows (PR #60). |
+| `*/5 * * * *`   | `/api/cron/landlord-message-digest`                | Per-message landlord digest. |
+| `2-58/5 * * * *` | `/api/cron/student-message-digest`                | Per-message student digest (mirror of landlord, offset 2 min). |
+| `*/15 * * * *`  | `/api/cron/synthetic-en-listing`                   | i18n regression guard (issue #49). |
 
-Adding a new cron is a one-line entry in each table.
+Adding a new cron is a one-line entry in each of `wrangler.jsonc.triggers.crons`
+and `cf/worker-entry.mjs`'s `CRON_ROUTES`, **plus** a manual schedule sync
+(see "Cron architecture" above — deploy pipeline doesn't sync triggers).
+If this would push the count above 5, consolidate an existing cron first
+(saved-searches is the template) or upgrade to Workers Paid.
 
 ## Synthetic monitoring
 

--- a/__tests__/api/savedSearchesDigest.test.js
+++ b/__tests__/api/savedSearchesDigest.test.js
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Covers the frequency-selection logic added in PR #150 (consolidation of
+// the daily and weekly saved-searches digest crons under a single trigger).
+// The route now picks which frequencies to process from either the
+// `?frequency=` query param (explicit override, used by manual curl and
+// any legacy registration that still passes it) or, when unset, the
+// current UTC day-of-week: daily every day, weekly also on Mondays.
+//
+// The branching itself is the entire new logic, so each test simply asserts
+// which `frequency` filter values the route applied to the saved_searches
+// query — that's the observable downstream of the decision. We short-circuit
+// with an empty result so the test doesn't have to mock the Resend send /
+// claim_digest_send paths, which are exercised by the route's existing
+// integration callers, not by this branch logic.
+
+const supabaseCalls = { frequencies: [] };
+
+vi.mock('@/lib/supabase', () => ({
+  getSupabase: () => ({
+    from: (_table) => {
+      const chain = {
+        select: () => chain,
+        eq: (col, val) => {
+          if (col === 'frequency') supabaseCalls.frequencies.push(val);
+          return chain;
+        },
+        // The route awaits the chained query; this resolves it.
+        then: (onFulfilled) => Promise.resolve({ data: [], error: null }).then(onFulfilled),
+      };
+      return chain;
+    },
+  }),
+}));
+
+vi.mock('@/lib/resend', () => ({
+  getResend: () => ({ emails: { send: vi.fn() } }),
+}));
+
+vi.mock('@/lib/emailSuppressions', () => ({
+  isEmailSuppressed: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('@/templates/email/digest', () => ({
+  digestEmailHtml: () => '<html />',
+  digestEmailSubject: () => 'subj',
+}));
+
+vi.mock('@/lib/transformListing', () => ({
+  transformListing: (x) => x,
+}));
+
+const { POST } = await import('@/app/api/cron/saved-searches-digest/route');
+
+const CRON_SECRET_VALUE = 'test-cron-secret';
+
+beforeEach(() => {
+  process.env.CRON_SECRET = CRON_SECRET_VALUE;
+  supabaseCalls.frequencies = [];
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function makeReq(query = '') {
+  const url = `https://test.local/api/cron/saved-searches-digest${query ? `?${query}` : ''}`;
+  return new Request(url, {
+    method: 'POST',
+    headers: { 'x-cron-secret': CRON_SECRET_VALUE },
+  });
+}
+
+describe('saved-searches-digest frequency selection', () => {
+  it('returns 401 when CRON_SECRET mismatches', async () => {
+    const req = new Request('https://test.local/api/cron/saved-searches-digest', {
+      method: 'POST',
+      headers: { 'x-cron-secret': 'wrong' },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('processes only weekly when ?frequency=weekly is set', async () => {
+    const res = await POST(makeReq('frequency=weekly'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.frequencies).toEqual(['weekly']);
+    expect(supabaseCalls.frequencies).toEqual(['weekly']);
+  });
+
+  it('processes only daily when ?frequency=daily is set', async () => {
+    const res = await POST(makeReq('frequency=daily'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.frequencies).toEqual(['daily']);
+    expect(supabaseCalls.frequencies).toEqual(['daily']);
+  });
+
+  it('processes only daily on a non-Monday with no query', async () => {
+    vi.useFakeTimers();
+    // 2026-05-12 is a Tuesday in UTC.
+    vi.setSystemTime(new Date('2026-05-12T09:00:00Z'));
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.frequencies).toEqual(['daily']);
+    expect(supabaseCalls.frequencies).toEqual(['daily']);
+  });
+
+  it('processes both daily and weekly on a Monday with no query', async () => {
+    vi.useFakeTimers();
+    // 2026-05-11 is a Monday in UTC. The cron's actual fire time is
+    // 09:00 UTC; pick a time well clear of the day boundary so the test
+    // documents the intended firing window rather than the edge case.
+    vi.setSystemTime(new Date('2026-05-11T09:00:00Z'));
+    const res = await POST(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.frequencies).toEqual(['daily', 'weekly']);
+    expect(supabaseCalls.frequencies).toEqual(['daily', 'weekly']);
+  });
+
+  it('aggregates zero processed/sent across both frequencies on a Monday', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T09:00:00Z'));
+    const res = await POST(makeReq());
+    const body = await res.json();
+    expect(body).toMatchObject({
+      processed: 0,
+      emailsSent: 0,
+      alreadyClaimed: 0,
+      frequencies: ['daily', 'weekly'],
+    });
+  });
+});

--- a/cf/worker-entry.mjs
+++ b/cf/worker-entry.mjs
@@ -18,13 +18,16 @@ export { DOQueueHandler, DOShardedTagCache, BucketCachePurge };
 // NEXT_PUBLIC_APP_URL; `query` is appended verbatim if present. Adding a new
 // scheduled route is a one-line addition here plus the cron pattern in
 // wrangler.jsonc.
+// NB: this map has 5 entries to stay under Cloudflare's Free-plan limit of
+// 5 cron triggers per Worker. The saved-searches-digest route picks daily
+// vs weekly internally (daily every day, weekly also on Mondays UTC) so a
+// single 09:00 UTC trigger covers both cadences.
 const CRON_ROUTES = {
-  "0 9 * * *":    { name: "saved-searches-daily",   path: "/api/cron/saved-searches-digest",   query: "frequency=daily" },
-  "0 9 * * 1":    { name: "saved-searches-weekly",  path: "/api/cron/saved-searches-digest",   query: "frequency=weekly" },
-  "15 9 * * *":   { name: "recompute-distances",    path: "/api/cron/recompute-distances",     query: null },
-  "*/5 * * * *":  { name: "landlord-message-digest", path: "/api/cron/landlord-message-digest", query: null },
-  "2-58/5 * * * *": { name: "student-message-digest", path: "/api/cron/student-message-digest", query: null },
-  "*/15 * * * *": { name: "synthetic-en-listing",   path: "/api/cron/synthetic-en-listing",    query: null },
+  "0 9 * * *":      { name: "saved-searches-digest",   path: "/api/cron/saved-searches-digest",   query: null },
+  "15 9 * * *":     { name: "recompute-distances",     path: "/api/cron/recompute-distances",     query: null },
+  "*/5 * * * *":    { name: "landlord-message-digest", path: "/api/cron/landlord-message-digest", query: null },
+  "2-58/5 * * * *": { name: "student-message-digest",  path: "/api/cron/student-message-digest",  query: null },
+  "*/15 * * * *":   { name: "synthetic-en-listing",    path: "/api/cron/synthetic-en-listing",    query: null },
 };
 
 async function runCron(event, env, ctx) {

--- a/src/app/api/cron/saved-searches-digest/route.js
+++ b/src/app/api/cron/saved-searches-digest/route.js
@@ -178,8 +178,16 @@ export async function POST(request) {
   } else if (frequencyParam === 'daily') {
     frequenciesToProcess = ['daily'];
   } else {
-    // getUTCDay(): 0=Sun, 1=Mon, ..., 6=Sat. Cron fires at 09:00 UTC, well
-    // away from the day boundary, so day-of-week is unambiguous.
+    // getUTCDay(): 0=Sun, 1=Mon, ..., 6=Sat. Coupling to keep in mind: the
+    // cron trigger in wrangler.jsonc fires at 09:00 UTC, well away from the
+    // day boundary, so "Monday in UTC at fire time" matches "Monday in
+    // Europe/Athens at fire time" (11:00 EET / 12:00 EEST) all year round.
+    // If you re-time this cron, re-check that the UTC-Monday window still
+    // aligns with the intended user-perceived Monday. Note this also reads
+    // the wall clock at request time, not at the scheduled fire time, so a
+    // manual curl invocation across the UTC day boundary will see whichever
+    // side it lands on — fine because claim_digest_send debounces any
+    // duplicate weekly run within 6 days.
     const dayOfWeek = new Date().getUTCDay();
     frequenciesToProcess = dayOfWeek === 1 ? ['daily', 'weekly'] : ['daily'];
   }

--- a/src/app/api/cron/saved-searches-digest/route.js
+++ b/src/app/api/cron/saved-searches-digest/route.js
@@ -72,16 +72,10 @@ async function fetchMatchingListings(supabase, filters, since) {
   return results;
 }
 
-export async function POST(request) {
-  if (!isCronAuthorized(request)) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  const { searchParams } = new URL(request.url);
-  const frequency = searchParams.get('frequency') === 'weekly' ? 'weekly' : 'daily';
-
-  const supabase = getSupabase();
-
+// Process one frequency's saved searches. Returns aggregate stats. Factored
+// out so a single cron invocation can run both daily and weekly back-to-back
+// (e.g. on Mondays under the consolidated cron).
+async function processFrequency(supabase, frequency, appUrl, resend) {
   // Fetch all active saved searches for this frequency
   const { data: searches, error: fetchError } = await supabase
     .from('saved_searches')
@@ -90,16 +84,14 @@ export async function POST(request) {
     .eq('frequency', frequency);
 
   if (fetchError) {
-    console.error('Failed to fetch saved searches:', fetchError);
-    return NextResponse.json({ error: 'Failed to fetch saved searches' }, { status: 500 });
+    console.error(`Failed to fetch ${frequency} saved searches:`, fetchError);
+    return { processed: 0, emailsSent: 0, alreadyClaimed: 0, error: true };
   }
 
   if (!searches || searches.length === 0) {
-    return NextResponse.json({ processed: 0, emailsSent: 0 });
+    return { processed: 0, emailsSent: 0, alreadyClaimed: 0 };
   }
 
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://studentx.uk';
-  const resend = getResend();
   let emailsSent = 0;
   let alreadyClaimed = 0;
   // Min interval per frequency. Slightly tighter than the full period so a
@@ -162,5 +154,70 @@ export async function POST(request) {
     }
   }
 
-  return NextResponse.json({ processed: searches.length, emailsSent, alreadyClaimed });
+  return { processed: searches.length, emailsSent, alreadyClaimed };
+}
+
+export async function POST(request) {
+  if (!isCronAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  // Cron consolidation: we run on a single daily trigger (0 9 * * *) instead
+  // of two separate triggers (one daily, one weekly), to stay under
+  // Cloudflare's Free-plan limit of 5 cron triggers per Worker. When called
+  // without an explicit `frequency` query param, process daily every day and
+  // also process weekly on Mondays (UTC). An explicit `?frequency=...` value
+  // overrides this — useful for manual curl invocations and for backward
+  // compatibility with any legacy cron registration that still passes the
+  // query string.
+  const { searchParams } = new URL(request.url);
+  const frequencyParam = searchParams.get('frequency');
+  let frequenciesToProcess;
+  if (frequencyParam === 'weekly') {
+    frequenciesToProcess = ['weekly'];
+  } else if (frequencyParam === 'daily') {
+    frequenciesToProcess = ['daily'];
+  } else {
+    // getUTCDay(): 0=Sun, 1=Mon, ..., 6=Sat. Cron fires at 09:00 UTC, well
+    // away from the day boundary, so day-of-week is unambiguous.
+    const dayOfWeek = new Date().getUTCDay();
+    frequenciesToProcess = dayOfWeek === 1 ? ['daily', 'weekly'] : ['daily'];
+  }
+
+  const supabase = getSupabase();
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://studentx.uk';
+  const resend = getResend();
+
+  let totalProcessed = 0;
+  let totalEmailsSent = 0;
+  let totalAlreadyClaimed = 0;
+  let sawError = false;
+
+  for (const frequency of frequenciesToProcess) {
+    const stats = await processFrequency(supabase, frequency, appUrl, resend);
+    totalProcessed += stats.processed;
+    totalEmailsSent += stats.emailsSent;
+    totalAlreadyClaimed += stats.alreadyClaimed;
+    if (stats.error) sawError = true;
+  }
+
+  if (sawError) {
+    return NextResponse.json(
+      {
+        error: 'One or more frequencies failed to fetch',
+        processed: totalProcessed,
+        emailsSent: totalEmailsSent,
+        alreadyClaimed: totalAlreadyClaimed,
+        frequencies: frequenciesToProcess,
+      },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    processed: totalProcessed,
+    emailsSent: totalEmailsSent,
+    alreadyClaimed: totalAlreadyClaimed,
+    frequencies: frequenciesToProcess,
+  });
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -55,8 +55,15 @@
   // NEXT_PUBLIC_APP_URL + CRON_SECRET. Keep cf/worker-entry.mjs's CRON_ROUTES
   // in sync with these patterns.
   //
-  //   0 9 * * *      → /api/cron/saved-searches-digest?frequency=daily
-  //   0 9 * * 1      → /api/cron/saved-searches-digest?frequency=weekly
+  // NB: Cloudflare's Free plan caps a Worker at 5 cron triggers — Cloudflare
+  // silently rejects the 6th at registration time (error 10072), so keep
+  // this list at ≤5. The saved-searches digest runs daily and also handles
+  // its weekly cadence on Mondays inside the route, so we don't need a
+  // separate weekly trigger.
+  //
+  //   0 9 * * *      → /api/cron/saved-searches-digest (daily every day +
+  //                    weekly on Mondays, picked by day-of-week inside the
+  //                    route)
   //   15 9 * * *     → /api/cron/recompute-distances (heals missing
   //                    faculty_distances pairs for new/edited listings;
   //                    no-op when fully populated)
@@ -74,12 +81,11 @@
   ],
   "triggers": {
     "crons": [
-      "0 9 * * *",    // daily saved-searches digest
-      "0 9 * * 1",    // weekly saved-searches digest (Mondays)
-      "15 9 * * *",   // nightly faculty_distances backfill
-      "*/5 * * * *",  // landlord message digest (every 5 min)
+      "0 9 * * *",      // saved-searches digest (daily, with weekly on Mondays handled in-route)
+      "15 9 * * *",     // nightly faculty_distances backfill
+      "*/5 * * * *",    // landlord message digest (every 5 min)
       "2-58/5 * * * *", // student message digest (every 5 min, offset 2 min from landlord)
-      "*/15 * * * *"  // synthetic /en/listing locale check (#49)
+      "*/15 * * * *"    // synthetic /en/listing locale check (#49)
     ]
   }
 }


### PR DESCRIPTION
## Summary

Cloudflare's Free plan caps a Worker at 5 cron triggers. `wrangler.jsonc` had 6, so the 6th — `2-58/5 * * * *` for student-message-digest, added in #123 — was being silently rejected at registration time (error 10072). The student message digest cron has therefore never fired in production.

This PR drops the separate `0 9 * * 1` weekly saved-searches trigger and folds its behavior into the daily `0 9 * * *` route. The route now picks frequencies by day-of-week (UTC): daily every day, weekly also on Mondays. Trigger count → 5, leaving room for `2-58/5` on the next schedule sync.

## Diagnosis (for the record)

- `GET /accounts/.../workers/scripts/studentx/schedules` returned only 5 of the 6 triggers from `wrangler.jsonc`. All registered schedules' `modified_on` was 20 min before #123 merged.
- `wrangler tail` confirmed live: `*/5` landlord ticks and `*/15` synthetic ticks fired on schedule, but no `2-58/5` student tick appeared at the expected minutes.
- Direct PUT of the 6-element array to the schedules API returned error 10072 with a link to https://developers.cloudflare.com/workers/platform/limits/#account-plan-limits.
- All other layers verified working: migration 044 applied, `get_pending_student_notifications` returns the pending jxhe row, all Worker secrets present, recipient not on the suppression list.

## What changed

- **`src/app/api/cron/saved-searches-digest/route.js`** — extracted `processFrequency()` helper. POST handler determines which frequencies to process: if `?frequency=` is set it honors that (manual curl + back-compat); otherwise it processes daily always, and weekly on Mondays (`getUTCDay() === 1`). Response now returns aggregated `processed`, `emailsSent`, `alreadyClaimed`, plus a `frequencies` array showing what ran.
- **`cf/worker-entry.mjs`** — removed the `0 9 * * 1` entry. The `0 9 * * *` entry no longer passes `?frequency=daily`; the route handles it.
- **`wrangler.jsonc`** — dropped `0 9 * * 1` from `triggers.crons`. Comment block updated to explain the 5-trigger Free-plan cap and the consolidated route behavior.

## Post-merge step (not part of this PR)

The CF deploy pipeline does NOT sync trigger changes — only the script bundle. Even after this merges and Workers Build redeploys, the live schedules will still be the same 5 stale ones (with `0 9 * * 1` still registered and `2-58/5` still missing). To complete the fix, the schedules array must be re-PUT against the CF API:

```bash
curl -X PUT \
  -H "Authorization: Bearer $CF_TOKEN" \
  -H "Content-Type: application/json" \
  "https://api.cloudflare.com/client/v4/accounts/<account>/workers/scripts/studentx/schedules" \
  -d '[{"cron":"0 9 * * *"},{"cron":"15 9 * * *"},{"cron":"*/5 * * * *"},{"cron":"2-58/5 * * * *"},{"cron":"*/15 * * * *"}]'
```

This trigger-sync gap is itself a real bug — worth a follow-up to either switch to `wrangler deploy` (which does sync triggers) or add a CI check that diffs `wrangler.jsonc.triggers.crons` against the live schedules endpoint.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run test` — 118/118 tests passing
- [x] `npm run build` passes locally
- [ ] After merge + deploy + schedule PUT: `wrangler tail` shows `[cron] student-message-digest ok: processed=1 sent=1 claimed=1` within 5 min
- [ ] `student_message_notifications.last_notified_at` is no longer NULL for inquiry `37e2ca4a-...`
- [ ] Recipient receives an email at `hejixuan1234@gmail.com` from `alerts@studentx.uk`
- [ ] First Monday after merge: tail shows `[cron] saved-searches-digest ok: processed=N emailsSent=N alreadyClaimed=N` with `frequencies: ["daily", "weekly"]` in the response body

🤖 Generated with [Claude Code](https://claude.com/claude-code)