### PR TITLE
fix(security): lock down claim_digest_send to service_role

### DIFF
--- a/__tests__/api/savedSearchesDigest.test.js
+++ b/__tests__/api/savedSearchesDigest.test.js
@@ -16,8 +16,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const supabaseCalls = { frequencies: [] };
 
-vi.mock('@/lib/supabase', () => ({
-  getSupabase: () => ({
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
     from: (_table) => {
       const chain = {
         select: () => chain,

--- a/src/app/api/cron/saved-searches-digest/route.js
+++ b/src/app/api/cron/saved-searches-digest/route.js
@@ -1,9 +1,20 @@
 import { NextResponse } from 'next/server';
-import { getSupabase } from '@/lib/supabase';
+import { createClient } from '@supabase/supabase-js';
 import { getResend } from '@/lib/resend';
 import { isEmailSuppressed } from '@/lib/emailSuppressions';
 import { digestEmailHtml, digestEmailSubject } from '@/templates/email/digest';
 import { transformListing } from '@/lib/transformListing';
+
+// Service-role client: claim_digest_send is GRANTed only to service_role
+// (migration 049). The CRON_SECRET check above gates the route; this
+// client gates the database. Mirrors the landlord-message-digest route.
+function getServiceSupabase() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+    { auth: { persistSession: false } },
+  );
+}
 
 const LISTING_SELECT = `
   listing_id,
@@ -192,7 +203,7 @@ export async function POST(request) {
     frequenciesToProcess = dayOfWeek === 1 ? ['daily', 'weekly'] : ['daily'];
   }
 
-  const supabase = getSupabase();
+  const supabase = getServiceSupabase();
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://studentx.uk';
   const resend = getResend();
 

--- a/supabase/migrations/049_lockdown_claim_digest_send.sql
+++ b/supabase/migrations/049_lockdown_claim_digest_send.sql
@@ -1,0 +1,24 @@
+-- ============================================================
+-- Migration 049: Lock down saved-search digest RPC to service_role.
+-- ============================================================
+--
+-- claim_digest_send (migration 022) was granted to anon and
+-- authenticated because the cron route at
+-- /api/cron/saved-searches-digest was using the anon Supabase
+-- client. That made the SECURITY DEFINER context — which can
+-- write to saved_searches.last_notified_at — reachable by anyone
+-- with the public anon key, bypassing the CRON_SECRET gate on the
+-- HTTP route. An attacker could hammer it with arbitrary
+-- saved_search UUIDs to advance last_notified_at and suppress
+-- legitimate digest emails.
+--
+-- Mirrors migration 033 (which locked down the landlord digest
+-- RPCs). Pairs with src/app/api/cron/saved-searches-digest/route.js
+-- which now uses a service-role client.
+-- ============================================================
+
+REVOKE EXECUTE ON FUNCTION public.claim_digest_send(uuid, interval)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.claim_digest_send(uuid, interval)
+  TO service_role;


### PR DESCRIPTION
## Summary

- **Vulnerability:** `claim_digest_send` (migration 022) was GRANTed to `anon` and `authenticated`, making its SECURITY DEFINER context reachable by anyone with the public anon key — bypassing the CRON_SECRET gate on the HTTP route. An attacker could call it with arbitrary saved-search UUIDs to advance `last_notified_at` and suppress legitimate digest emails.
- **Fix:** Switch `saved-searches-digest` cron route from the anon Supabase client (`getSupabase()`) to a service-role client (`getServiceSupabase()`), and revoke `anon`/`authenticated` execute on the RPC via migration 049.
- Mirrors migration 033 + the landlord-message-digest route change which locked down the equivalent landlord digest RPCs.

## Test plan

- [x] `npm run lint` passes (0 errors)
- [x] `npm run test` passes (127/127 tests, including 6 saved-searches-digest frequency-selection tests with updated mock)
- [ ] CI lint + test + build pass
- [ ] CI migration-check passes (migration 049 applies cleanly)
- [ ] Apply migration 049 to prod before merging (per CLAUDE.md convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)