### PR TITLE
chore(routing): remove leftover `locale === 'el'` branches

### DIFF
--- a/src/app/[locale]/page.js
+++ b/src/app/[locale]/page.js
@@ -1,6 +1,5 @@
 import { redirect } from 'next/navigation';
 
-export default async function HomePage({ params }) {
-  const { locale } = await params;
-  redirect(locale === 'el' ? '/property' : `/${locale}/property`);
+export default function HomePage() {
+  redirect('/property');
 }

--- a/src/app/[locale]/student/inquiries/[inquiry_id]/page.js
+++ b/src/app/[locale]/student/inquiries/[inquiry_id]/page.js
@@ -11,16 +11,12 @@ export default async function StudentInquiryThreadPage({ params }) {
 
   const auth = await requireStudent();
   if (!auth || auth.kind === 'wrong-role') {
-    const next =
-      locale === 'el'
-        ? `/student/inquiries/${inquiryId}`
-        : `/${locale}/student/inquiries/${inquiryId}`;
-    const loginParams = new URLSearchParams({ next });
+    const loginParams = new URLSearchParams({ next: `/student/inquiries/${inquiryId}` });
     if (auth?.kind === 'wrong-role' && auth.conflict_role) {
       loginParams.set('roleConflict', auth.conflict_role);
       if (auth.email) loginParams.set('email', auth.email);
     }
-    redirect(`${locale === 'el' ? '' : `/${locale}`}/student/login?${loginParams.toString()}`);
+    redirect(`/student/login?${loginParams.toString()}`);
   }
 
   const t = await getTranslations({ locale, namespace: 'student.chat' });


### PR DESCRIPTION
## Summary

Stragglers from issue #158 / Step B (Greek removal). With
`localePrefix: 'never'` and `en` the only locale, two server-side
redirects still carried `locale === 'el' ? ... : ...` ternaries that
always took the `/${locale}/...` branch — producing a `/en/...` URL
that then 301'd to its unprefixed equivalent via the catch-all
in `next.config.mjs#redirects()`. No bug, just an extra hop and a
confusing read. PR #176 already collapsed the same pattern in
`student/account/page.js`; this finishes the sweep.

Files touched:

- `src/app/[locale]/page.js` — `redirect('/property')` (was `redirect(`/${locale}/property`)`); also drops the now-unused `params` arg.
- `src/app/[locale]/student/inquiries/[inquiry_id]/page.js` — same shape as the cleanup already merged in `student/account/page.js`: plain `/student/login?...` and `/student/inquiries/<id>` for the `next` param.

After this PR, `grep -rn "locale === 'el'\|locale == 'el'" src/` returns no hits.

## Test plan

- [x] `npm run lint` — clean (one pre-existing warning in `cf/worker-entry.mjs`)
- [x] `npm run test` — 135 tests pass across 16 suites
- [x] `npm run build` — succeeds, all routes register
- [ ] After merge: visit `/` and confirm it lands on `/property` in a single redirect (network panel: one 307, then 200)
- [ ] After merge: visit `/student/inquiries/<some-id>` signed out and confirm it bounces straight to `/student/login?next=/student/inquiries/<id>` (not `/en/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)