### PR TITLE
chore(emails): English by default across all user-facing emails (step A of Greek removal)

### DIFF
--- a/__tests__/api/studentProfile.test.js
+++ b/__tests__/api/studentProfile.test.js
@@ -101,3 +101,81 @@ describe('POST /api/student/profile — role-conflict cleanup', () => {
     expect(cleanupFreshOrphanAuthUser).not.toHaveBeenCalled();
   });
 });
+
+describe('POST /api/student/profile — preferred_locale forwarding', () => {
+  // These tests guard the application-layer half of the "English by default"
+  // contract introduced in PR #157 / migration 047. The SQL half (COALESCE
+  // fallback in create_student_profile, schema DEFAULT 'en', trigger
+  // fallback) is exercised by the migration-check workflow's `supabase start`.
+  // Here we assert that the route forwards exactly what the RPC needs to see
+  // for the SQL fallback to do the right thing — i.e. an empty string when
+  // the client sends nothing or sends an unrecognized value. A future
+  // "simplification" that, say, defaults the preferred_locale variable to
+  // 'el' before forwarding would silently re-introduce Greek defaults; this
+  // test catches that.
+
+  function rpcCapturingSupabase() {
+    const rpcCalls = [];
+    const supabase = {
+      rpc: vi.fn(async (name, args) => {
+        rpcCalls.push({ name, args });
+        return {
+          data: { student_id: 'S99', email: 'fresh@example.com', display_name: 'Fresh' },
+          error: null,
+        };
+      }),
+    };
+    return { supabase, rpcCalls };
+  }
+
+  it('forwards an empty preferred_locale when the body omits the field', async () => {
+    extractToken.mockReturnValue('jwt');
+    getUserFromToken.mockResolvedValue(FRESH_USER());
+    const { supabase, rpcCalls } = rpcCapturingSupabase();
+    getSupabaseWithToken.mockReturnValue(supabase);
+
+    await POST(jsonRequest({ display_name: 'Fresh' }));
+
+    expect(rpcCalls).toHaveLength(1);
+    expect(rpcCalls[0].name).toBe('create_student_profile');
+    // The route MUST pass '' (empty string) so the RPC's
+    // `COALESCE(NULLIF(p_preferred_locale, ''), 'en')` resolves to 'en'.
+    expect(rpcCalls[0].args).toEqual({
+      p_display_name: 'Fresh',
+      p_preferred_locale: '',
+    });
+  });
+
+  it('forwards an empty preferred_locale when the body sends an unrecognized value', async () => {
+    extractToken.mockReturnValue('jwt');
+    getUserFromToken.mockResolvedValue(FRESH_USER());
+    const { supabase, rpcCalls } = rpcCapturingSupabase();
+    getSupabaseWithToken.mockReturnValue(supabase);
+
+    await POST(jsonRequest({ display_name: 'Fresh', preferred_locale: 'fr' }));
+
+    expect(rpcCalls[0].args.p_preferred_locale).toBe('');
+  });
+
+  it('forwards explicit "en" when the body asks for English', async () => {
+    extractToken.mockReturnValue('jwt');
+    getUserFromToken.mockResolvedValue(FRESH_USER());
+    const { supabase, rpcCalls } = rpcCapturingSupabase();
+    getSupabaseWithToken.mockReturnValue(supabase);
+
+    await POST(jsonRequest({ display_name: 'Fresh', preferred_locale: 'en' }));
+
+    expect(rpcCalls[0].args.p_preferred_locale).toBe('en');
+  });
+
+  it('still forwards explicit "el" when the body asks for Greek (back-compat until Step B)', async () => {
+    extractToken.mockReturnValue('jwt');
+    getUserFromToken.mockResolvedValue(FRESH_USER());
+    const { supabase, rpcCalls } = rpcCapturingSupabase();
+    getSupabaseWithToken.mockReturnValue(supabase);
+
+    await POST(jsonRequest({ display_name: 'Fresh', preferred_locale: 'el' }));
+
+    expect(rpcCalls[0].args.p_preferred_locale).toBe('el');
+  });
+});

--- a/src/app/[locale]/student/auth/callback/page.js
+++ b/src/app/[locale]/student/auth/callback/page.js
@@ -3,7 +3,7 @@
 import { Suspense, useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useRouter } from '@/i18n/navigation';
-import { useLocale, useTranslations } from 'next-intl';
+import { useTranslations } from 'next-intl';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 
 import AuthShell from '@/components/landlord/AuthShell';
@@ -13,7 +13,6 @@ import BauhausLoader from '@/components/BauhausLoader';
 function StudentOAuthCallbackInner() {
   const t = useTranslations('student.oauth');
   const tLoaders = useTranslations('loaders');
-  const locale = useLocale();
   const router = useRouter();
   const searchParams = useSearchParams();
   const nextRaw = searchParams.get('next') || '';

--- a/src/app/[locale]/student/auth/callback/page.js
+++ b/src/app/[locale]/student/auth/callback/page.js
@@ -64,7 +64,8 @@ function StudentOAuthCallbackInner() {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${session.access_token}`,
           },
-          body: JSON.stringify({ preferred_locale: locale }),
+          // English by default (2026-05-11 product call).
+          body: JSON.stringify({ preferred_locale: 'en' }),
         });
       } catch {
         // Network blip — proceed anyway; account page will surface

--- a/src/app/[locale]/student/signup/page.js
+++ b/src/app/[locale]/student/signup/page.js
@@ -72,7 +72,11 @@ export default function StudentSignupPage() {
               'Content-Type': 'application/json',
               Authorization: `Bearer ${session.access_token}`,
             },
-            body: JSON.stringify({ display_name: name, preferred_locale: locale }),
+            // English by default (2026-05-11 product call). Site is being
+            // collapsed to English-only in a follow-up; in the interim,
+            // every new signup gets 'en' regardless of which URL prefix
+            // they signed up through.
+            body: JSON.stringify({ display_name: name, preferred_locale: 'en' }),
           }),
         );
         if (!res.ok) {

--- a/src/app/api/cron/landlord-message-digest/route.js
+++ b/src/app/api/cron/landlord-message-digest/route.js
@@ -37,7 +37,9 @@ function isCronAuthorized(request) {
 
 function resolveLocale(landlordLocale) {
   if (landlordLocale === 'el' || landlordLocale === 'en') return landlordLocale;
-  return 'el';
+  // Default English (2026-05-11 product call: emails go in English by
+  // default; explicit 'el' preference still honored if set in settings).
+  return 'en';
 }
 
 export async function POST(request) {

--- a/src/app/api/cron/student-message-digest/route.js
+++ b/src/app/api/cron/student-message-digest/route.js
@@ -38,7 +38,9 @@ function isCronAuthorized(request) {
 
 function resolveLocale(studentLocale) {
   if (studentLocale === 'el' || studentLocale === 'en') return studentLocale;
-  return 'el';
+  // Default English (2026-05-11 product call: emails go in English by
+  // default; explicit 'el' preference still honored if set in settings).
+  return 'en';
 }
 
 export async function POST(request) {

--- a/src/lib/foundingWelcomeEmail.js
+++ b/src/lib/foundingWelcomeEmail.js
@@ -30,7 +30,8 @@ function pickLocale(request, hintedLocale) {
     if (tag === 'el' || tag.startsWith('el-')) return 'el';
     if (tag === 'en' || tag.startsWith('en-')) return 'en';
   }
-  return 'el';
+  // Default English (2026-05-11 product call).
+  return 'en';
 }
 
 /**

--- a/src/lib/inquiryEmail.js
+++ b/src/lib/inquiryEmail.js
@@ -18,7 +18,10 @@ function resolveLandlordEmailLocale(request, landlord) {
     if (tag === 'el' || tag.startsWith('el-')) return 'el';
     if (tag === 'en' || tag.startsWith('en-')) return 'en';
   }
-  return 'el';
+  // Default English (2026-05-11 product call). Note: header-based 'el'
+  // is still honored above so a browser explicitly requesting Greek
+  // still gets Greek — only the absent/unknown fallback changed.
+  return 'en';
 }
 
 /**

--- a/src/lib/subscriptionEmail.js
+++ b/src/lib/subscriptionEmail.js
@@ -33,7 +33,9 @@ export async function sendSubscriptionWelcomeEmail({ supabase, landlordId, tier 
       return;
     }
 
-    const locale = landlord.preferred_locale === 'en' ? 'en' : 'el';
+    // Default English (2026-05-11 product call). Explicit 'el'
+    // preference is still honored.
+    const locale = landlord.preferred_locale === 'el' ? 'el' : 'en';
     const tierName = TIER_DISPLAY_NAMES[tier] || 'SuperLandlord';
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://studentx.uk';
     const verificationUrl = `${appUrl}/${locale === 'en' ? 'en/' : ''}property/thessaloniki/landlord/verification`;

--- a/src/templates/email/inquiry.js
+++ b/src/templates/email/inquiry.js
@@ -2,10 +2,11 @@
  * Email sent to a landlord when a student submits an inquiry from a listing.
  * Mirrors the brand styling used by digest.js.
  *
- * Greek is the primary market, so locale defaults to 'el'. The route resolves
- * the locale from Accept-Language (and would prefer a landlord-stored
- * preferred_locale if/when that column is added). EN is kept as a fallback
- * for non-Greek-speaking landlords.
+ * English is the default locale as of 2026-05-11 (PR #157). The route
+ * still respects an explicit landlord-stored preferred_locale='el' and an
+ * Accept-Language='el-*' browser header for backward compatibility, but
+ * the absent/unknown fallback resolves to 'en'. Step B (issue #158) is
+ * planned to drop Greek support entirely.
  *
  * @param {object} params
  * @param {string} params.landlordName - Name shown in greeting (falls back to "there"/"εσένα")
@@ -13,7 +14,7 @@
  * @param {string} params.message - Raw student message
  * @param {object} params.listing - { listing_id, address?, neighborhood?, monthly_price? }
  * @param {string} params.appUrl - Base URL of the app (no trailing slash)
- * @param {'el'|'en'} [params.locale='el'] - Email locale
+ * @param {'el'|'en'} [params.locale='en'] - Email locale
  */
 
 const STRINGS = {

--- a/supabase/migrations/046_default_preferred_locale_to_english.sql
+++ b/supabase/migrations/046_default_preferred_locale_to_english.sql
@@ -1,0 +1,30 @@
+-- ============================================================
+-- Migration 046: Switch user-facing default locale from Greek to English.
+-- ============================================================
+--
+-- Product decision (2026-05-11): emails go in English by default. The
+-- founder doesn't want landlord/student-facing emails sent in Greek any
+-- more, and the broader site is being collapsed to English-only in a
+-- separate follow-up PR (tracking Greek-removal work). This migration
+-- handles the user-data half: existing rows where `preferred_locale =
+-- 'el'` get backfilled to 'en' so they pick up the new English default
+-- on the next email send.
+--
+-- Why backfill rather than just flip the code fallback: every existing
+-- landlord and student in the DB has `preferred_locale = 'el'`
+-- explicitly set (auto-assigned by the signup flow from the URL
+-- locale, not by a real user choice). The fallback in the resolveLocale
+-- helpers only kicks in when the column is NULL, so flipping the
+-- fallback alone wouldn't change a single user's email language.
+--
+-- Idempotent: re-applying is a no-op (the WHERE clause selects nothing
+-- on the second run). The companion code change updates the email
+-- senders' fallback to 'en' so future NULL rows resolve the same way.
+
+UPDATE landlords
+   SET preferred_locale = 'en'
+ WHERE preferred_locale = 'el';
+
+UPDATE students
+   SET preferred_locale = 'en'
+ WHERE preferred_locale = 'el';

--- a/supabase/migrations/047_preferred_locale_default_english.sql
+++ b/supabase/migrations/047_preferred_locale_default_english.sql
@@ -85,11 +85,16 @@ END;
 $$;
 
 -- ---- create_student_profile (re-create with 'en' fallback) ----------
--- Mirrors migration 026's version with only the COALESCE fallback
--- flipped. The validate-only return path (lines 116-118 in the
--- original) is preserved.
+-- TRUE line-for-line mirror of migration 026's body. The ONLY changes
+-- are the two `'el'` literals on the locale lines flipped to `'en'`
+-- (the COALESCE fallback and the validation re-pin). DECLARE block,
+-- auth.users lookup, existing-row early return, three-tier display
+-- name fallback chain (p_display_name → raw_user_meta_data display_name
+-- → email-local-part), INSERT shape, and grants all stay identical.
+-- A prior version of this migration drifted from 026 in ways that
+-- silently regressed unrelated behavior (PM review caught it).
 CREATE OR REPLACE FUNCTION public.create_student_profile(
-  p_display_name text,
+  p_display_name     text,
   p_preferred_locale text
 )
 RETURNS students
@@ -98,19 +103,24 @@ SECURITY DEFINER
 SET search_path = public
 AS $function$
 DECLARE
-  v_user RECORD;
-  v_name text;
-  v_locale text;
-  v_result students;
+  v_user        auth.users%ROWTYPE;
+  v_existing    students%ROWTYPE;
+  v_locale      text;
+  v_name        text;
+  v_result      students%ROWTYPE;
 BEGIN
-  SELECT auth.uid() AS id, auth.jwt()->>'email' AS email INTO v_user;
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'NOT_AUTHENTICATED' USING ERRCODE = 'P0004';
+  END IF;
+
+  SELECT * INTO v_user FROM auth.users WHERE id = auth.uid();
   IF v_user.id IS NULL THEN
     RAISE EXCEPTION 'NOT_AUTHENTICATED' USING ERRCODE = 'P0004';
   END IF;
 
-  v_name := COALESCE(NULLIF(trim(p_display_name), ''), split_part(v_user.email, '@', 1));
-  IF char_length(v_name) > 80 THEN
-    v_name := substr(v_name, 1, 80);
+  SELECT * INTO v_existing FROM students WHERE auth_user_id = v_user.id;
+  IF v_existing.student_id IS NOT NULL THEN
+    RETURN v_existing;
   END IF;
 
   v_locale := COALESCE(NULLIF(p_preferred_locale, ''), 'en');
@@ -118,10 +128,11 @@ BEGIN
     v_locale := 'en';
   END IF;
 
-  SELECT * INTO v_result FROM students WHERE auth_user_id = v_user.id;
-  IF FOUND THEN
-    RETURN v_result;
-  END IF;
+  v_name := COALESCE(
+    NULLIF(trim(p_display_name), ''),
+    NULLIF(v_user.raw_user_meta_data->>'display_name', ''),
+    split_part(v_user.email, '@', 1)
+  );
 
   INSERT INTO students (auth_user_id, email, display_name, preferred_locale)
   VALUES (v_user.id, lower(v_user.email), v_name, v_locale)

--- a/supabase/migrations/047_preferred_locale_default_english.sql
+++ b/supabase/migrations/047_preferred_locale_default_english.sql
@@ -1,0 +1,132 @@
+-- ============================================================
+-- Migration 047: Move preferred_locale's defaults from Greek to English
+-- everywhere they live in the schema and trigger code.
+-- ============================================================
+--
+-- Follow-up to migration 046, which only backfilled existing rows. Code
+-- review on PR #157 surfaced that several INSERT paths *bypass* the
+-- application code that 046's companion changes patched:
+--
+--   1. landlords.preferred_locale DEFAULT 'el' (migration 023).
+--   2. students.preferred_locale DEFAULT 'el' (migration 026).
+--   3. handle_new_student_user trigger (latest version in migration 036)
+--      writes 'el' when the auth.users row has no preferred_locale hint
+--      in metadata. This trigger fires BEFORE the OAuth callback's API
+--      POST, so a Google/Apple student signup was getting 'el' written
+--      first; the API call would then no-op via the idempotent RPC.
+--   4. public.create_student_profile RPC (migration 026) falls back to
+--      'el' in its COALESCE. The student signup API forwards 'en'
+--      explicitly so this works for password signups, but it would
+--      regress if any future caller passed NULL/empty.
+--
+-- This migration flips all four defaults to 'en'. Together with the
+-- email-resolver fallback changes in PR #157, every path from
+-- "user gets created" to "user gets emailed" now defaults to English
+-- unless explicit Greek is requested (and even that surface is being
+-- removed in Step B per issue #158).
+--
+-- Idempotent: ALTER COLUMN SET DEFAULT is no-op when already 'en';
+-- CREATE OR REPLACE FUNCTION is idempotent by definition.
+
+ALTER TABLE landlords
+  ALTER COLUMN preferred_locale SET DEFAULT 'en';
+
+ALTER TABLE students
+  ALTER COLUMN preferred_locale SET DEFAULT 'en';
+
+-- ---- handle_new_student_user (re-create with 'en' fallback) ---------
+-- Mirrors migration 036's version line-for-line, with the v_locale
+-- fallback flipped from 'el' to 'en'. Same SECURITY DEFINER context,
+-- same dual-role guard, same idempotent INSERT.
+CREATE OR REPLACE FUNCTION public.handle_new_student_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role           text;
+  v_provider       text;
+  v_display_name   text;
+  v_locale         text;
+BEGIN
+  v_role     := NULLIF(NEW.raw_user_meta_data->>'role', '');
+  v_provider := NULLIF(NEW.raw_app_meta_data->>'provider', '');
+  IF v_role IS DISTINCT FROM 'student'
+     AND (v_provider IS NULL OR v_provider NOT IN ('google', 'apple')) THEN
+    RETURN NEW;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.landlords l
+     WHERE lower(l.email) = lower(NEW.email)
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  v_display_name := COALESCE(
+    NULLIF(trim(NEW.raw_user_meta_data->>'display_name'), ''),
+    NULLIF(trim(NEW.raw_user_meta_data->>'full_name'), ''),
+    NULLIF(trim(NEW.raw_user_meta_data->>'name'), ''),
+    split_part(NEW.email, '@', 1)
+  );
+
+  v_locale := NULLIF(NEW.raw_user_meta_data->>'preferred_locale', '');
+  IF v_locale IS NULL OR v_locale NOT IN ('el', 'en') THEN
+    v_locale := 'en';
+  END IF;
+
+  INSERT INTO public.students (auth_user_id, email, display_name, preferred_locale)
+  VALUES (NEW.id, lower(NEW.email), v_display_name, v_locale)
+  ON CONFLICT (auth_user_id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+-- ---- create_student_profile (re-create with 'en' fallback) ----------
+-- Mirrors migration 026's version with only the COALESCE fallback
+-- flipped. The validate-only return path (lines 116-118 in the
+-- original) is preserved.
+CREATE OR REPLACE FUNCTION public.create_student_profile(
+  p_display_name text,
+  p_preferred_locale text
+)
+RETURNS students
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $function$
+DECLARE
+  v_user RECORD;
+  v_name text;
+  v_locale text;
+  v_result students;
+BEGIN
+  SELECT auth.uid() AS id, auth.jwt()->>'email' AS email INTO v_user;
+  IF v_user.id IS NULL THEN
+    RAISE EXCEPTION 'NOT_AUTHENTICATED' USING ERRCODE = 'P0004';
+  END IF;
+
+  v_name := COALESCE(NULLIF(trim(p_display_name), ''), split_part(v_user.email, '@', 1));
+  IF char_length(v_name) > 80 THEN
+    v_name := substr(v_name, 1, 80);
+  END IF;
+
+  v_locale := COALESCE(NULLIF(p_preferred_locale, ''), 'en');
+  IF v_locale NOT IN ('el', 'en') THEN
+    v_locale := 'en';
+  END IF;
+
+  SELECT * INTO v_result FROM students WHERE auth_user_id = v_user.id;
+  IF FOUND THEN
+    RETURN v_result;
+  END IF;
+
+  INSERT INTO students (auth_user_id, email, display_name, preferred_locale)
+  VALUES (v_user.id, lower(v_user.email), v_name, v_locale)
+  RETURNING * INTO v_result;
+
+  RETURN v_result;
+END;
+$function$;


### PR DESCRIPTION
Step A of the Greek-removal work (founder decision 2026-05-11). This PR handles the **user-data + email-resolver** half so emails stop going out in Greek immediately. The site-routing / SEO / drop-/el/ work is a separate, larger follow-up PR (step B).

## Summary

- **Migration 046** backfills `preferred_locale = 'el' → 'en'` for all existing landlords (6) and students (2). Already applied to prod; verified all 8 records now show `'en'`.
- **Five email-locale resolvers** flipped from `'el'` fallback to `'en'`:
  - `src/app/api/cron/landlord-message-digest/route.js`
  - `src/app/api/cron/student-message-digest/route.js`
  - `src/lib/inquiryEmail.js`
  - `src/lib/subscriptionEmail.js`
  - `src/lib/foundingWelcomeEmail.js`
- **Student signup flows** set `preferred_locale: 'en'` directly instead of mirroring URL locale.
- Landlord signup didn't set this field; no change.

## What's NOT in this PR (step B follow-up)

- Removing `'el'` from `src/i18n/routing.js` and changing `defaultLocale` to `'en'`
- Dropping `src/messages/el.json` + all Greek email templates
- 301'ing `/el/*` URLs to `/*` for SEO (or 410-ing them)
- Removing the `setRequestLocale('el')` patterns and the synthetic-en-listing canary
- Removing the `preferred_locale` column / settings UI
- The middleware redirect cleanup

That's a much larger blast radius and warrants its own review + SEO planning. Tracking issue to follow.

## Rationale for "data backfill rather than just code flip"

Every existing user record had `preferred_locale = 'el'` set **explicitly**, not NULL. That value was auto-assigned by the signup flow from the URL locale (Greek-default site → 'el' written on signup), not from any deliberate user choice. So merely flipping the code fallback to 'en' wouldn't have changed a single user's email language — their explicit 'el' would still win. The migration backfill is the part that actually moves the world.

## Apply order

Migration 046 applied to prod before this PR was opened (per CLAUDE.md's migration-ordering convention). Verified:

```sql
SELECT preferred_locale, COUNT(*) FROM landlords GROUP BY preferred_locale;
-- en | 6

SELECT preferred_locale, COUNT(*) FROM students GROUP BY preferred_locale;
-- en | 2
```

The schema column still allows `'el'`; the settings UI still exposes it. A user can still explicitly opt back into Greek emails until step B drops the option entirely.

## Test plan

- [x] `npm run lint` passes (one pre-existing warning, unrelated)
- [x] `npm run test` — 124/124 tests passing
- [x] Migration applied to prod; verified data state
- [ ] Next landlord-message-digest tick on a real inquiry sends an English-language email
- [ ] Next student-message-digest tick on a real inquiry sends an English-language email
- [ ] New student signup sets `preferred_locale='en'` regardless of which URL prefix they signed up through

🤖 Generated with [Claude Code](https://claude.com/claude-code)