### PR TITLE
fix(navbar): render sign-in dropdown immediately, not after auth resolves

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -131,15 +131,12 @@ const PILL_CLASS =
   'fixed top-5 right-5 z-50 flex items-center gap-3 bg-stone/80 backdrop-blur-sm rounded-full px-4 py-2 shadow-sm';
 
 function AuthMenu({ t, authState, accountHref, inquiriesHref, landlordLoginHref, unreadCount, onSignOut }) {
-  if (!authState.ready) {
-    return (
-      <nav className={PILL_CLASS}>
-        <span className="label-caps text-night/30">{t('signIn')}</span>
-      </nav>
-    );
-  }
-
-  if (authState.role) {
+  // Signed-in chrome (account + sign out) renders only once a role is
+  // CONFIRMED. While auth is still resolving — or for anonymous visitors —
+  // fall through to the interactive SignInDropdown immediately. The sign-in
+  // entry point must never be gated behind the getSession() round-trip, which
+  // can hang ~15s and otherwise leaves a dead, non-clickable "Sign in" pill.
+  if (authState.ready && authState.role) {
     return (
       <nav className={PILL_CLASS}>
         <UnreadBadge count={unreadCount} href={inquiriesHref} />


### PR DESCRIPTION
## The bug
The navbar "Sign in" pill was **dead/un-clickable on load** — clicking it did nothing.

## Root cause
`AuthMenu` gated the entire sign-in UI behind `authState.ready`. While `false`, it rendered an **inert, non-clickable `<span>`** ("Sign in"), not the dropdown button. `authState.ready` only flips to `true` after `supabase.auth.getSession()` resolves — and that call can hang up to the **15s ceiling** in [`withTimeout`](src/lib/withTimeout.js) (stale token / slow network / cold start). So the sign-in entry point sat dead for up to 15s, then the real dropdown appeared.

## Fix
Render the interactive `SignInDropdown` **by default** — for anonymous visitors *and* while auth is still resolving — and swap to the account / sign-out chrome only once a role is **confirmed** (`authState.ready && authState.role`). The sign-in entry point is no longer gated behind a network round-trip.

## Trade-off
A logged-in user may briefly see "Sign in" before auth resolves, then it swaps to "My account / Sign out". Acceptable — far better than a 15s dead pill for the (majority) anonymous homepage visitors.

## Verification
- Lint green. The dropdown trigger now renders on first paint (no inert placeholder) — confirmed in preview.
- Click-to-open is the unchanged, merged #184 dropdown; best verified on the Cloudflare branch preview (the headless dev preview doesn't fully hydrate the client app).

## Test plan
- [ ] Homepage, signed out → "Sign in" pill is immediately clickable → opens *Student* / *Landlord* options.
- [ ] Signed in → resolves to "My account / Sign out".

🤖 Generated with [Claude Code](https://claude.com/claude-code)