### PR TITLE
feat(landlord): streamline inbox cards to a single Open chat action

### DIFF
--- a/src/app/[locale]/property/[city]/landlord/inquiries/page.js
+++ b/src/app/[locale]/property/[city]/landlord/inquiries/page.js
@@ -6,7 +6,6 @@ import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 
 import LandlordShell from '@/components/landlord/LandlordShell';
 import Card from '@/components/ui/Card';
-import Button from '@/components/ui/Button';
 import Pill from '@/components/ui/Pill';
 import Icon from '@/components/ui/Icon';
 import { Link } from '@/i18n/navigation';
@@ -22,8 +21,6 @@ export default function LandlordInquiriesPage() {
   const [inquiries, setInquiries] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-  const [updating, setUpdating] = useState(null);
-  const [token, setToken] = useState('');
 
   const fetchInquiries = useCallback(async (accessToken) => {
     try {
@@ -47,42 +44,10 @@ export default function LandlordInquiriesPage() {
       const supabase = getSupabaseBrowser();
       const { data: { session } } = await supabase.auth.getSession();
       if (!session) return;
-      setToken(session.access_token);
       await fetchInquiries(session.access_token);
       setLoading(false);
     })();
   }, [fetchInquiries]);
-
-  async function handleStatusChange(inquiryId, newStatus) {
-    setUpdating(inquiryId);
-    try {
-      const res = await fetch(`/api/landlord/inquiries/${inquiryId}`, {
-        method: 'PATCH',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ status: newStatus }),
-      });
-      if (!res.ok) {
-        const { error: e } = await res.json();
-        alert(e || t('updateError'));
-        return;
-      }
-      const { inquiry: updated } = await res.json();
-      setInquiries((prev) =>
-        prev.map((inq) =>
-          inq.inquiry_id === inquiryId
-            ? { ...inq, status: updated.status, replied_at: updated.replied_at }
-            : inq
-        )
-      );
-    } catch {
-      alert(t('updateError'));
-    } finally {
-      setUpdating(null);
-    }
-  }
 
   return (
     <LandlordShell eyebrow="Inbox" title={t('title')}>
@@ -111,8 +76,6 @@ export default function LandlordInquiriesPage() {
             <InquiryCard
               key={inq.inquiry_id}
               inquiry={inq}
-              updating={updating === inq.inquiry_id}
-              onStatusChange={handleStatusChange}
               t={t}
             />
           ))}
@@ -128,7 +91,7 @@ function statusVariant(status) {
   return 'amenity';
 }
 
-function InquiryCard({ inquiry, updating, onStatusChange, t }) {
+function InquiryCard({ inquiry, t }) {
   const address = inquiry.listings?.location?.address || `#${inquiry.listing_id}`;
 
   return (
@@ -143,15 +106,11 @@ function InquiryCard({ inquiry, updating, onStatusChange, t }) {
               {t(`status_${inquiry.status}`)}
             </Pill>
           </div>
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-night/60">
-            <a
-              href={`mailto:${inquiry.student_email}`}
-              className="hover:text-blue transition-colors"
-            >
-              {inquiry.student_email}
-            </a>
-            {inquiry.student_phone && <span>{inquiry.student_phone}</span>}
-          </div>
+          {inquiry.student_phone && (
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-night/60">
+              <span>{inquiry.student_phone}</span>
+            </div>
+          )}
         </div>
         <div className="text-right text-xs text-night/50 shrink-0">
           <p className="label-caps">{formatDate(inquiry.created_at)}</p>
@@ -171,36 +130,6 @@ function InquiryCard({ inquiry, updating, onStatusChange, t }) {
           <Icon name="message" className="w-3.5 h-3.5" />
           {t('openChat')}
         </Link>
-        {inquiry.status === 'pending' && (
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={updating}
-            onClick={() => onStatusChange(inquiry.inquiry_id, 'replied')}
-          >
-            {updating ? '…' : t('markReplied')}
-          </Button>
-        )}
-        {inquiry.status !== 'closed' && (
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={updating}
-            onClick={() => onStatusChange(inquiry.inquiry_id, 'closed')}
-          >
-            {updating ? '…' : t('markClosed')}
-          </Button>
-        )}
-        {inquiry.status === 'closed' && (
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={updating}
-            onClick={() => onStatusChange(inquiry.inquiry_id, 'pending')}
-          >
-            {updating ? '…' : t('reopen')}
-          </Button>
-        )}
       </div>
     </Card>
   );

--- a/src/app/[locale]/student/account/page.js
+++ b/src/app/[locale]/student/account/page.js
@@ -173,8 +173,9 @@ async function InquiriesSection({ locale }) {
                         <span className="text-xs text-night/50">/mo</span>
                       </p>
                     )}
-                    <span className="mt-3 inline-flex items-center label-caps text-blue group-hover:text-night">
-                      {t('openThread')} →
+                    <span className="mt-3 inline-flex items-center justify-center gap-1 bg-blue text-white text-xs font-sans font-semibold uppercase tracking-[0.08em] px-3 py-1.5 rounded group-hover:bg-night transition-colors">
+                      <Icon name="message" className="w-3.5 h-3.5" />
+                      {t('openThread')}
                     </span>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
Simplifies the landlord inbox (inquiry cards) per design feedback:
- **Removes the student email** line.
- **Removes the Mark-as-replied / Close / Reopen** buttons.
- Leaves the **filled "Open chat"** as the sole action.

## Details
- `landlord/inquiries/page.js`: drops the `mailto` email line (phone, if present, still shows), and the three status `<Button>`s. Also removes the now-orphaned `handleStatusChange` handler and its `updating`/`token` state, plus the unused `Button` import.
- The status Pill (New / Replied / Closed) still shows.

## Reviewer note
This also removes the **ability to mark an inquiry replied/closed from this screen** (not just the buttons). If we want to keep that capability in another form, that's a follow-up. The status field itself and its API are untouched.

## Verification
- `npm run lint` passes.
- The inbox is landlord-auth-gated, so I verified the new card layout via a temporary sample-render route (deleted before commit) — screenshot shared with the author for sign-off.

## Test plan
- [ ] Landlord → Inbox: each inquiry shows name + status pill, date, address, message, and a single filled **Open chat** button. No email, no status buttons.
- [ ] Open chat still routes to the inquiry thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)