### PR TITLE
fix(crons): only re-send message digest when new messages have arrived (closes #151)

### DIFF
--- a/supabase/migrations/045_message_digest_new_message_filter.sql
+++ b/supabase/migrations/045_message_digest_new_message_filter.sql
@@ -1,0 +1,173 @@
+-- ============================================================
+-- Migration 045: Suppress message-digest re-sends of identical content.
+-- ============================================================
+--
+-- Pre-fix behavior (PR #40 landlord, PR #123 student): the cron's
+-- debounce window (4m30s) is shorter than the cron tick (5 min), so
+-- every tick re-claims and re-sends the same digest while
+-- *_unread_count stays > 0. The get_pending_*_notifications functions
+-- gated only on a coarse time-since-last-notify
+-- (`last_notified_at < now() - p_min_interval`), not on whether new
+-- messages had actually arrived since the last notification. Result:
+-- a landlord with one unread message received the same digest email
+-- every 5 minutes until they opened the chat in-app and triggered
+-- mark_messages_read. Surfaced 2026-05-11 in issue #151 after PR #150
+-- made the student-message-digest cron actually fire.
+--
+-- Fix: rewrite get_pending_landlord_notifications and
+-- get_pending_student_notifications to return a row only when there
+-- exists an unread message from the other side with `created_at >
+-- last_notified_at` (i.e. a NEW message we haven't notified about
+-- yet). Same return shape, same grants, same SECURITY DEFINER. The
+-- partial index `idx_inquiry_messages_unread (inquiry_id, sender_role)
+-- WHERE read_at IS NULL` (migration 027) serves the new EXISTS clause
+-- efficiently.
+--
+-- The companion claim_*_message_notification RPCs are NOT changed.
+-- Their conditional UPDATE remains the race-condition guard between
+-- overlapping cron invocations (e.g. a tick that runs a few seconds
+-- late doesn't get rejected by its own previous run); the new "is
+-- there anything new to say" gating lives one layer up in
+-- get_pending_*.
+--
+-- Effect on currently-stuck inquiries: any inquiry where the most
+-- recent unread message has `created_at <= last_notified_at` is
+-- immediately filtered out of the pending list on the next cron tick
+-- after this migration applies. No data backfill needed — the new
+-- query reads existing rows correctly.
+--
+-- Parameter note: p_min_interval is now unused inside both functions
+-- but kept in the signature so the calling routes
+-- (src/app/api/cron/{landlord,student}-message-digest/route.js)
+-- continue to compile without a coordinated change. A follow-up PR
+-- can drop the parameter once the migration has landed.
+
+CREATE OR REPLACE FUNCTION public.get_pending_landlord_notifications(
+  p_min_interval interval
+) RETURNS TABLE (
+  inquiry_id              UUID,
+  listing_id              TEXT,
+  landlord_email          TEXT,
+  landlord_name           TEXT,
+  landlord_locale         TEXT,
+  student_display_name    TEXT,
+  unread_count            INT,
+  last_message_at         TIMESTAMPTZ,
+  latest_message_body     TEXT,
+  listing_address         TEXT,
+  listing_neighborhood    TEXT,
+  listing_monthly_price   NUMERIC
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+  SELECT i.inquiry_id,
+         i.listing_id,
+         ll.email,
+         ll.name,
+         ll.preferred_locale,
+         st.display_name,
+         i.landlord_unread_count,
+         i.last_message_at,
+         (SELECT m.body
+            FROM inquiry_messages m
+           WHERE m.inquiry_id = i.inquiry_id
+             AND m.sender_role = 'student'
+             AND m.read_at IS NULL
+           ORDER BY m.created_at DESC
+           LIMIT 1) AS latest_message_body,
+         loc.address,
+         loc.neighborhood,
+         r.monthly_price
+    FROM inquiries i
+    JOIN listings  l  ON l.listing_id  = i.listing_id
+    JOIN landlords ll ON ll.landlord_id = l.landlord_id
+    LEFT JOIN students st ON st.auth_user_id = i.student_user_id
+    LEFT JOIN location loc ON loc.location_id = l.location_id
+    LEFT JOIN rent     r   ON r.rent_id       = l.rent_id
+    LEFT JOIN landlord_message_notifications n
+           ON n.inquiry_id = i.inquiry_id
+   WHERE i.landlord_unread_count > 0
+     AND ll.email IS NOT NULL
+     -- "Is there at least one unread student message that arrived
+     -- after we last notified this landlord?" Using
+     -- read_at IS NULL (rather than read_at > last_notified_at) because
+     -- read_at is the canonical "landlord acknowledged this" signal —
+     -- mark_messages_read sets it transactionally alongside the
+     -- unread-count zeroing. The partial index
+     -- idx_inquiry_messages_unread (inquiry_id, sender_role) WHERE
+     -- read_at IS NULL keeps this scan O(unread messages per inquiry).
+     AND EXISTS (
+       SELECT 1
+         FROM inquiry_messages m
+        WHERE m.inquiry_id = i.inquiry_id
+          AND m.sender_role = 'student'
+          AND m.read_at IS NULL
+          AND (n.last_notified_at IS NULL
+               OR m.created_at > n.last_notified_at)
+     );
+$function$;
+
+CREATE OR REPLACE FUNCTION public.get_pending_student_notifications(
+  p_min_interval interval
+) RETURNS TABLE (
+  inquiry_id              UUID,
+  listing_id              TEXT,
+  student_email           TEXT,
+  student_name            TEXT,
+  student_locale          TEXT,
+  landlord_display_name   TEXT,
+  unread_count            INT,
+  last_message_at         TIMESTAMPTZ,
+  latest_message_body     TEXT,
+  listing_address         TEXT,
+  listing_neighborhood    TEXT,
+  listing_monthly_price   NUMERIC
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+  SELECT i.inquiry_id,
+         i.listing_id,
+         st.email,
+         st.display_name,
+         st.preferred_locale,
+         ll.name,
+         i.student_unread_count,
+         i.last_message_at,
+         (SELECT m.body
+            FROM inquiry_messages m
+           WHERE m.inquiry_id = i.inquiry_id
+             AND m.sender_role = 'landlord'
+             AND m.read_at IS NULL
+           ORDER BY m.created_at DESC
+           LIMIT 1) AS latest_message_body,
+         loc.address,
+         loc.neighborhood,
+         r.monthly_price
+    FROM inquiries i
+    JOIN students  st ON st.auth_user_id = i.student_user_id
+    JOIN listings  l  ON l.listing_id    = i.listing_id
+    JOIN landlords ll ON ll.landlord_id  = l.landlord_id
+    LEFT JOIN location loc ON loc.location_id = l.location_id
+    LEFT JOIN rent     r   ON r.rent_id       = l.rent_id
+    LEFT JOIN student_message_notifications n
+           ON n.inquiry_id = i.inquiry_id
+   WHERE i.student_unread_count > 0
+     AND st.email IS NOT NULL
+     -- Mirror of the landlord variant: only return the inquiry if
+     -- there's at least one unread landlord message newer than the
+     -- last notification we sent. See the comment block above for the
+     -- full rationale.
+     AND EXISTS (
+       SELECT 1
+         FROM inquiry_messages m
+        WHERE m.inquiry_id = i.inquiry_id
+          AND m.sender_role = 'landlord'
+          AND m.read_at IS NULL
+          AND (n.last_notified_at IS NULL
+               OR m.created_at > n.last_notified_at)
+     );
+$function$;


### PR DESCRIPTION
Closes #151.

## Summary

Both `landlord-message-digest` and `student-message-digest` crons re-sent the identical digest email every 5 minutes for as long as the recipient's `*_unread_count` stayed > 0. Surfaced 2026-05-11 by the user creating a test inquiry and getting the same "new message" email at 3:00, 3:05, 3:10, 3:15, 3:20 PM EEST after submitting one message at 2:55 PM EEST.

This PR rewrites the two `get_pending_*_notifications` RPCs so the cron only returns an inquiry when there's an **unread message newer than `last_notified_at`** — i.e. a new message we haven't notified about yet. Pure SQL change; the calling routes don't change, the claim RPCs don't change.

## Root cause (full detail in #151)

Two pre-existing design flaws compound:

1. `MIN_INTERVAL` (4m30s) < cron tick (5min), so every tick is always eligible to re-claim.
2. `get_pending_*_notifications` gated only on `last_notified_at < now() - p_min_interval`, never on whether new messages had arrived. The `unread_count_snapshot` column was stored at claim time but never read.

Result: one unread message → identical email every 5 min until the recipient opened the chat in-app.

Latent on the landlord side since #40; surfaced for both sides after #150 made the student cron actually fire.

## Implementation

`supabase/migrations/045_message_digest_new_message_filter.sql` replaces both `get_pending_*_notifications` RPCs. The new WHERE clause adds:

```sql
AND EXISTS (
  SELECT 1
    FROM inquiry_messages m
   WHERE m.inquiry_id = i.inquiry_id
     AND m.sender_role = 'student'  -- 'landlord' for the student variant
     AND m.read_at IS NULL
     AND (n.last_notified_at IS NULL
          OR m.created_at > n.last_notified_at)
)
```

Same function signatures, same return shape, same grants (`anon`, `authenticated`), same `SECURITY DEFINER`. The partial index `idx_inquiry_messages_unread (inquiry_id, sender_role) WHERE read_at IS NULL` (migration 027) serves the new scan efficiently.

`claim_*_message_notification` is unchanged — its conditional UPDATE remains the race-condition guard between overlapping cron invocations.

`p_min_interval` is now unused inside the function bodies but kept in the signatures so the calling routes don't need a coordinated change. A follow-up PR can drop the parameter cleanly.

## Effect on currently-stuck inquiries

Any inquiry where the most recent unread message has `created_at <= last_notified_at` is immediately filtered out on the next cron tick after the migration applies.

For inquiry `0f6e4125-...` (the user's test case that's been spamming since ~11:55 UTC): `last_notified_at ~= 12:25 UTC`, only unread message at 11:55 UTC. After this migration applies, that row stops being returned by `get_pending_landlord_notifications` — the email storm stops immediately, no in-app action needed from the user.

## Pre-merge step (per CLAUDE.md migration-ordering convention)

Apply this migration to prod **before** merging:

```bash
# via the Supabase MCP, with the contents of 045_*.sql
mcp__supabase__apply_migration name="045_message_digest_new_message_filter" query=<file-contents>
```

I attempted to apply directly from this session but was correctly blocked because production migrations need explicit per-action confirmation. Want to authorize me to run it, or do you prefer to run it yourself / via `supabase db push`?

## Test plan

- [x] Migration file is syntactically valid (would also be caught by `migration-check.yml` workflow's `supabase start` step).
- [ ] After migration applies: inquiry `0f6e4125-...` falls out of pending. The next `*/5` cron tick logs `processed=0 sent=0 claimed=0`. No further email arrives until you send a new chat message in that thread.
- [ ] Send a new chat message in the same thread → next cron tick picks it up (`processed=1 sent=1`). Wait through the next tick → `processed=0` (no new messages since the email).
- [ ] Same pair of checks against the student side (have your test student account receive a landlord-sent message → confirm exactly one email arrives at the student inbox, no recurrence).
- [ ] `claim_*_message_notification` race-condition guard still works — covered by migration-check workflow keeping migrations 032/044 intact.

## Followups

- Drop the now-unused `p_min_interval` parameter in a separate PR (touches the function signatures + both route handlers; small, mechanical).
- Add a route-level vitest (mock the RPC pending/claim sequence) — none exists today for either digest route. Would document the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)