### PR TITLE
feat(globe): per-city globe loader animations

### DIFF
--- a/src/components/CityGlobeLoader.js
+++ b/src/components/CityGlobeLoader.js
@@ -1,0 +1,499 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import {
+  geoOrthographic,
+  geoPath,
+  geoGraticule10,
+} from 'd3-geo';
+import * as topojson from 'topojson-client';
+import CITY_GLOBE_CONFIG from './city-globe-data';
+
+const W = 200;
+const H = 200;
+const R = 92;
+
+export default function CityGlobeLoader({ city, onComplete }) {
+  const stageRef = useRef(null);
+  const layerGlobeRef = useRef(null);
+  const layerCityRef = useRef(null);
+  const graticuleRef = useRef(null);
+  const countriesRef = useRef(null);
+  const cityZoomRef = useRef(null);
+  const cityTier1Ref = useRef(null);
+  const cityTier2Ref = useRef(null);
+  const cityTier3Ref = useRef(null);
+  const cityPulseRef = useRef(null);
+
+  const onCompleteRef = useRef(onComplete);
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
+
+  const cfg = CITY_GLOBE_CONFIG[city];
+
+  useEffect(() => {
+    if (!cfg) {
+      if (onCompleteRef.current) onCompleteRef.current();
+      return;
+    }
+
+    if (typeof window !== 'undefined' && window.matchMedia) {
+      const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+      if (mq.matches) {
+        const id = setTimeout(() => onCompleteRef.current && onCompleteRef.current(), 200);
+        return () => clearTimeout(id);
+      }
+    }
+
+    let cancelled = false;
+    const cleanups = [];
+
+    (async () => {
+      let world;
+      let countriesHi = null;
+      try {
+        world = await fetch('/topojson/countries-110m.json').then((r) => r.json());
+      } catch (err) {
+        console.error('CityGlobeLoader: failed to load 110m topology', err);
+        if (!cancelled && onCompleteRef.current) onCompleteRef.current();
+        return;
+      }
+      if (cancelled) return;
+
+      const countries = topojson.feature(world, world.objects.countries);
+      countriesHi = countries;
+      fetch('/topojson/countries-50m.json')
+        .then((r) => r.json())
+        .then((wHi) => {
+          if (cancelled || !wHi) return;
+          countriesHi = topojson.feature(wHi, wHi.objects.countries);
+        })
+        .catch(() => {});
+
+      const proj = geoOrthographic()
+        .scale(R)
+        .translate([W / 2, H / 2])
+        .clipAngle(90)
+        .rotate([0, -15, 0]);
+      const path = geoPath(proj);
+      const graticule = geoGraticule10();
+
+      const gGrat = graticuleRef.current;
+      const gCountries = countriesRef.current;
+      if (!gGrat || !gCountries) return;
+
+      function renderGlobe(lambda, opts) {
+        opts = opts || {};
+        const rot = opts.rotate || [lambda, -15, 0];
+        const scale = opts.scale || R;
+        proj.rotate(rot).scale(scale);
+        if (opts.drawGraticule !== false) {
+          const d = path(graticule) || '';
+          gGrat.innerHTML = '<path d="' + d + '"/>';
+        } else {
+          gGrat.innerHTML = '';
+        }
+        if (opts.gratOpacity !== undefined) {
+          gGrat.setAttribute('opacity', opts.gratOpacity.toFixed(3));
+        } else {
+          gGrat.setAttribute('opacity', '1');
+        }
+        const set = opts.useHi ? countriesHi.features : countries.features;
+        let s = '';
+        for (const f of set) {
+          const d = path(f);
+          if (d) s += '<path d="' + d + '"/>';
+        }
+        gCountries.innerHTML = s;
+      }
+
+      // Phase 1 — spinning globe
+      let lambda = 0;
+      let spinning = true;
+      let last = performance.now();
+      let rafId = 0;
+      function tick(now) {
+        if (cancelled) return;
+        const dt = now - last;
+        last = now;
+        if (spinning) {
+          lambda = (lambda + dt * 0.04) % 360;
+          renderGlobe(lambda);
+        }
+        rafId = requestAnimationFrame(tick);
+      }
+      renderGlobe(0);
+      rafId = requestAnimationFrame(tick);
+      cleanups.push(() => cancelAnimationFrame(rafId));
+
+      function easeInOut(t) {
+        return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+      }
+
+      function settleOnEurope() {
+        return new Promise((resolve) => {
+          spinning = false;
+          const t0 = performance.now();
+          const dur = 1200;
+          const start = ((lambda % 360) + 360) % 360;
+          const targetRaw = 345;
+          let delta = targetRaw - start;
+          if (delta < 0) delta += 360;
+          function step(now) {
+            if (cancelled) return resolve();
+            const t = Math.min(1, (now - t0) / dur);
+            const e = easeInOut(t);
+            lambda = (start + delta * e) % 360;
+            renderGlobe(lambda);
+            if (t < 1) requestAnimationFrame(step);
+            else resolve();
+          }
+          requestAnimationFrame(step);
+        });
+      }
+
+      // Phase 2 — ortho zoom (variant-dependent easing)
+      function animateOrthoZoom() {
+        return new Promise((resolve) => {
+          const o = cfg.ortho;
+          const t0 = performance.now();
+          const startLambda = -15;
+          const startPhi = -15;
+          const startScale = R;
+
+          function step(now) {
+            if (cancelled) return resolve();
+            const t = Math.min(1, (now - t0) / o.dur);
+
+            let lam, phi, scl;
+            if (cfg.variant === 'B') {
+              const ePan = 1 - Math.pow(1 - t, o.ePanExp);
+              const eScale = Math.pow(t, o.eScaleExp);
+              lam = startLambda + (o.endLambda - startLambda) * ePan;
+              phi = startPhi + (o.endPhi - startPhi) * ePan;
+              scl = startScale * Math.pow(o.endScale / startScale, eScale);
+            } else {
+              const e = 1 - Math.pow(1 - t, 3);
+              lam = startLambda + (o.endLambda - startLambda) * e;
+              phi = startPhi + (o.endPhi - startPhi) * e;
+              scl = startScale * Math.pow(o.endScale / startScale, e);
+            }
+
+            const drawGrat = cfg.variant === 'B' ? true : t < 0.4;
+            const gratOp = cfg.variant === 'B'
+              ? Math.max(0, 1 - t / o.gratFade)
+              : undefined;
+
+            renderGlobe(lam, {
+              rotate: [lam, phi, 0],
+              scale: scl,
+              useHi: t > o.hiAt,
+              drawGraticule: drawGrat,
+              gratOpacity: gratOp,
+            });
+
+            if (t < 1) requestAnimationFrame(step);
+            else resolve();
+          }
+          requestAnimationFrame(step);
+        });
+      }
+
+      // Phase 3A — continuous reveal (Variant A: Larissa)
+      function animateCityReveal() {
+        return new Promise((resolve) => {
+          const cr = cfg.cityReveal;
+          const tiers = [
+            { el: cityTier1Ref.current, s: cr.tier1.s, e: cr.tier1.e },
+            { el: cityTier2Ref.current, s: cr.tier2.s, e: cr.tier2.e },
+            { el: cityTier3Ref.current, s: cr.tier3.s, e: cr.tier3.e },
+          ];
+          const t0 = performance.now();
+          function step(now) {
+            if (cancelled) return resolve();
+            const t = Math.min(1, (now - t0) / cr.dur);
+            for (const tier of tiers) {
+              if (!tier.el) continue;
+              const local = Math.max(0, Math.min(1, (t - tier.s) / (tier.e - tier.s)));
+              const o = 1 - Math.pow(1 - local, 3);
+              tier.el.setAttribute('opacity', o.toFixed(3));
+            }
+            if (t < 1) requestAnimationFrame(step);
+            else resolve();
+          }
+          requestAnimationFrame(step);
+        });
+      }
+
+      // Phase 3B — city zoom-in (Variant B)
+      function animateCityZoomIn() {
+        return new Promise((resolve) => {
+          const cz = cfg.cityZoomIn;
+          const cityZoom = cityZoomRef.current;
+          const t1 = cityTier1Ref.current;
+          const layerGlobe = layerGlobeRef.current;
+          const cx = 100, cy = 100;
+          const t0 = performance.now();
+          const o = cfg.ortho;
+
+          function step(now) {
+            if (cancelled) return resolve();
+            const t = Math.min(1, (now - t0) / cz.dur);
+            const e = 1 - Math.pow(1 - t, cz.easeExp);
+
+            const s = cz.startScale + (1.0 - cz.startScale) * e;
+            const tx = cx - cx * s + (cz.offsetX || 0) * s;
+            const ty = cy - cy * s;
+            if (cityZoom) {
+              cityZoom.setAttribute('transform', `translate(${tx} ${ty}) scale(${s})`);
+            }
+
+            if (cz.orthoStart && cz.orthoEnd) {
+              const oScale = cz.orthoStart * Math.pow(cz.orthoEnd / cz.orthoStart, e);
+              renderGlobe(o.endLambda, {
+                rotate: [o.endLambda, o.endPhi, 0],
+                scale: oScale,
+                useHi: true,
+                drawGraticule: false,
+              });
+            }
+
+            if (t1) {
+              const fadeT = Math.max(0, Math.min(1, (t - (cz.tier1FadeStart || 0)) / cz.tier1FadeDenom));
+              t1.setAttribute('opacity', (1 - Math.pow(1 - fadeT, 3)).toFixed(3));
+            }
+
+            if (layerGlobe) {
+              if (cz.keepGlobe) {
+                layerGlobe.style.opacity = '1';
+              } else if (cz.globeFadeStart != null) {
+                const gFade = t < cz.globeFadeStart
+                  ? 0
+                  : Math.pow((t - cz.globeFadeStart) / (cz.globeFadeEnd - cz.globeFadeStart), cz.globeFadeExp);
+                layerGlobe.style.opacity = (1 - gFade).toFixed(3);
+              }
+            }
+
+            if (t < 1) requestAnimationFrame(step);
+            else resolve();
+          }
+          requestAnimationFrame(step);
+        });
+      }
+
+      // Phase 3B cont. — city outline (tiers 2+3)
+      function animateCityOutline() {
+        return new Promise((resolve) => {
+          const co = cfg.cityOutline;
+          const tiers = [
+            { el: cityTier2Ref.current, s: co.tier2.s, e: co.tier2.e },
+            { el: cityTier3Ref.current, s: co.tier3.s, e: co.tier3.e },
+          ];
+          const t0 = performance.now();
+          function step(now) {
+            if (cancelled) return resolve();
+            const t = Math.min(1, (now - t0) / co.dur);
+            for (const tier of tiers) {
+              if (!tier.el) continue;
+              const local = Math.max(0, Math.min(1, (t - tier.s) / (tier.e - tier.s)));
+              const o = 1 - Math.pow(1 - local, 3);
+              tier.el.setAttribute('opacity', o.toFixed(3));
+            }
+            if (t < 1) requestAnimationFrame(step);
+            else resolve();
+          }
+          requestAnimationFrame(step);
+        });
+      }
+
+      function animateCityPulse(durationMs) {
+        return new Promise((resolve) => {
+          const t0 = performance.now();
+          function step(now) {
+            if (cancelled) return resolve();
+            const elapsed = now - t0;
+            const pulse = cityPulseRef.current;
+            if (pulse) {
+              const cyc = (elapsed / 1200) % 1;
+              const r = 3 + cyc * 12;
+              const op = 0.75 * (1 - cyc);
+              pulse.setAttribute('r', r.toFixed(2));
+              pulse.setAttribute('stroke-opacity', op.toFixed(2));
+            }
+            if (elapsed < durationMs) requestAnimationFrame(step);
+            else resolve();
+          }
+          requestAnimationFrame(step);
+        });
+      }
+
+      // Run the timeline
+      const stage = stageRef.current;
+      const layerGlobe = layerGlobeRef.current;
+      try {
+        await new Promise((r) => setTimeout(r, 1500));
+        if (cancelled) return;
+        await settleOnEurope();
+        if (cancelled) return;
+        await new Promise((r) => setTimeout(r, 280));
+        if (cancelled) return;
+
+        if (stage) stage.dataset.phase = 'greece';
+        if (cityTier1Ref.current) cityTier1Ref.current.setAttribute('opacity', '0');
+        if (cityTier2Ref.current) cityTier2Ref.current.setAttribute('opacity', '0');
+        if (cityTier3Ref.current) cityTier3Ref.current.setAttribute('opacity', '0');
+
+        if (cfg.variant === 'A') {
+          if (cityZoomRef.current) {
+            cityZoomRef.current.setAttribute('transform', 'translate(0 0) scale(1)');
+          }
+
+          const zoomPromise = animateOrthoZoom();
+          const revealTimer = setTimeout(() => {
+            if (cancelled) return;
+            if (stage) stage.dataset.phase = 'city';
+            if (layerCityRef.current) layerCityRef.current.classList.add('active');
+            animateCityReveal();
+          }, 1400);
+          cleanups.push(() => clearTimeout(revealTimer));
+          await zoomPromise;
+          if (cancelled) return;
+          await animateCityPulse(1100);
+        } else {
+          const cz = cfg.cityZoomIn;
+          if (cityZoomRef.current) {
+            const s0 = cz.startScale;
+            const cx = 100, cy = 100;
+            const tx = cx - cx * s0 + (cz.offsetX || 0) * s0;
+            const ty = cy - cy * s0;
+            cityZoomRef.current.setAttribute('transform', `translate(${tx} ${ty}) scale(${s0})`);
+          }
+
+          await animateOrthoZoom();
+          if (cancelled) return;
+
+          if (stage) stage.dataset.phase = 'city';
+          if (layerCityRef.current) layerCityRef.current.classList.add('active');
+
+          await animateCityZoomIn();
+          if (cancelled) return;
+
+          if (layerGlobe && !cz.keepGlobe) {
+            layerGlobe.style.opacity = '';
+            layerGlobe.classList.remove('active');
+          }
+
+          await animateCityOutline();
+          if (cancelled) return;
+          await animateCityPulse(1100);
+        }
+
+        if (cancelled) return;
+      } catch (err) {
+        console.error('CityGlobeLoader animation failed:', err);
+      }
+
+      if (!cancelled && onCompleteRef.current) onCompleteRef.current();
+    })();
+
+    return () => {
+      cancelled = true;
+      for (const fn of cleanups) {
+        try { fn(); } catch { /* noop */ }
+      }
+    };
+  }, [cfg]);
+
+  if (!cfg) return null;
+
+  const { ink, bg } = cfg;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center"
+      style={{ background: bg }}
+      role="status"
+      aria-live="polite"
+      aria-label="Loading city"
+    >
+      <div ref={stageRef} className="cgl-stage" data-phase="globe">
+        <style>{`
+          .cgl-stage {
+            width: 200px;
+            height: 200px;
+            position: relative;
+          }
+          .cgl-stage .layer {
+            position: absolute;
+            inset: 0;
+            opacity: 0;
+            transition: opacity 600ms ease;
+          }
+          .cgl-stage .layer.active { opacity: 1; }
+          .cgl-stage svg {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            overflow: visible;
+          }
+        `}</style>
+
+        {/* Globe (orthographic, spinning) */}
+        <div ref={layerGlobeRef} className="layer active">
+          <svg viewBox="0 0 200 200" aria-hidden="true">
+            <defs>
+              <clipPath id="cgl-globe-clip">
+                <circle cx="100" cy="100" r="92" />
+              </clipPath>
+            </defs>
+            <circle cx="100" cy="100" r="92" fill="none" stroke={ink} strokeWidth="1.25" />
+            <g clipPath="url(#cgl-globe-clip)">
+              <g
+                ref={graticuleRef}
+                stroke={ink}
+                strokeOpacity="0.18"
+                fill="none"
+                strokeWidth="0.5"
+              />
+              <g
+                ref={countriesRef}
+                stroke={ink}
+                strokeWidth="0.7"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+                fill="none"
+              />
+            </g>
+          </svg>
+        </div>
+
+        {/* City map */}
+        <div ref={layerCityRef} className="layer">
+          <svg viewBox="0 0 200 200" aria-hidden="true">
+            <defs>
+              <clipPath id="cgl-city-clip">
+                <circle cx="100" cy="100" r="92" />
+              </clipPath>
+            </defs>
+            <g clipPath="url(#cgl-city-clip)">
+              <g ref={cityZoomRef} transform="translate(0 0) scale(1)">
+                <g ref={cityTier1Ref} opacity="0">
+                  {cfg.tier1(ink, bg)}
+                </g>
+                <g ref={cityTier2Ref} opacity="0">
+                  {cfg.tier2(ink)}
+                </g>
+                <g ref={cityTier3Ref} opacity="0">
+                  {cfg.tier3(ink, cityPulseRef)}
+                </g>
+              </g>
+            </g>
+            <circle cx="100" cy="100" r="92" fill="none" stroke={ink} strokeWidth="1.25" />
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/city-globe-data/athens.js
+++ b/src/components/city-globe-data/athens.js
@@ -1,0 +1,98 @@
+const config = {
+  slug: 'athens',
+  variant: 'B',
+  ink: '#1a1a1a',
+  bg: '#f1ede4',
+
+  ortho: {
+    endLambda: -23.7275,
+    endPhi: -37.9838,
+    endScale: 4200,
+    dur: 2400,
+    ePanExp: 2.2,
+    eScaleExp: 1.6,
+    hiAt: 0.04,
+    gratFade: 0.55,
+  },
+
+  cityZoomIn: {
+    dur: 1400,
+    startScale: 0.32,
+    easeExp: 2.6,
+    orthoStart: 4200,
+    orthoEnd: 11000,
+    tier1FadeStart: 0,
+    tier1FadeDenom: 0.55,
+    globeFadeStart: 0.55,
+    globeFadeEnd: 1.0,
+    globeFadeExp: 1.6,
+    keepGlobe: false,
+    offsetX: 0,
+  },
+
+  cityOutline: { dur: 900, tier2: { s: 0, e: 0.65 }, tier3: { s: 0.4, e: 1.0 } },
+  pin: { cx: 124, cy: 96 },
+
+  tier1: (ink) => (
+    <>
+      <path d="M 80 110 Q 88 102 100 102 Q 114 102 122 110 Q 124 122 114 130 Q 100 134 88 130 Q 78 122 80 110 Z"
+        fill={ink} fillOpacity=".09" stroke={ink} strokeOpacity=".55" strokeWidth=".7"/>
+      <path d="M 56 132 Q 66 126 76 132 Q 78 142 70 148 Q 60 148 54 142 Q 52 136 56 132 Z"
+        fill={ink} fillOpacity=".06" stroke={ink} strokeOpacity=".45" strokeWidth=".55"/>
+      <circle cx="68" cy="112" r="4" fill={ink} fillOpacity=".05" stroke={ink} strokeOpacity=".4" strokeWidth=".5"/>
+      <path d="M 138 64 Q 146 58 152 62 Q 156 70 152 76 Q 144 80 138 74 Q 134 68 138 64 Z"
+        fill={ink} fillOpacity=".07" stroke={ink} strokeOpacity=".5" strokeWidth=".6"/>
+      <path d="M 116 96 L 138 94 L 140 110 L 118 112 Z"
+        fill={ink} fillOpacity=".06" stroke={ink} strokeOpacity=".45" strokeWidth=".5"/>
+      <rect x="94" y="42" width="14" height="16" fill={ink} fillOpacity=".05" stroke={ink} strokeOpacity=".4" strokeWidth=".5"/>
+    </>
+  ),
+
+  tier2: (ink) => (
+    <>
+      <g stroke={ink} fill="none" strokeLinecap="round">
+        <path d="M 70 76 L 90 84 L 110 92 L 124 96" strokeOpacity=".9" strokeWidth="1.1"/>
+        <path d="M 68 82 L 88 90 L 108 96 L 124 100" strokeOpacity=".75" strokeWidth=".95"/>
+        <path d="M 72 70 L 92 78 L 112 86 L 126 92" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 124 96 L 142 90 L 162 82" strokeOpacity=".85" strokeWidth="1.05"/>
+        <path d="M 124 96 L 122 116 L 118 134" strokeOpacity=".75" strokeWidth=".95"/>
+        <path d="M 124 100 L 100 104 L 80 108" strokeOpacity=".8" strokeWidth="1"/>
+        <path d="M 70 76 L 76 92 L 80 108" strokeOpacity=".7" strokeWidth=".9"/>
+        <path d="M 70 76 L 72 60 L 74 44 L 76 28" strokeOpacity=".7" strokeWidth=".9"/>
+        <path d="M 142 90 L 158 70 L 174 50" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 70 76 L 56 96 L 40 116 L 22 134" strokeOpacity=".7" strokeWidth=".9"/>
+        <path d="M 118 134 L 110 156 L 100 178" strokeOpacity=".75" strokeWidth=".95"/>
+        <path d="M 78 132 Q 96 138 122 132" strokeOpacity=".5" strokeWidth=".7"/>
+        <path d="M 78 132 Q 70 124 64 116" strokeOpacity=".45" strokeWidth=".65"/>
+      </g>
+      <g stroke={ink} fill="none" strokeLinecap="round" strokeOpacity=".4" strokeWidth=".55">
+        <path d="M 92 112 L 116 110"/>
+        <path d="M 94 118 L 118 116"/>
+        <path d="M 96 124 L 120 122"/>
+        <path d="M 100 108 L 102 128"/>
+        <path d="M 110 106 L 112 128"/>
+      </g>
+    </>
+  ),
+
+  tier3: (ink, pulseRef) => (
+    <>
+      <rect x="97" y="114" width="6" height="3" fill={ink}/>
+      <rect x="105" y="112" width="2.4" height="2" fill={ink} fillOpacity=".8"/>
+      <rect x="126" y="118" width="3" height="2" fill={ink} fillOpacity=".75"/>
+      <path d="M 138 124 A 4 5 0 0 1 138 134" fill="none" stroke={ink} strokeWidth=".8"/>
+      <rect x="122.5" y="94.5" width="3" height="3" fill={ink}/>
+      <circle cx="70" cy="76" r="1.6" fill="none" stroke={ink} strokeWidth=".75"/>
+      <circle cx="70" cy="76" r="0.5" fill={ink}/>
+      <circle cx="80" cy="108" r="1.4" fill={ink}/>
+      <rect x="94" y="134" width="2.4" height="2.4" fill={ink} fillOpacity=".8"/>
+      <circle cx="146" cy="68" r="0.8" fill={ink}/>
+      <rect x="73" y="50" width="2.4" height="2.4" fill={ink} fillOpacity=".75"/>
+      <g>
+        <circle ref={pulseRef} cx="124" cy="96" r="3.2" fill="none" stroke={ink} strokeWidth="1"/>
+        <circle cx="124" cy="96" r="2.5" fill={ink}/>
+      </g>
+    </>
+  ),
+};
+export default config;

--- a/src/components/city-globe-data/dublin.js
+++ b/src/components/city-globe-data/dublin.js
@@ -1,0 +1,94 @@
+const config = {
+  slug: 'dublin',
+  variant: 'B',
+  ink: '#1a1a1a',
+  bg: '#f1ede4',
+
+  ortho: {
+    endLambda: 6.76,
+    endPhi: -53.3498,
+    endScale: 7200,
+    dur: 2400,
+    ePanExp: 2.2,
+    eScaleExp: 1.6,
+    hiAt: 0.04,
+    gratFade: 0.55,
+  },
+
+  cityZoomIn: {
+    dur: 1100,
+    startScale: 0.55,
+    easeExp: 2.6,
+    orthoStart: null,
+    orthoEnd: null,
+    tier1FadeStart: 0,
+    tier1FadeDenom: 0.55,
+    globeFadeStart: null,
+    globeFadeEnd: null,
+    globeFadeExp: null,
+    keepGlobe: true,
+    offsetX: 20,
+  },
+
+  cityOutline: { dur: 900, tier2: { s: 0, e: 0.65 }, tier3: { s: 0.4, e: 1.0 } },
+  pin: { cx: 118, cy: 114 },
+
+  tier1: (ink) => (
+    <>
+      <path d="M -10 104 C 14 102, 30 106, 50 104 C 70 102, 86 106, 104 104 C 122 102, 134 106, 144 108 L 144 116 C 134 114, 122 110, 104 112 C 86 114, 70 110, 50 112 C 30 114, 14 110, -10 112 Z"
+        fill={ink} fillOpacity=".09" stroke={ink} strokeOpacity=".55" strokeWidth=".7" strokeLinejoin="round"/>
+      <path d="M -8 60 Q 40 58 90 60 Q 120 62 144 70"
+        fill="none" stroke={ink} strokeOpacity=".35" strokeWidth=".55" strokeDasharray="2 1.4"/>
+      <path d="M -8 150 Q 40 152 90 150 Q 120 149 152 146"
+        fill="none" stroke={ink} strokeOpacity=".35" strokeWidth=".55" strokeDasharray="2 1.4"/>
+      <path d="M 14 70 L 56 68 L 58 96 L 14 98 Z"
+        fill={ink} fillOpacity=".05" stroke={ink} strokeOpacity=".4" strokeWidth=".55"/>
+      <rect x="104" y="126" width="12" height="10" fill={ink} fillOpacity=".06" stroke={ink} strokeOpacity=".45" strokeWidth=".5"/>
+      <rect x="122" y="122" width="10" height="8" fill={ink} fillOpacity=".06" stroke={ink} strokeOpacity=".45" strokeWidth=".5"/>
+      <path d="M 110 110 L 132 110 L 132 122 L 110 122 Z"
+        fill={ink} fillOpacity=".06" stroke={ink} strokeOpacity=".45" strokeWidth=".5"/>
+    </>
+  ),
+
+  tier2: (ink) => (
+    <>
+      <g stroke={ink} fill="none" strokeLinecap="round">
+        <path d="M 14 100 Q 50 100 88 100 Q 120 100 144 102" strokeOpacity=".75" strokeWidth=".9"/>
+        <path d="M 14 116 Q 50 116 88 116 Q 120 116 144 118" strokeOpacity=".7" strokeWidth=".85"/>
+        <path d="M 14 76 Q 56 74 100 76 Q 130 78 146 80" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 56 92 Q 90 90 122 92 Q 138 93 144 94" strokeOpacity=".6" strokeWidth=".8"/>
+        <path d="M 70 122 Q 96 120 122 122 Q 138 123 146 124" strokeOpacity=".75" strokeWidth=".9"/>
+        <path d="M 14 142 Q 56 144 100 142 Q 130 141 148 140" strokeOpacity=".55" strokeWidth=".75"/>
+      </g>
+      <g stroke={ink} fill="none" strokeLinecap="round">
+        <path d="M 76 60 L 78 100 L 80 116 L 82 140" strokeOpacity=".65" strokeWidth=".8"/>
+        <path d="M 92 56 L 94 92 L 96 100 L 98 108 L 100 116 L 102 140" strokeOpacity=".95" strokeWidth="1.15"/>
+        <path d="M 104 60 L 106 100 L 108 116 L 110 140" strokeOpacity=".5" strokeWidth=".7"/>
+        <path d="M 116 58 L 118 100 L 120 116 L 122 144" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 132 70 L 134 110 L 136 124 L 138 144" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 64 80 L 66 100 L 68 116 L 70 134" strokeOpacity=".5" strokeWidth=".7"/>
+        <path d="M 142 92 L 144 102 L 146 118 L 144 138" strokeOpacity=".5" strokeWidth=".7"/>
+      </g>
+    </>
+  ),
+
+  tier3: (ink, pulseRef) => (
+    <>
+      <path d="M 94 90 L 95 84 L 96 90 Z" fill={ink}/>
+      <rect x="92" y="94" width="2.4" height="2.4" fill={ink}/>
+      <circle cx="118" cy="114" r="1.4" fill={ink}/>
+      <circle cx="68" cy="114" r="1.5" fill="none" stroke={ink} strokeWidth=".75"/>
+      <circle cx="68" cy="114" r="0.5" fill={ink}/>
+      <circle cx="74" cy="128" r="1.4" fill="none" stroke={ink} strokeWidth=".7"/>
+      <circle cx="74" cy="128" r="0.4" fill={ink}/>
+      <rect x="126" y="96" width="2.6" height="2.4" fill={ink} fillOpacity=".85"/>
+      <rect x="50" y="122" width="2.4" height="2.4" fill={ink}/>
+      <rect x="82" y="118" width="2.2" height="2.2" fill={ink} fillOpacity=".75"/>
+      <g>
+        <circle ref={pulseRef} cx="118" cy="114" r="3.2" fill="none" stroke={ink} strokeWidth="1"/>
+        <circle cx="118" cy="114" r="2.5" fill={ink}/>
+      </g>
+    </>
+  ),
+};
+export default config;

--- a/src/components/city-globe-data/heraklion.js
+++ b/src/components/city-globe-data/heraklion.js
@@ -1,0 +1,101 @@
+const config = {
+  slug: 'heraklion',
+  variant: 'B',
+  ink: '#1a1a1a',
+  bg: '#f1ede4',
+
+  ortho: {
+    endLambda: -25.1442,
+    endPhi: -35.3387,
+    endScale: 3600,
+    dur: 2400,
+    ePanExp: 2.2,
+    eScaleExp: 1.6,
+    hiAt: 0.04,
+    gratFade: 0.55,
+  },
+
+  cityZoomIn: {
+    dur: 1500,
+    startScale: 0.32,
+    easeExp: 2.6,
+    orthoStart: 3600,
+    orthoEnd: 14000,
+    tier1FadeStart: 0.18,
+    tier1FadeDenom: 0.55,
+    globeFadeStart: 0.55,
+    globeFadeEnd: 1.0,
+    globeFadeExp: 1.6,
+    keepGlobe: false,
+    offsetX: 0,
+  },
+
+  cityOutline: { dur: 900, tier2: { s: 0, e: 0.65 }, tier3: { s: 0.4, e: 1.0 } },
+  pin: { cx: 100, cy: 110 },
+
+  tier1: (ink) => (
+    <>
+      <path d="M -10 -10 L 210 -10 L 210 50 Q 170 56 130 54 Q 100 52 70 56 Q 40 60 -10 56 Z"
+        fill={ink} fillOpacity=".07" stroke="none"/>
+      <path d="M -10 56 Q 40 60 70 56 Q 100 52 130 54 Q 170 56 210 50"
+        fill="none" stroke={ink} strokeWidth="1"/>
+      <path d="M 80 56 L 80 70 L 116 70 L 116 56"
+        fill={ink} fillOpacity=".06" stroke={ink} strokeOpacity=".55" strokeWidth=".7" strokeLinejoin="round"/>
+      <path d="M 116 56 L 130 50 L 138 44 L 138 38"
+        fill="none" stroke={ink} strokeOpacity=".7" strokeWidth=".9" strokeLinecap="round"/>
+      <path d="M 38 58 L 38 80 Q 36 100 46 122 Q 60 146 90 154 Q 124 156 150 144 Q 170 124 168 100 Q 168 78 162 58"
+        fill="none" stroke={ink} strokeOpacity=".7" strokeWidth=".9" strokeLinejoin="round" strokeLinecap="round"/>
+      <g fill="none" stroke={ink} strokeOpacity=".65" strokeWidth=".7" strokeLinejoin="round">
+        <path d="M 38 96 L 28 100 L 38 108"/>
+        <path d="M 60 144 L 56 156 L 70 154"/>
+        <path d="M 100 156 L 102 168 L 112 156"/>
+        <path d="M 140 142 L 152 152 L 154 140"/>
+        <path d="M 168 96 L 178 96 L 168 86"/>
+      </g>
+    </>
+  ),
+
+  tier2: (ink) => (
+    <>
+      <g stroke={ink} fill="none" strokeLinecap="round">
+        <path d="M 96 60 L 98 78 L 100 96 L 102 110" strokeOpacity=".95" strokeWidth="1.15"/>
+        <path d="M 60 110 L 102 110 L 140 112" strokeOpacity=".85" strokeWidth="1.05"/>
+        <path d="M 38 100 L 70 100 L 100 96" strokeOpacity=".7" strokeWidth=".9"/>
+        <path d="M 102 110 L 124 124 L 152 142" strokeOpacity=".6" strokeWidth=".8"/>
+        <path d="M 102 110 L 104 130 L 106 156" strokeOpacity=".7" strokeWidth=".85"/>
+        <path d="M 100 96 L 124 100" strokeOpacity=".55" strokeWidth=".7"/>
+        <path d="M 102 110 L 88 132 L 70 152" strokeOpacity=".55" strokeWidth=".7"/>
+        <path d="M 50 96 Q 60 130 90 148 Q 130 152 156 132 Q 168 110 162 78" strokeOpacity=".4" strokeWidth=".6"/>
+      </g>
+      <g stroke={ink} fill="none" strokeLinecap="round" strokeOpacity=".4" strokeWidth=".55">
+        <path d="M 80 84 L 116 86"/>
+        <path d="M 78 92 L 118 94"/>
+        <path d="M 76 102 L 120 104"/>
+        <path d="M 86 70 L 86 110"/>
+        <path d="M 110 70 L 112 110"/>
+        <path d="M 122 78 L 124 110"/>
+      </g>
+    </>
+  ),
+
+  tier3: (ink, pulseRef) => (
+    <>
+      <rect x="135" y="35" width="5" height="5" fill="none" stroke={ink} strokeWidth=".9"/>
+      <rect x="136.5" y="36.5" width="2" height="2" fill={ink}/>
+      <circle cx="100" cy="96" r="1.6" fill="none" stroke={ink} strokeWidth=".75"/>
+      <circle cx="100" cy="96" r="0.5" fill={ink}/>
+      <rect x="99" y="90" width="2" height="2" fill={ink}/>
+      <circle cx="94" cy="86" r="1.4" fill="none" stroke={ink} strokeWidth=".7"/>
+      <circle cx="94" cy="86" r="0.4" fill={ink}/>
+      <circle cx="82" cy="104" r="1.6" fill="none" stroke={ink} strokeWidth=".8"/>
+      <circle cx="82" cy="104" r="0.5" fill={ink}/>
+      <rect x="125" y="104" width="2.4" height="2.4" fill={ink} fillOpacity=".8"/>
+      <path d="M 105 162 L 109 162 L 109 158" fill="none" stroke={ink} strokeWidth=".7"/>
+      <g>
+        <circle ref={pulseRef} cx="100" cy="110" r="3.2" fill="none" stroke={ink} strokeWidth="1"/>
+        <circle cx="100" cy="110" r="2.5" fill={ink}/>
+      </g>
+    </>
+  ),
+};
+export default config;

--- a/src/components/city-globe-data/index.js
+++ b/src/components/city-globe-data/index.js
@@ -1,0 +1,17 @@
+import athens from './athens';
+import larissa from './larissa';
+import heraklion from './heraklion';
+import london from './london';
+import dublin from './dublin';
+import nicosia from './nicosia';
+
+const CITY_GLOBE_CONFIG = {
+  athens,
+  larissa,
+  heraklion,
+  london,
+  dublin,
+  nicosia,
+};
+
+export default CITY_GLOBE_CONFIG;

--- a/src/components/city-globe-data/larissa.js
+++ b/src/components/city-globe-data/larissa.js
@@ -1,0 +1,79 @@
+const config = {
+  slug: 'larissa',
+  variant: 'A',
+  ink: '#1a1a1a',
+  bg: '#f1ede4',
+
+  ortho: {
+    endLambda: -22.4191,
+    endPhi: -39.6390,
+    endScale: 5200,
+    dur: 2600,
+    hiAt: 0.12,
+  },
+
+  cityReveal: {
+    dur: 1600,
+    tier1: { s: 0.0, e: 0.45 },
+    tier2: { s: 0.2, e: 0.8 },
+    tier3: { s: 0.55, e: 1.0 },
+  },
+
+  pin: { cx: 100, cy: 122 },
+
+  tier1: (ink) => (
+    <>
+      <path d="M -10 70 C 18 64, 36 72, 56 68 C 76 64, 90 72, 108 70 C 128 68, 144 76, 162 74 C 180 72, 196 76, 210 78 L 210 86 C 196 84, 180 80, 162 82 C 144 84, 128 76, 108 78 C 90 80, 76 72, 56 76 C 36 80, 18 72, -10 78 Z"
+        fill={ink} fillOpacity=".09" stroke={ink} strokeOpacity=".55" strokeWidth=".7" strokeLinejoin="round"/>
+      <path d="M 60 84 L 92 84 L 90 96 L 60 96 Z"
+        fill={ink} fillOpacity=".05" stroke={ink} strokeOpacity=".4" strokeWidth=".55"/>
+      <path d="M 110 86 Q 122 82 134 86 Q 138 96 132 104 Q 120 108 110 102 Q 106 94 110 86 Z"
+        fill={ink} fillOpacity=".06" stroke={ink} strokeOpacity=".45" strokeWidth=".5"/>
+      <rect x="96" y="118" width="8" height="6" fill={ink} fillOpacity=".05" stroke={ink} strokeOpacity=".4" strokeWidth=".5"/>
+    </>
+  ),
+
+  tier2: (ink) => (
+    <>
+      <g stroke={ink} fill="none" strokeLinecap="round">
+        <path d="M 60 100 Q 70 80 100 78 Q 130 78 142 100 Q 142 130 110 142 Q 78 142 64 122 Q 56 110 60 100 Z"
+          strokeOpacity=".6" strokeWidth=".8"/>
+        <path d="M 30 100 Q 50 60 100 58 Q 156 58 172 102 Q 172 144 110 162 Q 50 164 28 130 Q 18 114 30 100 Z"
+          strokeOpacity=".5" strokeWidth=".75"/>
+      </g>
+      <g stroke={ink} fill="none" strokeLinecap="round">
+        <path d="M 100 50 L 100 78 L 100 118 L 100 162" strokeOpacity=".85" strokeWidth="1.05"/>
+        <path d="M 30 122 L 60 122 L 96 122 L 142 122 L 174 122" strokeOpacity=".85" strokeWidth="1.05"/>
+        <path d="M 50 70 L 80 100 L 100 122 L 130 150" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 150 70 L 120 100 L 100 122 L 70 150" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 100 122 L 130 90" strokeOpacity=".5" strokeWidth=".7"/>
+        <path d="M 100 122 L 70 90" strokeOpacity=".5" strokeWidth=".7"/>
+        <path d="M 100 122 L 86 156" strokeOpacity=".5" strokeWidth=".7"/>
+        <path d="M 100 122 L 116 156" strokeOpacity=".5" strokeWidth=".7"/>
+      </g>
+      <g stroke={ink} fill="none" strokeLinecap="round" strokeOpacity=".55" strokeWidth=".65">
+        <path d="M 78 70 L 78 84"/>
+        <path d="M 100 68 L 100 82"/>
+        <path d="M 124 70 L 124 84"/>
+      </g>
+    </>
+  ),
+
+  tier3: (ink, pulseRef) => (
+    <>
+      <path d="M 116 100 A 5 5 0 0 1 126 100" fill="none" stroke={ink} strokeWidth=".8"/>
+      <circle cx="121" cy="100" r="0.6" fill={ink}/>
+      <circle cx="122" cy="94" r="1.5" fill={ink}/>
+      <circle cx="94" cy="108" r="1.4" fill="none" stroke={ink} strokeWidth=".75"/>
+      <circle cx="94" cy="108" r="0.5" fill={ink}/>
+      <rect x="99" y="120.5" width="2.4" height="2.4" fill={ink}/>
+      <rect x="138" y="96" width="2.2" height="2.2" fill={ink} fillOpacity=".8"/>
+      <rect x="60" y="118" width="2.4" height="2.4" fill={ink} fillOpacity=".75"/>
+      <g>
+        <circle ref={pulseRef} cx="100" cy="122" r="3.2" fill="none" stroke={ink} strokeWidth="1"/>
+        <circle cx="100" cy="122" r="2.5" fill={ink}/>
+      </g>
+    </>
+  ),
+};
+export default config;

--- a/src/components/city-globe-data/london.js
+++ b/src/components/city-globe-data/london.js
@@ -1,0 +1,93 @@
+const config = {
+  slug: 'london',
+  variant: 'B',
+  ink: '#1a1a1a',
+  bg: '#f1ede4',
+
+  ortho: {
+    endLambda: 0.1278,
+    endPhi: -51.5074,
+    endScale: 4200,
+    dur: 2400,
+    ePanExp: 2.2,
+    eScaleExp: 1.6,
+    hiAt: 0.04,
+    gratFade: 0.55,
+  },
+
+  cityZoomIn: {
+    dur: 1100,
+    startScale: 0.32,
+    easeExp: 2.6,
+    orthoStart: null,
+    orthoEnd: null,
+    tier1FadeStart: 0,
+    tier1FadeDenom: 0.55,
+    globeFadeStart: 0.45,
+    globeFadeEnd: 1.0,
+    globeFadeExp: 1.6,
+    keepGlobe: false,
+    offsetX: 0,
+  },
+
+  cityOutline: { dur: 900, tier2: { s: 0, e: 0.65 }, tier3: { s: 0.4, e: 1.0 } },
+  pin: { cx: 108, cy: 60 },
+
+  tier1: (ink, bg) => (
+    <>
+      <path d="M -10 118 C 18 116, 36 120, 54 124 C 72 128, 78 124, 86 118 C 96 110, 110 108, 122 116 C 134 124, 138 132, 132 142 C 126 152, 134 160, 150 156 C 168 152, 184 142, 210 138 L 210 178 C 184 178, 168 188, 150 192 C 134 196, 126 188, 132 178 C 138 168, 134 160, 122 152 C 110 144, 96 146, 86 154 C 78 160, 72 164, 54 160 C 36 156, 18 152, -10 154 Z"
+        fill={bg} fillOpacity=".85" stroke={ink} strokeOpacity=".7" strokeWidth=".8" strokeLinejoin="round"/>
+      <path d="M 30 70 L 64 70 L 64 92 L 30 92 Z"
+        fill={ink} fillOpacity=".05" stroke={ink} strokeOpacity=".5" strokeWidth=".6"/>
+      <path d="M 70 92 L 92 90 L 94 100 L 72 102 Z"
+        fill={ink} fillOpacity=".05" stroke={ink} strokeOpacity=".5" strokeWidth=".6"/>
+      <path d="M 60 38 Q 76 34 92 38 Q 96 50 90 60 Q 74 64 60 60 Q 56 50 60 38 Z"
+        fill={ink} fillOpacity=".05" stroke={ink} strokeOpacity=".5" strokeWidth=".6"/>
+    </>
+  ),
+
+  tier2: (ink) => (
+    <>
+      <g stroke={ink} fill="none" strokeLinecap="round">
+        <path d="M 20 110 Q 50 110 80 106 Q 102 102 116 108 Q 130 116 132 130" strokeOpacity=".7" strokeWidth=".85"/>
+        <path d="M 18 100 L 70 100 Q 90 100 110 96 Q 130 92 150 96 Q 170 100 184 102" strokeOpacity=".9" strokeWidth="1.15"/>
+        <path d="M 18 80 L 60 80 Q 90 80 120 78 Q 150 76 184 78" strokeOpacity=".8" strokeWidth="1"/>
+        <path d="M 22 60 L 60 60 Q 96 58 132 60 Q 162 62 186 64" strokeOpacity=".75" strokeWidth=".95"/>
+        <path d="M 64 92 Q 90 88 116 90" strokeOpacity=".5" strokeWidth=".7"/>
+        <path d="M 18 90 L 30 90 L 64 90" strokeOpacity=".5" strokeWidth=".7"/>
+        <path d="M 150 100 Q 170 102 188 106" strokeOpacity=".55" strokeWidth=".75"/>
+      </g>
+      <g stroke={ink} fill="none" strokeLinecap="round">
+        <path d="M 32 32 L 30 70 L 30 110" strokeOpacity=".5" strokeWidth=".7"/>
+        <path d="M 76 30 L 78 60 L 80 100 L 82 110" strokeOpacity=".7" strokeWidth=".85"/>
+        <path d="M 70 56 L 72 80 L 74 96" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 96 60 L 98 96 L 100 108" strokeOpacity=".5" strokeWidth=".7"/>
+        <path d="M 110 36 L 112 76 L 114 100 L 116 110" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 130 40 L 132 76 L 134 100 L 136 132" strokeOpacity=".75" strokeWidth=".95"/>
+        <path d="M 148 40 L 150 78 L 152 102 L 154 130" strokeOpacity=".6" strokeWidth=".8"/>
+        <path d="M 88 100 L 90 116 L 92 130" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 144 102 L 146 124 L 148 146" strokeOpacity=".5" strokeWidth=".7"/>
+      </g>
+      <path d="M 70 92 L 80 100" stroke={ink} strokeOpacity=".45" strokeWidth=".65" fill="none" strokeLinecap="round"/>
+      <path d="M 80 100 Q 76 96 72 94" stroke={ink} strokeOpacity=".4" strokeWidth=".6" fill="none" strokeLinecap="round"/>
+    </>
+  ),
+
+  tier3: (ink, pulseRef) => (
+    <>
+      <rect x="86" y="108" width="2.4" height="2.4" fill={ink}/>
+      <circle cx="90" cy="118" r="2" fill="none" stroke={ink} strokeWidth=".7"/>
+      <circle cx="90" cy="118" r="0.5" fill={ink}/>
+      <circle cx="114" cy="96" r="1.6" fill="none" stroke={ink} strokeWidth=".8"/>
+      <circle cx="114" cy="96" r="0.6" fill={ink}/>
+      <rect x="144.5" y="104" width="3" height="3" fill={ink} fillOpacity=".85"/>
+      <circle cx="82" cy="100" r="1.3" fill={ink}/>
+      <path d="M 134 138 L 137 134 L 137 138 Z" fill={ink}/>
+      <g>
+        <circle ref={pulseRef} cx="108" cy="60" r="3.2" fill="none" stroke={ink} strokeWidth="1"/>
+        <circle cx="108" cy="60" r="2.5" fill={ink}/>
+      </g>
+    </>
+  ),
+};
+export default config;

--- a/src/components/city-globe-data/nicosia.js
+++ b/src/components/city-globe-data/nicosia.js
@@ -1,0 +1,99 @@
+const config = {
+  slug: 'nicosia',
+  variant: 'B',
+  ink: '#1a1a1a',
+  bg: '#f1ede4',
+
+  ortho: {
+    endLambda: -33.3823,
+    endPhi: -35.1856,
+    endScale: 4200,
+    dur: 2400,
+    ePanExp: 2.2,
+    eScaleExp: 1.6,
+    hiAt: 0.04,
+    gratFade: 0.55,
+  },
+
+  cityZoomIn: {
+    dur: 1100,
+    startScale: 0.32,
+    easeExp: 2.6,
+    orthoStart: null,
+    orthoEnd: null,
+    tier1FadeStart: 0,
+    tier1FadeDenom: 0.55,
+    globeFadeStart: null,
+    globeFadeEnd: null,
+    globeFadeExp: null,
+    keepGlobe: true,
+    offsetX: 0,
+  },
+
+  cityOutline: { dur: 900, tier2: { s: 0, e: 0.65 }, tier3: { s: 0.4, e: 1.0 } },
+  pin: { cx: 100, cy: 144 },
+
+  tier1: (ink) => (
+    <>
+      <path d="M -10 56 Q 30 50 70 56 Q 110 64 150 58 Q 180 54 210 58"
+        fill="none" stroke={ink} strokeOpacity=".4" strokeWidth=".7" strokeDasharray="3 1.6"/>
+      <g fill={ink} fillOpacity=".04" stroke={ink} strokeOpacity=".7" strokeWidth=".85"
+        strokeLinejoin="round" strokeLinecap="round">
+        <path d="M 100 64 L 104 56 L 110 56 L 112 66 L 124 64 L 132 56 L 138 60 L 134 70 L 144 76 L 154 76 L 154 84 L 142 88 L 148 96 L 156 102 L 152 110 L 142 108 L 142 120 L 148 130 L 140 134 L 132 124 L 124 132 L 124 142 L 116 142 L 112 132 L 100 138 L 92 146 L 84 142 L 88 132 L 76 128 L 66 130 L 64 122 L 76 118 L 60 110 L 52 104 L 56 96 L 68 98 L 60 86 L 56 78 L 64 74 L 74 82 L 76 72 L 86 64 L 92 68 L 90 76 Z"/>
+      </g>
+    </>
+  ),
+
+  tier2: (ink) => (
+    <>
+      <g stroke={ink} fill="none" strokeLinecap="round">
+        <path d="M 96 70 L 98 90 L 100 106 L 102 124 L 104 142" strokeOpacity=".95" strokeWidth="1.1"/>
+        <path d="M 88 72 L 90 92 L 92 108 L 94 126 L 96 144" strokeOpacity=".7" strokeWidth=".85"/>
+        <path d="M 110 70 L 112 90 L 114 108 L 116 126" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 122 72 L 122 102 L 122 130" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 64 124 L 90 126 L 116 128 L 142 124" strokeOpacity=".7" strokeWidth=".85"/>
+        <path d="M 70 86 Q 90 82 110 84 Q 130 86 144 92" strokeOpacity=".6" strokeWidth=".8"/>
+        <path d="M 70 130 Q 90 138 110 138 Q 130 134 144 128" strokeOpacity=".6" strokeWidth=".8"/>
+        <path d="M 100 64 L 100 40 L 100 18" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 154 80 L 174 70 L 188 60" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 152 110 L 174 116 L 188 122" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 140 138 L 158 156 L 172 174" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 100 142 L 100 162 L 100 184" strokeOpacity=".7" strokeWidth=".85"/>
+        <path d="M 64 138 L 44 156 L 28 172" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 52 108 L 28 110 L 12 110" strokeOpacity=".55" strokeWidth=".75"/>
+        <path d="M 60 80 L 38 70 L 22 60" strokeOpacity=".55" strokeWidth=".75"/>
+      </g>
+      <g stroke={ink} fill="none" strokeLinecap="round" strokeOpacity=".35" strokeWidth=".5">
+        <path d="M 76 88 L 138 92"/>
+        <path d="M 74 96 L 142 100"/>
+        <path d="M 78 118 L 138 120"/>
+        <path d="M 80 134 L 134 134"/>
+        <path d="M 102 80 L 104 138"/>
+        <path d="M 116 80 L 116 138"/>
+        <path d="M 84 78 L 86 138"/>
+      </g>
+    </>
+  ),
+
+  tier3: (ink, pulseRef) => (
+    <>
+      <rect x="108" y="86" width="3.5" height="3" fill="none" stroke={ink} strokeWidth=".8"/>
+      <path d="M 109 86 L 109 82 L 110 82 L 110 86" stroke={ink} strokeWidth=".6" fill="none"/>
+      <path d="M 113 86 L 113 82 L 114 82 L 114 86" stroke={ink} strokeWidth=".6" fill="none"/>
+      <circle cx="94" cy="96" r="1.4" fill="none" stroke={ink} strokeWidth=".75"/>
+      <circle cx="94" cy="96" r="0.4" fill={ink}/>
+      <rect x="104" y="94" width="3" height="3" fill="none" stroke={ink} strokeWidth=".75"/>
+      <path d="M 142 116 L 144 110 L 146 116 Z" fill={ink}/>
+      <rect x="142" y="86" width="2.4" height="2.4" fill={ink} fillOpacity=".85"/>
+      <rect x="42" y="100" width="2.4" height="2.4" fill={ink} fillOpacity=".75"/>
+      <rect x="50" y="148" width="2.4" height="2.4" fill={ink} fillOpacity=".75"/>
+      <circle cx="100" cy="144" r="1.6" fill={ink}/>
+      <rect x="117" y="118" width="2.4" height="2.4" fill={ink} fillOpacity=".8"/>
+      <g>
+        <circle ref={pulseRef} cx="100" cy="144" r="3.2" fill="none" stroke={ink} strokeWidth="1"/>
+        <circle cx="100" cy="144" r="2.5" fill={ink}/>
+      </g>
+    </>
+  ),
+};
+export default config;

--- a/src/components/property/HubDiagram.js
+++ b/src/components/property/HubDiagram.js
@@ -7,6 +7,7 @@ import dynamic from 'next/dynamic';
 import { COUNTRIES, propertyHref } from '@/lib/cityRoutes';
 
 const GlobeLoader = dynamic(() => import('@/components/GlobeLoader'), { ssr: false });
+const CityGlobeLoader = dynamic(() => import('@/components/CityGlobeLoader'), { ssr: false });
 
 // Multi-country hub diagram — port of `NeuralNetLanding` (stripe theme
 // only) from the Claude Design wireframe bundle. Renders the
@@ -72,7 +73,7 @@ export default function HubDiagram() {
   const router = useRouter();
   const [hovered, setHovered] = useState(null);
   const [search, setSearch] = useState('');
-  const [globeLoading, setGlobeLoading] = useState(false);
+  const [globeLoading, setGlobeLoading] = useState(null);
 
   // Order countries; append per-country ghost row ("coming soon…") for
   // any non-Greek country with no second city yet. Ghost rows are
@@ -150,17 +151,13 @@ export default function HubDiagram() {
     activeCity && activeCity.country.code === cc && activeCity.slug === slug;
 
   const handleGlobeComplete = useCallback(() => {
-    router.push(propertyHref('thessaloniki'));
-  }, [router]);
+    if (globeLoading) router.push(propertyHref(globeLoading));
+  }, [router, globeLoading]);
 
   const onCityClick = (city) => {
     if (!city.clickable && city.clickable !== undefined) return;
     if (city.ghost) return;
-    if (city.slug === 'thessaloniki') {
-      setGlobeLoading(true);
-      return;
-    }
-    router.push(propertyHref(city.slug));
+    setGlobeLoading(city.slug);
   };
 
   return (
@@ -545,7 +542,10 @@ export default function HubDiagram() {
           )}
         </div>
       </div>
-      {globeLoading && <GlobeLoader onComplete={handleGlobeComplete} />}
+      {globeLoading === 'thessaloniki' && <GlobeLoader onComplete={handleGlobeComplete} />}
+      {globeLoading && globeLoading !== 'thessaloniki' && (
+        <CityGlobeLoader city={globeLoading} onComplete={handleGlobeComplete} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add globe-to-city-map zoom animations for **Athens, Larissa, Heraklion, London, Dublin, and Nicosia** — clicking any city on the `/property` hub now plays a globe animation before navigating, matching the existing Thessaloniki behavior
- One parametric `CityGlobeLoader` component handles all 6 cities, with per-city SVG data files containing unique city maps (coast/parks, streets, landmarks)
- Two animation variants: **Variant A** (continuous descent, Larissa) and **Variant B** (split descent with city zoom-in, all others)
- Existing Thessaloniki `GlobeLoader` is completely untouched

## Architecture

```
src/components/
  CityGlobeLoader.js           # NEW: parametric loader for 6 cities (~500 lines)
  city-globe-data/             # NEW: per-city config + SVG tiers
    index.js                   # Re-exports CITY_GLOBE_CONFIG lookup map
    athens.js                  # Variant B, Acropolis hill + Plaka grid
    larissa.js                 # Variant A, Pineios River + concentric rings
    heraklion.js               # Variant B, Venetian harbor + fortress walls
    london.js                  # Variant B, Thames meander + parks
    dublin.js                  # Variant B, Liffey + canals, globe stays as coast
    nicosia.js                 # Variant B, 11-pointed Venetian walls
  property/HubDiagram.js       # MODIFIED: 4 surgical edits (~15 lines changed)
```

## HubDiagram changes

1. Added `CityGlobeLoader` dynamic import
2. Changed `globeLoading` state from `boolean` to `string|null` (stores city slug)
3. Generalized `handleGlobeComplete` to use `globeLoading` slug for navigation
4. Generalized `onCityClick` — all non-ghost cities now trigger the globe animation
5. Render: Thessaloniki → existing `GlobeLoader`, all others → `CityGlobeLoader`

## Test plan

- [ ] Click each of the 6 new cities on `/property` — verify globe spins → settles on Europe → zooms to correct region → city map appears → pulse → navigates to `/property/<city>`
- [ ] Click Thessaloniki — verify existing animation is unchanged
- [ ] Test `prefers-reduced-motion` — should skip animation and navigate immediately
- [ ] `npm run lint` — passes (0 errors)
- [ ] `npm run build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)