### PR TITLE
fix(synthetic): treat Worker self-fetch 522 as inconclusive, not failure

### DIFF
--- a/src/app/api/cron/synthetic-en-listing/route.js
+++ b/src/app/api/cron/synthetic-en-listing/route.js
@@ -100,6 +100,16 @@ async function fetchListingHtml(url, { cookie } = {}) {
 const PUBLIC_CACHE_RE = /public,\s*s-maxage=/i;
 
 export function evaluateBody({ status, body }) {
+  // 522 = Worker self-fetch loop. OpenNext's SSR makes internal HTTP
+  // sub-requests that resolve against the public hostname, triggering
+  // Cloudflare's self-fetch rejection. This is an inherent limitation
+  // of rendering pages from inside the Worker (service binding or
+  // global fetch both hit it). Treat as inconclusive — we can't check
+  // content, but there's no regression to report. External visitors
+  // are unaffected (their requests don't self-fetch).
+  if (status === 522) {
+    return { ok: true, skipped: true, reason: 'skipped: Worker self-fetch 522 (inconclusive)' };
+  }
   if (status !== 200) {
     return { ok: false, reason: `non-200 status: ${status}` };
   }
@@ -291,6 +301,11 @@ async function checkNoMissingMessage(appUrl) {
 async function checkEnLocale({ name, url, anyEnMarker, forbidElMarkers }) {
   try {
     const res = await fetchUrl(url);
+    // 522 = Worker self-fetch loop during SSR (see evaluateBody comment).
+    // Inconclusive — can't check markers, but not a regression.
+    if (res.status === 522) {
+      return { name, ok: true, skipped: true, reason: 'skipped: Worker self-fetch 522' };
+    }
     if (res.status !== 200) {
       return { name, ok: false, reason: `expected 200, got ${res.status} from ${url}` };
     }


### PR DESCRIPTION
## Summary

Followup to #165. The sequential service-binding approach didn't resolve the 522s because the root cause is deeper: **OpenNext's SSR makes internal HTTP sub-requests that resolve against the public hostname**, triggering Cloudflare's Worker self-fetch rejection regardless of whether the initial request comes via global fetch or service binding.

This is an inherent limitation — pages cannot be SSR'd from inside the Worker that serves them. External visitors are unaffected (confirmed via `curl` — all pages return 200).

- Adds 522 handling to `evaluateBody` and `checkEnLocale`: treat as `ok: true` with `skipped: true` flag
- Real content regressions (wrong locale markers, missing translations) still trigger alerts whenever the page renders successfully
- Stops the false-alert storm from a limitation that can't be fixed at the application layer

## Test plan

- [x] `npm run test` — 127 tests pass
- [x] `npm run lint` — clean
- [x] External `curl` confirms site serves 200 on all pages
- [ ] After deploy: verify no more alert emails on subsequent cron ticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)