### PR TITLE
fix(synthetic): eliminate Worker self-fetch 522s in page-locale checks

### DIFF
--- a/src/app/api/cron/synthetic-en-listing/route.js
+++ b/src/app/api/cron/synthetic-en-listing/route.js
@@ -48,17 +48,12 @@ const SYNTHETIC_AUTH_COOKIE = 'sb-access-token=synthetic-canary-stub';
 // null when running outside the Cloudflare runtime (local dev, unit tests),
 // in which case fetchUrl falls back to global fetch.
 //
-// Heads-up for future maintainers: the three /en/property/* page-locale
-// checks deliberately opt out of this binding via useGlobalFetch=true. The
-// service binding bypasses the CDN cache and forces fresh SSR on every
-// probe — which is fine for the AuthGate listing detail (cheap render)
-// and for API routes (no SSR), but tips the heavy property pages over
-// the Worker's resource limits when the 8 checks run concurrently
-// (HubBackground 240k particles + HubDiagram + StripeGradientMesh
-// WebGL all SSR-walking at once → 503/timeout). Those checks only need
-// HTML marker presence, so a CDN-cached response is fine; please don't
-// "unify" them back onto the service binding without rethinking the
-// concurrency model.
+// The three property-page locale checks previously used useGlobalFetch=true
+// to hit the CDN cache instead of the service binding, avoiding concurrent
+// SSR resource exhaustion. That caused Worker self-fetch 522s whenever the
+// CDN cache was cold (post-deploy, different edge PoP). Fixed by running
+// them sequentially via the service binding after the lightweight checks
+// finish — one SSR at a time stays within the Worker's resource budget.
 async function getSelfFetcher() {
   try {
     const { env } = await getCloudflareContext({ async: true });
@@ -386,48 +381,49 @@ export async function POST(request) {
   }
 
   // --- Additional assertions, run independently ----------------------------
+  // Lightweight checks (API routes, static assets, redirects) run concurrently
+  // via service binding — fast and no resource pressure.
   const additional = await Promise.all([
     checkListingApiDistanceVariety(appUrl, listingId),
     checkSoft404(appUrl),
     checkOgDefault(appUrl),
     checkLandlordListingsApi(appUrl),
     checkNoMissingMessage(appUrl),
-    // Site-wide page renders. Originally these checked /en/* against
-    // Greek leakage (PR #109 regression); with Greek removed in Step B
-    // (#158), the Greek-leakage angle is moot but the English-marker
-    // assertions still catch any regression that breaks the page render
-    // entirely. Repurpose vs. delete is tracked in #158 followups.
-    // These three checks use global fetch (CDN path) instead of the
-    // self service-binding — see the comment on getSelfFetcher above.
-    // The marker assertions only need HTML presence, so a CDN-cached
-    // response satisfies them; routing through the service binding
-    // triggers fresh SSR of the heavy property pages and 503s the Worker.
-    checkEnLocale({
+  ]);
+
+  // Heavy property-page locale checks run sequentially via service binding.
+  // These pages SSR WebGL components (HubBackground, StripeGradientMesh) that
+  // are too resource-intensive to render concurrently. Sequential keeps each
+  // render within the Worker's CPU budget. Previously these used global fetch
+  // (CDN path) to avoid SSR, but that caused Worker self-fetch 522s whenever
+  // the CDN cache was cold (post-deploy, different edge PoP).
+  const heavyPageChecks = [
+    {
       name: 'en-cityhub-locale',
       url: `${appUrl}/property`,
-      useGlobalFetch: true,
       anyEnMarker: [
         'Hover over your city',
         'Global students empowered',
         'Curated student housing',
       ],
       forbidElMarkers: [],
-    }),
-    checkEnLocale({
+    },
+    {
       name: 'en-homepage-locale',
       url: `${appUrl}/property/thessaloniki`,
-      useGlobalFetch: true,
       anyEnMarker: ['Take the quiz', 'See all listings', 'How it works'],
       forbidElMarkers: [],
-    }),
-    checkEnLocale({
+    },
+    {
       name: 'en-quiz-locale',
       url: `${appUrl}/property/thessaloniki/quiz`,
-      useGlobalFetch: true,
       anyEnMarker: ['One minute', "That's it"],
       forbidElMarkers: [],
-    }),
-  ]);
+    },
+  ];
+  for (const check of heavyPageChecks) {
+    additional.push(await checkEnLocale(check));
+  }
   for (const r of additional) {
     checks.push(r);
     if (!r.ok) failures.push(r);

--- a/src/app/api/cron/synthetic-en-listing/route.js
+++ b/src/app/api/cron/synthetic-en-listing/route.js
@@ -63,7 +63,7 @@ async function getSelfFetcher() {
   }
 }
 
-async function fetchUrl(url, { method = 'GET', cookie = '', useGlobalFetch = false } = {}) {
+async function fetchUrl(url, { method = 'GET', cookie = '' } = {}) {
   const headers = { 'user-agent': 'StudentX-synthetic/1.0' };
   if (cookie) headers.cookie = cookie;
   const init = {
@@ -72,7 +72,6 @@ async function fetchUrl(url, { method = 'GET', cookie = '', useGlobalFetch = fal
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     redirect: 'manual',
   };
-  if (useGlobalFetch) return fetch(url, init);
   const self = await getSelfFetcher();
   return self ? self.fetch(url, init) : fetch(url, init);
 }
@@ -285,15 +284,13 @@ async function checkNoMissingMessage(appUrl) {
   }
 }
 
-// Generic /en/* locale check: assert at least one EN-only marker is present
-// and no EL-only marker leaks through. Caller passes a list of EN markers
-// any of which is sufficient (forgiving against copy tweaks) and a list of
-// EL forbidden markers all of which must be absent. Pass useGlobalFetch=true
-// to route via the CDN instead of the self service-binding — see the comment
-// on getSelfFetcher above for when (and why) you'd want that.
-async function checkEnLocale({ name, url, anyEnMarker, forbidElMarkers, useGlobalFetch = false }) {
+// Generic locale check: assert at least one EN-only marker is present and no
+// EL-only marker leaks through. Caller passes a list of EN markers any of
+// which is sufficient (forgiving against copy tweaks) and a list of EL
+// forbidden markers all of which must be absent.
+async function checkEnLocale({ name, url, anyEnMarker, forbidElMarkers }) {
   try {
-    const res = await fetchUrl(url, { useGlobalFetch });
+    const res = await fetchUrl(url);
     if (res.status !== 200) {
       return { name, ok: false, reason: `expected 200, got ${res.status} from ${url}` };
     }


### PR DESCRIPTION
## Summary

- The three property-page locale checks (`en-cityhub-locale`, `en-homepage-locale`, `en-quiz-locale`) used `useGlobalFetch: true` (CDN path) to avoid concurrent SSR resource exhaustion. This caused **Worker self-fetch 522s** whenever the CDN cache was cold — the Worker fetching its own hostname (`studentx.uk`) loops back and Cloudflare rejects it with 522.
- Switches those checks to **sequential service-binding calls**: one SSR at a time stays within the Worker's CPU budget while completely avoiding the self-fetch loop.
- Lightweight checks (API routes, static assets, redirects) still run concurrently via `Promise.all` — only the heavy WebGL pages (HubBackground, StripeGradientMesh) are serialized.

**Investigation:** Confirmed via `curl` that the site is healthy for external visitors — the 522s were purely internal to the canary's self-fetch pattern. See Cloudflare's [documented cause #7](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-5xx-errors/error-522/) (Workers fetching own hostname).

## Test plan

- [x] `npm run test` — 127 tests pass
- [x] `npm run lint` — clean (1 pre-existing warning in `cf/worker-entry.mjs`)
- [x] External `curl` confirms site is live and serving 200s on all pages
- [ ] After deploy: trigger synthetic check manually (`curl -X POST -H "x-cron-secret: $CRON_SECRET" https://studentx.uk/api/cron/synthetic-en-listing`) and verify all 11 checks pass
- [ ] Monitor next 2-3 automated cron runs via `wrangler tail` to confirm no 522s

🤖 Generated with [Claude Code](https://claude.com/claude-code)