### PR TITLE
fix(synthetic): treat CF 520/523/524 as inconclusive, like 522

### DIFF
--- a/__tests__/api/syntheticEnListing.test.js
+++ b/__tests__/api/syntheticEnListing.test.js
@@ -47,6 +47,34 @@ describe('evaluateBody', () => {
     expect(result.ok).toBe(false);
     expect(result.reason).toMatch(/forbidden EL marker/);
   });
+
+  // Cloudflare "couldn't reach origin"-class 5xx is treated as inconclusive
+  // (skipped) so transient infra noise doesn't fire alerts. 521 (web server
+  // down) and 500 stay as real failures — those are NOT in the skip set.
+  // The 2026-05-17 16:00 alert (en-listing-locale: non-200 status: 523)
+  // is what prompted broadening the set beyond 522.
+  describe('inconclusive CF 5xx → skipped', () => {
+    for (const status of [520, 522, 523, 524]) {
+      it(`treats ${status} as inconclusive`, () => {
+        const result = evaluateBody({ status, body: '' });
+        expect(result.ok).toBe(true);
+        expect(result.skipped).toBe(true);
+        expect(result.reason).toMatch(new RegExp(`Cloudflare ${status}`));
+      });
+    }
+
+    it('still fails on 521 (real outage signal)', () => {
+      const result = evaluateBody({ status: 521, body: '' });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toMatch(/non-200 status: 521/);
+    });
+
+    it('still fails on generic 500 (app-level error)', () => {
+      const result = evaluateBody({ status: 500, body: '' });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toMatch(/non-200 status: 500/);
+    });
+  });
 });
 
 describe('evaluateAnonCacheHeader', () => {

--- a/docs/runbooks/synthetic-en-listing.md
+++ b/docs/runbooks/synthetic-en-listing.md
@@ -38,12 +38,16 @@ Any failed assertion (or non-200, or fetch timeout) attempts to send an email vi
 
 > **Status (2026-05-03):** Resend is verified for `studentx.uk` and `RESEND_API_KEY` is set as a Worker secret — the alert path is live. On failure the route emails `SYNTHETIC_ALERT_EMAIL` from `alerts@studentx.uk`. Failures still surface in `wrangler tail` regardless. The route's email send is wrapped in try/catch, so a Resend hiccup doesn't break the check itself.
 
-### Fetch strategy: service binding vs. global fetch
+### Fetch strategy: service binding, sequential heavy renders
 
-The route uses two fetch paths depending on the check:
+Every check fetches via the **service binding (`env.WORKER_SELF_REFERENCE`)** — `fetchUrl` in `route.js` falls back to global `fetch()` only outside the Cloudflare runtime (local dev, unit tests). Service-binding sub-fetches bypass DNS/CDN/asset-binding interception, giving a deterministic origin response — required for the cache-header assertions and to avoid the workers.dev asset-binding 404 on `/api/*`.
 
-- **Service binding (`env.WORKER_SELF_REFERENCE`)** — used by the listing-detail body + cache-header checks and the API checks (`/api/listings/<id>`, `/api/landlord/listings`, `/og-default.png`, `/en` missing-message). Bypasses DNS/CDN/asset-binding interception, so it gives a deterministic origin response (required for the cache-header assertions and avoids the workers.dev asset-binding 404 on `/api/*`).
-- **Global `fetch()` (CDN path)** — used by the three `/en/property/*` page-locale checks (`en-cityhub-locale`, `en-homepage-locale`, `en-quiz-locale`). Service-binding sub-fetches force fresh SSR for these heavy property pages (HubBackground 240k particles, HubDiagram, StripeGradientMesh WebGL) and exceed Worker resource limits when 8 checks run concurrently — symptom is 503/timeout in the alert email despite the pages serving 200 to real users. The locale checks only need HTML marker presence, so a CDN-cached response satisfies them; a real i18n regression surfaces within the CDN TTL on the first cache miss after deploy.
+To stay inside Worker resource limits, the route splits the checks into two waves:
+
+- **Lightweight checks** (API routes, static assets, redirects: `/api/listings/<id>`, `/api/landlord/listings`, `/og-default.png`, `/en` missing-message, `soft-404`) run **concurrently** via `Promise.all`. These don't render heavy SSR, so concurrent execution is fine.
+- **Heavy property-page locale checks** (`en-cityhub-locale`, `en-homepage-locale`, `en-quiz-locale`) and the listing-detail render run **sequentially** via the same service binding. These pages SSR WebGL components (HubBackground 240k particles, HubDiagram, StripeGradientMesh) and would exhaust the Worker CPU budget if rendered in parallel.
+
+> **Historical note (PR #133):** the three heavy property-page checks originally used global `fetch()` via the CDN to dodge SSR entirely, but that caused Worker self-fetch 522s whenever the CDN cache was cold (post-deploy, different edge PoP). Running them sequentially via the service binding sidesteps both the SSR resource pressure and the cold-cache 522. The trade-off is that genuine i18n regressions surface immediately (no CDN-TTL lag).
 
 ## Configuration
 
@@ -65,7 +69,7 @@ Subject: `[StudentX synthetic] N check(s) failed`
 
 Body includes the failing check name, reason, and the first 500 chars of the anon HTML response. Possible reasons:
 
-- `non-200 status: <code>` — the page errored or redirected. Check the Worker logs. **For the three `/en/property/*` page-locale checks**, these go via the CDN (see [Fetch strategy](#fetch-strategy-service-binding-vs-global-fetch)), so a non-200 means the CDN itself is failing or the origin is genuinely down — try the user-facing curl first before assuming the Worker is broken.
+- `non-200 status: <code>` — the page errored or redirected. Check the Worker logs. Every probe goes via the service binding (see [Fetch strategy](#fetch-strategy-service-binding-sequential-heavy-renders)), so a non-200 is the origin's own response — not a CDN miss. Try the user-facing curl to confirm whether external visitors see the same. **Cloudflare-class 5xx (520, 522, 523, 524) is no longer reported as a failure** — service-binding sub-fetches can hit these transiently when CF's runtime hiccups, and the page is almost always healthy seconds before and after (e.g. the 2026-05-17 16:00 `523` alert that prompted this carve-out). The skip surfaces in the run record as `{ ok: true, skipped: true, reason: "skipped: Cloudflare 523" }`. A genuine Worker outage still surfaces — either as `fetch threw: ...` errors or as simultaneous failures across multiple canaries (the suppressed codes are checked per-fetch, not globally).
 - `missing required EN marker: <marker>` — page returned 200 but the English copy disappeared. Either the gate copy was edited (update marker constants in `route.js`) or the i18n regression class from PR #48 is back.
 - `forbidden EL marker present: <marker>` — Greek leaked onto the EN page. **i18n regression** — investigate `getTranslations` calls in any recently-changed server component.
 - `anon listing detail must serve public, s-maxage=...` — the middleware-set per-request cache header (PR #105) regressed for anon visitors. Either middleware.js stopped matching the path, or `next.config.mjs` re-introduced a static `private` rule that's overriding it. Run the curl commands in the [Manual cache-header probe](#manual-cache-header-probe) section to localise.

--- a/src/app/api/cron/synthetic-en-listing/route.js
+++ b/src/app/api/cron/synthetic-en-listing/route.js
@@ -31,6 +31,21 @@ const EL_MARKERS_FORBIDDEN = [
   'Συνδέσου για να επικοινωνήσεις',
 ];
 
+// Cloudflare "couldn't reach origin"-class status codes. The synthetic
+// invokes the Worker via a service binding (env.WORKER_SELF_REFERENCE),
+// but service-binding sub-fetches still surface Cloudflare's edge errors
+// when the runtime hiccups mid-render — none of which are app-level
+// regressions. Treating them as inconclusive (skipped) prevents false
+// positives like the 2026-05-17 16:00 alert ("en-listing-locale: non-200
+// status: 523"), where the listing page was healthy 30s before and after.
+//   520 — unknown server error (Worker errored mid-response)
+//   522 — connection timed out (already handled — Worker self-fetch loop)
+//   523 — origin unreachable
+//   524 — origin responded too slowly
+// 521 (web server down) and 525–527 (SSL/Railgun) are deliberately left
+// out — those would indicate a real outage class worth alerting on.
+const INCONCLUSIVE_CF_5XX = new Set([520, 522, 523, 524]);
+
 function isCronAuthorized(request) {
   const secret = process.env.CRON_SECRET;
   if (!secret) return false;
@@ -103,15 +118,14 @@ async function fetchListingHtml(url, { cookie } = {}) {
 const PUBLIC_CACHE_RE = /public,\s*s-maxage=/i;
 
 export function evaluateBody({ status, body }) {
-  // 522 = Worker self-fetch loop. OpenNext's SSR makes internal HTTP
-  // sub-requests that resolve against the public hostname, triggering
-  // Cloudflare's self-fetch rejection. This is an inherent limitation
-  // of rendering pages from inside the Worker (service binding or
-  // global fetch both hit it). Treat as inconclusive — we can't check
-  // content, but there's no regression to report. External visitors
-  // are unaffected (their requests don't self-fetch).
-  if (status === 522) {
-    return { ok: true, skipped: true, reason: 'skipped: Worker self-fetch 522 (inconclusive)' };
+  // Cloudflare "couldn't reach origin"-class 5xx (520/522/523/524) is
+  // treated as inconclusive — see INCONCLUSIVE_CF_5XX above for the
+  // full rationale. 522 is the classic self-fetch loop; 523 fired the
+  // 2026-05-17 false-positive alert that prompted broadening the skip
+  // set. External visitors are unaffected (their requests don't
+  // self-fetch).
+  if (INCONCLUSIVE_CF_5XX.has(status)) {
+    return { ok: true, skipped: true, reason: `skipped: Cloudflare ${status} (inconclusive)` };
   }
   if (status !== 200) {
     return { ok: false, reason: `non-200 status: ${status}` };
@@ -304,10 +318,10 @@ async function checkNoMissingMessage(appUrl) {
 async function checkEnLocale({ name, url, anyEnMarker, forbidElMarkers }) {
   try {
     const res = await fetchUrl(url);
-    // 522 = Worker self-fetch loop during SSR (see evaluateBody comment).
+    // CF "couldn't reach origin"-class 5xx (see INCONCLUSIVE_CF_5XX).
     // Inconclusive — can't check markers, but not a regression.
-    if (res.status === 522) {
-      return { name, ok: true, skipped: true, reason: 'skipped: Worker self-fetch 522' };
+    if (INCONCLUSIVE_CF_5XX.has(res.status)) {
+      return { name, ok: true, skipped: true, reason: `skipped: Cloudflare ${res.status}` };
     }
     if (res.status !== 200) {
       return { name, ok: false, reason: `expected 200, got ${res.status} from ${url}` };


### PR DESCRIPTION
## Summary

- The synthetic uptime check emailed a false-positive alert at 16:00 today (`en-listing-locale: non-200 status: 523`) for what was a transient Cloudflare-edge hiccup. The listing URL was healthy 200 within the same minute, and no follow-up alerts fired.
- HTTP 523 ("Origin Is Unreachable") is the same Cloudflare "couldn't reach origin"-class as 522, which the route already treats as `{ ok: true, skipped: true, reason: "inconclusive" }`. 520 and 524 are in the same class. This PR broadens the skip set to `{520, 522, 523, 524}`.
- 521 (web server down) and generic 500 still alert — tests pin the boundary so the suppression doesn't drift into "swallow all 5xx".
- Refreshed the runbook's "Fetch strategy" section, which had gone stale describing the CDN-via-global-fetch path abandoned in PR #133.

## Test plan

- [x] `npm run test -- __tests__/api/syntheticEnListing.test.js` — 20/20 (6 new boundary cases).
- [x] `npm run test` — 141/141.
- [x] `npm run lint` — clean (only pre-existing unrelated warning).
- [x] Probed `/property/thessaloniki/listing/0100006` on both `studentx.uk` and the `workers.dev` URL: both 200, healthy.
- [x] Unauthenticated `POST /api/cron/synthetic-en-listing` on prod → 401 in 277ms (route alive).
- [ ] After deploy, the next `*/15` cron tick will exercise the new code naturally. Future 523s should surface in the run record as `{ skipped: true, reason: "skipped: Cloudflare 523" }` instead of firing an alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)