### PR TITLE
fix(auth): switch local JWT verification from HS256 to JWKS

### DIFF
--- a/__tests__/lib/verifyJwt.test.js
+++ b/__tests__/lib/verifyJwt.test.js
@@ -1,26 +1,55 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { SignJWT } from 'jose';
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { SignJWT, generateKeyPair, exportJWK } from 'jose';
 
-const SECRET = 'test-jwt-secret-with-enough-entropy-to-be-realistic';
+const SUPABASE_URL = 'https://example.supabase.co';
+const JWKS_URL = `${SUPABASE_URL}/auth/v1/.well-known/jwks.json`;
 
-async function signSupabaseLike(payload, { secret = SECRET, alg = 'HS256' } = {}) {
-  const key = new TextEncoder().encode(secret);
+// One real ES256 keypair shared across the suite — generating per test
+// is wasteful and the SUT caches its JWKS resolver per isolate, so the
+// test fixtures need to match what the resolver fetched on first use.
+let privateKey;
+let publicJwk;
+let otherPrivateKey;
+
+beforeAll(async () => {
+  const kp = await generateKeyPair('ES256');
+  privateKey = kp.privateKey;
+  publicJwk = { ...(await exportJWK(kp.publicKey)), kid: 'test-key-1', alg: 'ES256', use: 'sig' };
+
+  const other = await generateKeyPair('ES256');
+  otherPrivateKey = other.privateKey;
+});
+
+// Stub global fetch so jose's createRemoteJWKSet resolves the test
+// keypair's public half instead of hitting the network. The SUT calls
+// fetch with the JWKS endpoint URL.
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
+  vi.stubGlobal('fetch', vi.fn(async (input) => {
+    const url = typeof input === 'string' ? input : input.url ?? String(input);
+    if (url === JWKS_URL) {
+      return new Response(JSON.stringify({ keys: [publicJwk] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }));
+});
+
+const { verifyAccessTokenLocal } = await import('@/lib/verifyJwt');
+
+async function signWith(key, payload, { kid = 'test-key-1' } = {}) {
   return new SignJWT(payload)
-    .setProtectedHeader({ alg })
+    .setProtectedHeader({ alg: 'ES256', kid })
     .setIssuedAt()
     .setExpirationTime('1h')
     .sign(key);
 }
 
-beforeEach(() => {
-  process.env.SUPABASE_JWT_SECRET = SECRET;
-});
-
-const { verifyAccessTokenLocal } = await import('@/lib/verifyJwt');
-
 describe('verifyAccessTokenLocal', () => {
   it('returns a Supabase-shaped user when the token is valid', async () => {
-    const token = await signSupabaseLike({
+    const token = await signWith(privateKey, {
       sub: 'auth-user-123',
       email: 'happy@example.com',
       role: 'authenticated',
@@ -39,31 +68,29 @@ describe('verifyAccessTokenLocal', () => {
     expect(user.user_metadata).toEqual({ display_name: 'Happy' });
   });
 
-  it('returns null when the signature is wrong (token signed with a different secret)', async () => {
-    const token = await signSupabaseLike(
-      { sub: 'auth-user-1', aud: 'authenticated' },
-      { secret: 'a-different-secret' }
-    );
+  it('returns null when the signature is wrong (token signed with a different key)', async () => {
+    const token = await signWith(otherPrivateKey, {
+      sub: 'auth-user-1',
+      aud: 'authenticated',
+    });
     expect(await verifyAccessTokenLocal(token)).toBeNull();
   });
 
   it('returns null when the audience is not "authenticated" (refresh token, anon, etc.)', async () => {
-    const key = new TextEncoder().encode(SECRET);
     const token = await new SignJWT({ sub: 'auth-user-1', aud: 'anon' })
-      .setProtectedHeader({ alg: 'HS256' })
+      .setProtectedHeader({ alg: 'ES256', kid: 'test-key-1' })
       .setIssuedAt()
       .setExpirationTime('1h')
-      .sign(key);
+      .sign(privateKey);
     expect(await verifyAccessTokenLocal(token)).toBeNull();
   });
 
   it('returns null when the token is expired', async () => {
-    const key = new TextEncoder().encode(SECRET);
     const token = await new SignJWT({ sub: 'auth-user-1', aud: 'authenticated' })
-      .setProtectedHeader({ alg: 'HS256' })
+      .setProtectedHeader({ alg: 'ES256', kid: 'test-key-1' })
       .setIssuedAt(Math.floor(Date.now() / 1000) - 7200)
       .setExpirationTime(Math.floor(Date.now() / 1000) - 3600)
-      .sign(key);
+      .sign(privateKey);
     expect(await verifyAccessTokenLocal(token)).toBeNull();
   });
 
@@ -75,19 +102,18 @@ describe('verifyAccessTokenLocal', () => {
     expect(await verifyAccessTokenLocal(12345)).toBeNull();
   });
 
-  it('returns null when SUPABASE_JWT_SECRET is unset (caller falls back to network path)', async () => {
-    delete process.env.SUPABASE_JWT_SECRET;
-    const token = await signSupabaseLike({ sub: 'auth-user-1', aud: 'authenticated' });
+  it('returns null when NEXT_PUBLIC_SUPABASE_URL is unset (caller falls back to network path)', async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const token = await signWith(privateKey, { sub: 'auth-user-1', aud: 'authenticated' });
     expect(await verifyAccessTokenLocal(token)).toBeNull();
   });
 
   it('returns null when the token has no sub claim', async () => {
-    const key = new TextEncoder().encode(SECRET);
     const token = await new SignJWT({ aud: 'authenticated' })
-      .setProtectedHeader({ alg: 'HS256' })
+      .setProtectedHeader({ alg: 'ES256', kid: 'test-key-1' })
       .setIssuedAt()
       .setExpirationTime('1h')
-      .sign(key);
+      .sign(privateKey);
     expect(await verifyAccessTokenLocal(token)).toBeNull();
   });
 });

--- a/src/lib/supabaseServer.js
+++ b/src/lib/supabaseServer.js
@@ -19,20 +19,21 @@ export function getSupabaseWithToken(token) {
 /**
  * Validates a JWT and returns the Supabase user, or null if invalid.
  *
- * Fast path: when SUPABASE_JWT_SECRET is set (Worker secret in prod),
- * verifies the JWT signature locally with jose. No network call — a few
+ * Fast path: verifies the JWT signature locally with jose, using the
+ * project's JWKS (public key) fetched once per Worker isolate. No
+ * network call per token check after the first fetch — a few
  * microseconds of crypto vs. a ~200–1000 ms round-trip to Supabase's
  * /auth/v1/user. This is the single biggest sign-in latency win because
  * requireStudent / requireLandlord and every authenticated API route
  * funnel through here.
  *
- * Fallback: any time local verification doesn't return a user — secret
- * unset, secret rotated, secret drifted from the Supabase project — we
- * fall back to supabase.auth.getUser(token). This means a misconfigured
- * or rotated secret causes a slow login, not a mass 401, and prod is
- * safe to merge before the Worker secret is propagated. The only
- * additional cost is one Supabase round-trip on genuinely invalid
- * tokens, which is fine — that's the same cost as before the change.
+ * Fallback: any time local verification doesn't return a user — JWKS
+ * fetch failed, token signed with an unknown key, NEXT_PUBLIC_SUPABASE_URL
+ * misconfigured — we fall back to supabase.auth.getUser(token). This
+ * means a transient network blip or Supabase key rotation causes a slow
+ * login, not a mass 401. The only additional cost is one Supabase
+ * round-trip on genuinely invalid tokens, which is the same cost as
+ * before the change.
  */
 export async function getUserFromToken(token) {
   const local = await verifyAccessTokenLocal(token);

--- a/src/lib/verifyJwt.js
+++ b/src/lib/verifyJwt.js
@@ -1,12 +1,21 @@
-import { jwtVerify } from 'jose';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
 
-// Local JWT verification for Supabase access tokens. Supabase issues HS256
-// JWTs signed with SUPABASE_JWT_SECRET (Project Settings → API → JWT
-// Settings in the Supabase dashboard). Verifying locally with jose is a
-// few microseconds of crypto vs. a ~200–1000 ms round-trip to
-// /auth/v1/user — which compounds because requireStudent /
-// requireLandlord and every authenticated API route call this on every
-// request.
+// Local JWT verification for Supabase access tokens.
+//
+// Supabase now signs access tokens with an asymmetric key (ES256 / ECC
+// P-256 by default — see Project Settings → Auth → JWT Signing Keys in
+// the Supabase dashboard). The public key is published at the project's
+// JWKS endpoint and can be fetched by anyone — there's no shared secret
+// to manage, no Worker secret to set. jose's createRemoteJWKSet fetches
+// the JWKS on first use, caches it for the lifetime of the Worker
+// isolate, and re-fetches automatically when a token references a `kid`
+// it doesn't recognise (the key-rotation case).
+//
+// Why bother verifying locally at all? requireStudent / requireLandlord
+// and every authenticated API route used to call supabase.auth.getUser
+// which is a ~200–1000 ms round-trip to Supabase Auth. Local verification
+// is a few microseconds of crypto. The win compounds across every
+// authenticated server check.
 //
 // Trade-off: a locally-verified token doesn't catch revocations within
 // its 1-hour TTL. We don't currently revoke tokens (sign-out only clears
@@ -18,40 +27,55 @@ import { jwtVerify } from 'jose';
 //   { id, email, role, aud, app_metadata, user_metadata, ... }
 // Returns null when the token is missing, malformed, expired, or fails
 // signature verification — callers can keep their existing `if (!user)`
-// branch and don't need to distinguish failure modes.
+// branch and don't need to distinguish failure modes. getUserFromToken
+// in supabaseServer.js then transparently falls back to the network on
+// null, so a JWKS fetch failure / network blip degrades to "slow" not
+// "broken".
 
-let _cachedKey;
-let _cachedKeySource;
+let _jwks;
+let _jwksUrlSource;
 
-function getKey() {
-  const secret = process.env.SUPABASE_JWT_SECRET;
-  if (!secret) return null;
-  // Cache the encoded key across requests in the same Worker isolate.
-  // TextEncoder is cheap but encoding the same secret on every auth check
-  // is needless work.
-  if (_cachedKey && _cachedKeySource === secret) return _cachedKey;
-  _cachedKey = new TextEncoder().encode(secret);
-  _cachedKeySource = secret;
-  return _cachedKey;
+function getJwks() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!supabaseUrl) return null;
+
+  // Cache the JWKS resolver per isolate, keyed by the URL it was built
+  // for. Recreating it on every call would defeat the internal cache
+  // that makes the fast path fast.
+  if (_jwks && _jwksUrlSource === supabaseUrl) return _jwks;
+  _jwksUrlSource = supabaseUrl;
+  _jwks = createRemoteJWKSet(
+    new URL(`${supabaseUrl}/auth/v1/.well-known/jwks.json`),
+    {
+      // Re-fetch the JWKS at most once every 10 minutes under normal
+      // operation. The 30-second cooldown bounds how often we'll retry
+      // a fetch when a token references an unknown `kid` (the rotation
+      // signal) — prevents a misbehaving client from spamming the
+      // upstream with one fetch per failed token.
+      cacheMaxAge: 10 * 60 * 1000,
+      cooldownDuration: 30 * 1000,
+    },
+  );
+  return _jwks;
 }
 
 export async function verifyAccessTokenLocal(token) {
   if (!token || typeof token !== 'string') return null;
-  const key = getKey();
-  if (!key) return null;
+  const jwks = getJwks();
+  if (!jwks) return null;
 
   try {
-    const { payload } = await jwtVerify(token, key, {
+    const { payload } = await jwtVerify(token, jwks, {
       // Supabase access tokens carry aud="authenticated" — pinning this
-      // rejects refresh tokens, anon-role tokens, or anything else the
+      // rejects refresh tokens, anon-role tokens, or anything else an
       // attacker could try to coerce through.
       audience: 'authenticated',
     });
 
     if (!payload.sub) return null;
 
-    // Mirror the @supabase/supabase-js user shape so call sites don't care
-    // which path resolved the user.
+    // Mirror the @supabase/supabase-js user shape so call sites don't
+    // care which path resolved the user.
     return {
       id: payload.sub,
       email: payload.email ?? null,


### PR DESCRIPTION
## Summary

Follow-up to PR #176. The local JWT verifier shipped in #176 assumed Supabase's legacy HS256 shared-secret model — but this project is on the newer asymmetric scheme (current key is ECC P-256 / ES256, with HS256 only retained briefly to verify pre-rotation tokens). Real tokens were always falling through to the network fallback, so the speedup wasn't actually live.

This PR fixes that by switching `verifyJwt.js` to verify against the project's JWKS endpoint.

## Changes

- **`src/lib/verifyJwt.js`** — `createRemoteJWKSet` against `${NEXT_PUBLIC_SUPABASE_URL}/auth/v1/.well-known/jwks.json`. jose handles fetching, caching, and re-fetching on unknown `kid` (the key-rotation case). Audience pin on `"authenticated"` preserved.
- **`src/lib/supabaseServer.js`** — doc comment updated; `getUserFromToken` logic unchanged (still falls back to network on local-fail, so any JWKS hiccup degrades to slow, not broken).
- **`__tests__/lib/verifyJwt.test.js`** — rewritten to generate a real ES256 keypair, stub `fetch` to serve the public JWK from the expected URL, and sign fixtures with the private half. Same 7 scenarios as before.

## Operational notes

**No Worker secret required.** The public key is public — that's the whole point of asymmetric signing. The speedup goes live the moment this deploys. Any prior plan to `wrangler secret put SUPABASE_JWT_SECRET` can be skipped; the env var is no longer read.

**Key rotation: automatic.** Next time you rotate signing keys in Supabase, jose's JWKS resolver picks up the new key on the first token that references its new `kid`. Zero human action.

**Cost: one HTTP fetch per cold Worker isolate.** ~50–200 ms one-time to fetch the JWKS, then every subsequent verification in that isolate uses the cached key.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run test` — 135 pass (7 updated tests in verifyJwt + 4 unchanged in supabaseServer fallback)
- [x] `npm run build` — succeeds
- [ ] After deploy: sign in as a test student, watch `wrangler tail` — auth-touching routes should be visibly faster than before this PR
- [ ] After deploy: watch the `landlord-listings-api` synthetic canary (`/api/cron/synthetic-en-listing`) for 15 minutes — exercises `requireLandlord` → `getUserFromToken`. Stays green if verification works, falls back to network silently if JWKS fetch fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)