### PR TITLE
Broaden email housing-partner tagline beyond AUSoM

### DIFF
--- a/src/templates/email/foundingCohortWelcome.js
+++ b/src/templates/email/foundingCohortWelcome.js
@@ -82,7 +82,7 @@ const COPY = {
   el: {
     eyebrow: 'Founding 50',
     headerTagline: 'Φοιτητική Στέγαση · Θεσσαλονίκη',
-    footerTagline: 'Επίσημος συνεργάτης στέγασης AUSoM',
+    footerTagline: 'Επίσημος συνεργάτης στέγασης AUSoM και άλλων κορυφαίων πανεπιστημίων',
     title: 'Είσαι ο ιδρυτικός #{rank} από τους 50',
     greetingPrefix: 'Γεια σου',
     greetingFallback: 'Γεια σου,',
@@ -97,7 +97,7 @@ const COPY = {
   en: {
     eyebrow: 'Founding 50',
     headerTagline: 'Student Housing · Thessaloniki',
-    footerTagline: 'Official housing partner for AUSoM',
+    footerTagline: 'Official housing partner for AUSoM and other world-class universities',
     title: "You're founding member #{rank} of 50",
     greetingPrefix: 'Hi',
     greetingFallback: 'Hi there,',

--- a/src/templates/email/foundingFiveWelcome.js
+++ b/src/templates/email/foundingFiveWelcome.js
@@ -95,7 +95,7 @@ const COPY = {
   el: {
     eyebrow: 'Founding Five',
     headerTagline: 'Φοιτητική Στέγαση · Θεσσαλονίκη',
-    footerTagline: 'Επίσημος συνεργάτης στέγασης AUSoM',
+    footerTagline: 'Επίσημος συνεργάτης στέγασης AUSoM και άλλων κορυφαίων πανεπιστημίων',
     title: 'Είσαι ο ιδρυτικός #{rank} από τους 50',
     greetingPrefix: 'Γεια σου',
     greetingFallback: 'Γεια σου,',
@@ -112,7 +112,7 @@ const COPY = {
   en: {
     eyebrow: 'Founding Five',
     headerTagline: 'Student Housing · Thessaloniki',
-    footerTagline: 'Official housing partner for AUSoM',
+    footerTagline: 'Official housing partner for AUSoM and other world-class universities',
     title: "You're founding member #{rank} of 50",
     greetingPrefix: 'Hi',
     greetingFallback: 'Hi there,',


### PR DESCRIPTION
## Summary
- Updates the footer tagline in both founding welcome email templates (`foundingFiveWelcome.js` and `foundingCohortWelcome.js`) from "Official housing partner for AUSoM" to "Official housing partner for AUSoM and other world-class universities" (+ Greek equivalent)

## Test plan
- [ ] Verify email template renders correctly by inspecting the COPY objects in both files
- [ ] No other AUSoM references are affected (scoped and confirmed with user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)