### PR TITLE
fix(ui): unify page canvases to a single white base

### DIFF
--- a/src/app/[locale]/about/page.js
+++ b/src/app/[locale]/about/page.js
@@ -86,8 +86,6 @@ function Body({ children, style }) {
 
 function AboutContent() {
   return (
-    <>
-      <style>{`body { background: #fff8f0 !important; }`}</style>
     <div>
       {/* Back link */}
       <div style={{ maxWidth: 680, margin: '0 auto', padding: '32px 24px 0' }}>
@@ -157,6 +155,5 @@ function AboutContent() {
         © {new Date().getFullYear()} StudentX
       </div>
     </div>
-    </>
   );
 }

--- a/src/app/[locale]/page.js
+++ b/src/app/[locale]/page.js
@@ -19,6 +19,7 @@ export default async function HomePage({ params }) {
       <HomeHero />
 
       <section
+        className="bg-stone"
         style={{
           minHeight: '100dvh',
           display: 'flex',
@@ -27,7 +28,6 @@ export default async function HomePage({ params }) {
           justifyContent: 'center',
           padding: '64px 24px',
           gap: 28,
-          background: '#ffffff',
         }}
       >
         <div style={{ textAlign: 'center', maxWidth: 520 }}>

--- a/src/app/[locale]/property/[city]/landlord/onboarding/page.js
+++ b/src/app/[locale]/property/[city]/landlord/onboarding/page.js
@@ -129,7 +129,7 @@ export default function LandlordOnboardingPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center px-4 py-12">
+    <div className="min-h-screen bg-stone flex flex-col items-center justify-center px-4 py-12">
       <h1 className="font-heading text-3xl font-bold text-navy mb-2 text-center">
         Choose your plan
       </h1>


### PR DESCRIPTION
## Summary

Unifies every page's full-bleed canvas to a single **white** base (`stone` = `#ffffff`, already set on `<body>` in `src/app/[locale]/layout.js`). This PR removes the page-level background **inconsistencies** so all pages inherit that white canvas — without touching any bounded element/accent (cards, skeleton loaders, badges, banners, chips, buttons, inputs, navbar pill, modal scrims, the dark landlord sidebar).

### What changed
- **`/about`** (`src/app/[locale]/about/page.js`) — removed the injected `<style>{`body { background: #fff8f0 !important; }`}</style>` cream override (and its wrapping fragment). The page now inherits the white body. All other inline styles left untouched.
- **Landlord onboarding** (`src/app/[locale]/property/[city]/landlord/onboarding/page.js`) — changed the page-level `bg-gray-50` wrapper to `bg-stone`. The `bg-gray-light` skeleton placeholder boxes are bounded elements and were left as-is.
- **Homepage** (`src/app/[locale]/page.js`) — cosmetic normalization of the buttons section's inline `background:'#ffffff'` to the `bg-stone` class for consistency (no visual change).

### Preserved (intentionally not touched)
- The animated `<StripeGradientMesh />` hero backgrounds in `src/app/[locale]/property/[city]/landlord/charter/page.js` and `src/components/property/ThessalonikiLanding.js`.
- All card/element accents: `bg-parchment` image placeholders, modal/drawer scrims (`bg-night/60`, `bg-navy/40`), the dark `bg-night` landlord sidebar (`LandlordShell.js`), the violet `#f6f4ff` `GlobeLoader` splash overlay, and inline element backgrounds in `HubButton`/`HubDiagram`.

### Audit
Searched all of `src/app/**` and top-level section wrappers in `src/components/**` for inline `background`/`backgroundColor` and non-white `bg-*` classes on page/section canvas wrappers. The only page-level canvas deviations were the two known outliers above; everything else flagged was a bounded element or an intentional hero/loader accent and was left in place.

## Files changed
- `src/app/[locale]/about/page.js`
- `src/app/[locale]/page.js`
- `src/app/[locale]/property/[city]/landlord/onboarding/page.js`

## Test plan
- [x] `npm run lint` passes (0 errors; the one pre-existing `cf/worker-entry.mjs` anonymous-default-export warning is unrelated)
- [x] `npm run build` compiles successfully
- [ ] Visual spot-check: `/about`, `/property/thessaloniki/landlord/onboarding`, and `/` all render on a white canvas; gradient-mesh heroes and card/element accents still contrast correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)