### PR TITLE
feat(student): match landlord inbox card layout in My inquiries

### DIFF
--- a/src/app/[locale]/student/account/page.js
+++ b/src/app/[locale]/student/account/page.js
@@ -131,56 +131,55 @@ async function InquiriesSection({ locale }) {
 
         return (
           <li key={inq.inquiry_id}>
-            <Link
-              href={`/student/inquiries/${inq.inquiry_id}`}
-              className="block group"
-            >
-              <Card
-                tone="white"
-                className="p-5 md:p-6 hover:border-blue transition-colors"
-              >
-                <div className="flex items-start justify-between gap-4">
-                  <div className="min-w-0 flex-1">
-                    <div className="flex flex-wrap items-center gap-2 mb-1">
-                      <p className="font-display text-xl text-night truncate">{address}</p>
-                      {unread > 0 && (
-                        <span
-                          aria-label={t('unread', { count: unread })}
-                          className="inline-flex items-center justify-center min-w-5 h-5 rounded-full bg-yellow text-white text-[11px] font-sans font-semibold px-1.5"
-                        >
-                          {unread}
-                        </span>
-                      )}
-                    </div>
-                    {neighborhood && (
-                      <p className="label-caps text-night/50">{neighborhood}</p>
+            <Card tone="white" className="p-5 md:p-6">
+              <div className="flex items-start justify-between gap-4 mb-4">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2 mb-1">
+                    <p className="font-display text-xl text-night truncate">{address}</p>
+                    {unread > 0 && (
+                      <span
+                        aria-label={t('unread', { count: unread })}
+                        className="inline-flex items-center justify-center min-w-5 h-5 rounded-full bg-yellow text-white text-[11px] font-sans font-semibold px-1.5"
+                      >
+                        {unread}
+                      </span>
                     )}
-                    {inq.message && (
-                      <p className="mt-3 text-sm text-night/70 line-clamp-2">
-                        {inq.message}
-                      </p>
-                    )}
-                    <p className="mt-3 label-caps text-night/40">
-                      {lastWhen
-                        ? t('lastMessageAt', { when: lastWhen })
-                        : t('lastMessageNever')}
-                    </p>
                   </div>
-                  <div className="text-right shrink-0">
-                    {price != null && (
-                      <p className="font-display text-xl text-blue">
-                        €{price}
-                        <span className="text-xs text-night/50">/mo</span>
-                      </p>
-                    )}
-                    <span className="mt-3 inline-flex items-center justify-center gap-1 bg-blue text-white text-xs font-sans font-semibold uppercase tracking-[0.08em] px-3 py-1.5 rounded group-hover:bg-night transition-colors">
-                      <Icon name="message" className="w-3.5 h-3.5" />
-                      {t('openThread')}
-                    </span>
-                  </div>
+                  {neighborhood && (
+                    <p className="label-caps text-night/50">{neighborhood}</p>
+                  )}
                 </div>
-              </Card>
-            </Link>
+                <div className="text-right shrink-0">
+                  {price != null && (
+                    <p className="font-display text-xl text-blue">
+                      €{price}
+                      <span className="text-xs text-night/50">/mo</span>
+                    </p>
+                  )}
+                  <p className="mt-1 label-caps text-night/40">
+                    {lastWhen
+                      ? t('lastMessageAt', { when: lastWhen })
+                      : t('lastMessageNever')}
+                  </p>
+                </div>
+              </div>
+
+              {inq.message && (
+                <blockquote className="bg-parchment rounded-sm px-5 py-4 text-night/80 leading-relaxed mb-4 font-sans text-sm md:text-base">
+                  {inq.message}
+                </blockquote>
+              )}
+
+              <div className="flex flex-wrap items-center gap-2">
+                <Link
+                  href={`/student/inquiries/${inq.inquiry_id}`}
+                  className="inline-flex items-center justify-center gap-1 bg-blue text-white text-xs font-sans font-semibold uppercase tracking-[0.08em] px-3 py-1.5 rounded hover:bg-night transition-colors"
+                >
+                  <Icon name="message" className="w-3.5 h-3.5" />
+                  {t('openThread')}
+                </Link>
+              </div>
+            </Card>
           </li>
         );
       })}


### PR DESCRIPTION
## Summary
Restructures the student **"My inquiries"** card to mirror the merged landlord inbox card (#187), so a student and a landlord see the **same message view**.

## What changed (student card)
- **Message** now sits in a **parchment blockquote** (was plain inline, line-clamped text).
- **"Open chat"** moved to its **own bottom action row** (was top-right beside the price).
- **Price + last-message date** grouped top-right; **only the button navigates** now (the whole card was previously one big `<Link>`).

Same blockquote + button classes as the landlord `InquiryCard`, so they're visually identical in structure.

## Verification
- Lint green.
- Visual check needs a student login — best confirmed on the branch preview signed in as a student (the sign-in fix from #190 is now on main, so logging in works).

## Test plan
- [ ] `/student/account` signed in → message in a parchment box, "Open chat" button in a row beneath it — matching the landlord inbox card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)