### PR TITLE
fix(auth): prevent orphan landlord emails from blocking student signup

### DIFF
--- a/src/app/[locale]/student/login/page.js
+++ b/src/app/[locale]/student/login/page.js
@@ -68,6 +68,37 @@ function StudentLoginInner() {
                 body: JSON.stringify({ access_token: data.session.access_token }),
               }),
             );
+
+            // Idempotent profile probe — ensures a students row exists
+            // even if the signup trigger was skipped (e.g. pre-seeded
+            // landlord email collision). Returns the existing row when
+            // one is already present, so this is a no-op on happy path.
+            try {
+              const profileRes = await withTimeout(
+                fetch('/api/student/profile', {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${data.session.access_token}`,
+                  },
+                  body: JSON.stringify({ preferred_locale: 'en' }),
+                }),
+              );
+              if (profileRes.status === 409) {
+                const profileBody = await profileRes.json().catch(() => ({}));
+                if (profileBody.conflict_role === 'landlord') {
+                  const conflictUrl = new URL(window.location.href);
+                  conflictUrl.searchParams.set('roleConflict', 'landlord');
+                  if (data.session.user?.email) {
+                    conflictUrl.searchParams.set('email', data.session.user.email);
+                  }
+                  window.location.assign(conflictUrl.toString());
+                  return;
+                }
+              }
+            } catch {
+              // Best-effort — proceed with redirect.
+            }
           }
 
           if (safeNext) {

--- a/src/components/AuthGate.js
+++ b/src/components/AuthGate.js
@@ -3,6 +3,7 @@ import { Link } from '@/i18n/navigation';
 import Card from '@/components/ui/Card';
 import Icon from '@/components/ui/Icon';
 import AuthGateRescue from '@/components/AuthGateRescue';
+import { hasAuthCookie } from '@/lib/requireStudent';
 
 /**
  * Server-rendered gate shown when requireStudent() blocks listing access.
@@ -25,6 +26,7 @@ import AuthGateRescue from '@/components/AuthGateRescue';
  */
 export default async function AuthGate({ next, locale, mode = 'guest' }) {
   const t = await getTranslations({ locale, namespace: 'student.gate' });
+  const cookiePresent = await hasAuthCookie();
   const safeNext = typeof next === 'string' && next.startsWith('/') ? next : '';
   const nextQuery = safeNext ? `?next=${encodeURIComponent(safeNext)}` : '';
 
@@ -32,7 +34,7 @@ export default async function AuthGate({ next, locale, mode = 'guest' }) {
 
   return (
     <div className="min-h-[calc(100vh-12rem)] flex items-center justify-center px-5 py-16 bg-stone">
-      <AuthGateRescue />
+      <AuthGateRescue cookiePresent={cookiePresent} />
 
       <Card tone="white" className="w-full max-w-md p-8 md:p-10 text-center relative overflow-hidden">
         <div

--- a/src/components/AuthGateRescue.js
+++ b/src/components/AuthGateRescue.js
@@ -15,8 +15,10 @@ import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
  * Keep this side-effect-only and silent — if no session exists, the
  * gate is correct and nothing should change.
  */
-export default function AuthGateRescue() {
+export default function AuthGateRescue({ cookiePresent = false }) {
   useEffect(() => {
+    if (cookiePresent) return;
+
     let cancelled = false;
     (async () => {
       const supabase = getSupabaseBrowser();
@@ -40,7 +42,7 @@ export default function AuthGateRescue() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [cookiePresent]);
 
   return null;
 }

--- a/src/components/listing/ContactGate.js
+++ b/src/components/listing/ContactGate.js
@@ -4,12 +4,14 @@ import Card from '@/components/ui/Card';
 import Icon from '@/components/ui/Icon';
 import Pill from '@/components/ui/Pill';
 import AuthGateRescue from '@/components/AuthGateRescue';
+import { hasAuthCookie } from '@/lib/requireStudent';
 
 export default async function ContactGate({ listing, locale, fromRaw }) {
   const t = await getTranslations({ locale, namespace: 'propylaea.listing' });
   const tListing = await getTranslations({ locale, namespace: 'listing' });
   const tContact = await getTranslations({ locale, namespace: 'student.contact' });
   const tGate = await getTranslations({ locale, namespace: 'student.gate' });
+  const cookiePresent = await hasAuthCookie();
 
   const fromQs = fromRaw ? `?from=${encodeURIComponent(fromRaw)}` : '';
   const nextPath = `/property/thessaloniki/listing/${listing.listing_id}${fromQs}`;
@@ -19,7 +21,7 @@ export default async function ContactGate({ listing, locale, fromRaw }) {
     <aside>
       <div className="lg:sticky lg:top-6">
         <Card tone="white" className="p-6">
-          <AuthGateRescue />
+          <AuthGateRescue cookiePresent={cookiePresent} />
           <p className="font-display text-3xl text-blue">
             {listing.monthly_price != null ? (
               <>

--- a/supabase/migrations/051_fix_trigger_orphan_landlord_email_check.sql
+++ b/supabase/migrations/051_fix_trigger_orphan_landlord_email_check.sql
@@ -1,0 +1,113 @@
+-- ============================================================
+-- Migration 051: Tighten email-based dual-role checks to ignore
+-- unlinked (pre-seeded) rows.
+--
+-- BUG: A student (morneg101@hotmail.com) signed up but
+-- handle_new_student_user skipped row creation because a
+-- pre-seeded landlord row with the same email existed
+-- (landlord_id 0104, auth_user_id = NULL). The prevent_dual_role
+-- trigger has the same flaw — its email branch matches unlinked
+-- seed data, blocking both the trigger and manual recovery.
+--
+-- FIX: Add `auth_user_id IS NOT NULL` to every email-only branch
+-- in both functions. The auth_user_id equality check already
+-- guards the real dual-role case; the email heuristic should only
+-- fire for claimed accounts, not administrative seed data.
+-- ============================================================
+
+-- ---- 1. Patch handle_new_student_user --------------------------
+
+CREATE OR REPLACE FUNCTION public.handle_new_student_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role           text;
+  v_provider       text;
+  v_display_name   text;
+  v_locale         text;
+BEGIN
+  v_role     := NULLIF(NEW.raw_user_meta_data->>'role', '');
+  v_provider := NULLIF(NEW.raw_app_meta_data->>'provider', '');
+  IF v_role IS DISTINCT FROM 'student'
+     AND (v_provider IS NULL OR v_provider NOT IN ('google', 'apple')) THEN
+    RETURN NEW;
+  END IF;
+
+  -- Landlord trumps: skip auto-student creation if this email
+  -- already belongs to a CLAIMED landlord account. Unlinked seed
+  -- data (auth_user_id IS NULL) must not block student signups.
+  IF EXISTS (
+    SELECT 1 FROM public.landlords l
+     WHERE lower(l.email) = lower(NEW.email)
+       AND l.auth_user_id IS NOT NULL
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  v_display_name := COALESCE(
+    NULLIF(trim(NEW.raw_user_meta_data->>'display_name'), ''),
+    NULLIF(trim(NEW.raw_user_meta_data->>'full_name'), ''),
+    NULLIF(trim(NEW.raw_user_meta_data->>'name'), ''),
+    split_part(NEW.email, '@', 1)
+  );
+
+  v_locale := NULLIF(NEW.raw_user_meta_data->>'preferred_locale', '');
+  IF v_locale IS NULL OR v_locale NOT IN ('el', 'en') THEN
+    v_locale := 'en';
+  END IF;
+
+  INSERT INTO public.students (auth_user_id, email, display_name, preferred_locale)
+  VALUES (NEW.id, lower(NEW.email), v_display_name, v_locale)
+  ON CONFLICT (auth_user_id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+-- ---- 2. Patch prevent_dual_role --------------------------------
+
+CREATE OR REPLACE FUNCTION public.prevent_dual_role()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  conflict_role text;
+BEGIN
+  IF TG_TABLE_NAME = 'students' THEN
+    IF EXISTS (
+      SELECT 1 FROM public.landlords l
+       WHERE l.auth_user_id = NEW.auth_user_id
+          OR (NEW.email IS NOT NULL
+              AND l.email IS NOT NULL
+              AND l.auth_user_id IS NOT NULL
+              AND lower(l.email) = lower(NEW.email))
+    ) THEN
+      conflict_role := 'landlord';
+    END IF;
+  ELSE
+    -- public.landlords
+    IF EXISTS (
+      SELECT 1 FROM public.students s
+       WHERE s.auth_user_id = NEW.auth_user_id
+          OR (NEW.email IS NOT NULL
+              AND s.email IS NOT NULL
+              AND s.auth_user_id IS NOT NULL
+              AND lower(s.email) = lower(NEW.email))
+    ) THEN
+      conflict_role := 'student';
+    END IF;
+  END IF;
+
+  IF conflict_role IS NOT NULL THEN
+    RAISE EXCEPTION
+      'Email % already registered as a %; one email cannot be both a student and a landlord',
+      NEW.email, conflict_role
+      USING ERRCODE = 'unique_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Summary

- **Migration 051**: tightens `handle_new_student_user` and `prevent_dual_role` triggers to only match landlord rows where `auth_user_id IS NOT NULL` — pre-seeded/unlinked seed data no longer blocks student signup
- **Login page**: adds idempotent `POST /api/student/profile` after cookie sync as a safety net when the trigger was skipped (mirrors the OAuth callback fallback)
- **AuthGateRescue**: accepts `cookiePresent` prop from server components to prevent infinite reload loop when the cookie is set but the user has no students row

**Root cause**: `morneg101@hotmail.com` signed up as a student, but a pre-seeded landlord row (landlord_id `0104`, `auth_user_id = NULL`) with the same email caused both triggers to skip/block student row creation. With email-confirmation enforced, the signup page's fallback profile-POST never ran either — leaving the user with a valid auth session but no student record. `AuthGateRescue` then looped infinitely trying to "rescue" a state that reloading couldn't fix.

**Data fix applied**: student row manually created for this user (verified in prod).

## Test plan

- [ ] `npm run test` passes (127 tests, verified locally)
- [ ] `npm run lint` clean (0 errors)
- [ ] `npm run build` succeeds
- [ ] Apply migration 051 to prod before merging
- [ ] Verify `morneg101@hotmail.com` can see the message composer on listing pages
- [ ] Verify a new signup with an email matching an unlinked landlord gets a students row
- [ ] Verify a new signup with an email matching a *linked* landlord still gets blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)