### PR TITLE
fix(auth): match orphan landlords by email in wrong-role probe (#148)

### DIFF
--- a/__tests__/lib/requireStudent.test.js
+++ b/__tests__/lib/requireStudent.test.js
@@ -36,18 +36,32 @@ beforeEach(() => {
   vi.mocked(supabaseServer.getSupabaseWithToken).mockReset();
 });
 
-// Build a fake token-scoped supabase client whose chained
-// `.from(table).select().eq().maybeSingle()` returns the table-keyed
-// fixture. Used by both requireStudent and requireLandlord tests.
+// Build a fake token-scoped supabase client. Supports both the
+// `.select().eq().maybeSingle()` chain and the orphan-landlord email probe's
+// `.select().ilike().limit().maybeSingle()` chain.
+//
+// A table fixture is either a row object (returned for any lookup) or a
+// `{ byAuth, byEmail }` split so a test can make the auth_user_id lookup miss
+// while the email lookup hits (the orphan-landlord case).
 function buildFakeSupabase(fixtures) {
   return {
-    from: (table) => ({
-      select: () => ({
-        eq: () => ({
-          maybeSingle: async () => ({ data: fixtures[table] ?? null, error: null }),
-        }),
-      }),
-    }),
+    from: (table) => {
+      const entry = table in fixtures ? fixtures[table] : null;
+      let mode = 'auth';
+      const builder = {
+        select: () => builder,
+        eq: () => ((mode = 'auth'), builder),
+        ilike: () => ((mode = 'email'), builder),
+        limit: () => builder,
+        maybeSingle: async () => {
+          const split =
+            entry && typeof entry === 'object' && ('byAuth' in entry || 'byEmail' in entry);
+          const data = split ? (mode === 'email' ? entry.byEmail ?? null : entry.byAuth ?? null) : entry;
+          return { data, error: null };
+        },
+      };
+      return builder;
+    },
   };
 }
 
@@ -122,6 +136,30 @@ describe('requireStudent wrong-role shape', () => {
       kind: 'wrong-role',
       conflict_role: 'landlord',
       email: 'duo@example.com',
+    });
+  });
+
+  it('returns wrong-role with conflict_role=landlord for an orphan landlord matched by email', async () => {
+    cookieHeader = 'sb-access-token=jwt';
+    tokenValue = 'jwt';
+    vi.mocked(supabaseServer.getUserFromToken).mockResolvedValue({
+      id: 'auth-user-orphan',
+      email: 'orphan-landlord@example.com',
+    });
+    vi.mocked(supabaseServer.getSupabaseWithToken).mockReturnValue(
+      buildFakeSupabase({
+        students: null,
+        // auth_user_id lookup misses (orphan row has NULL auth_user_id); the
+        // email lookup is the one that finds it.
+        landlords: { byAuth: null, byEmail: { email: 'orphan-landlord@example.com' } },
+      })
+    );
+
+    const auth = await requireStudent();
+    expect(auth).toEqual({
+      kind: 'wrong-role',
+      conflict_role: 'landlord',
+      email: 'orphan-landlord@example.com',
     });
   });
 

--- a/src/lib/requireStudent.js
+++ b/src/lib/requireStudent.js
@@ -17,6 +17,35 @@ export async function hasAuthCookie() {
   return cookieHeader.includes(`${SB_ACCESS_TOKEN_COOKIE}=`);
 }
 
+// Escape ILIKE wildcards so an email matches literally — a `_` or `%` in an
+// address must not act as a wildcard.
+function escapeLikePattern(value) {
+  return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+// Resolve the landlord row that conflicts with the current auth user, for the
+// wrong-role banner. Match by auth_user_id first, then by email: orphan
+// landlord rows (auth_user_id NULL, from pre-linked / seeded data) only match
+// by email, mirroring the prevent_dual_role trigger which keys on
+// lower(email). landlords is public-read (migration 006), so the email probe
+// is not RLS-filtered. Extra round-trip only on the unhappy path.
+async function findConflictingLandlord(supabase, user) {
+  const byId = await supabase
+    .from('landlords')
+    .select('email')
+    .eq('auth_user_id', user.id)
+    .maybeSingle();
+  if (byId.data) return byId.data;
+  if (!user.email) return null;
+  const byEmail = await supabase
+    .from('landlords')
+    .select('email')
+    .ilike('email', escapeLikePattern(user.email))
+    .limit(1)
+    .maybeSingle();
+  return byEmail.data ?? null;
+}
+
 /**
  * Server-side helper that resolves the current student account from
  * the sb-access-token cookie set by SessionSync. Returns one of:
@@ -58,14 +87,9 @@ export const requireStudent = cache(async function requireStudent() {
     .maybeSingle();
 
   if (error || !student) {
-    // Wrong-role: probe the landlords table so the redirect can carry
-    // the conflict context. One extra round-trip only on the unhappy
-    // path; the cache wrapper still amortises across layout + page.
-    const { data: landlord } = await supabase
-      .from('landlords')
-      .select('email')
-      .eq('auth_user_id', user.id)
-      .maybeSingle();
+    // Wrong-role: probe landlords so the redirect can carry the conflict
+    // context. The cache wrapper amortises this across layout + page.
+    const landlord = await findConflictingLandlord(supabase, user);
     return {
       kind: 'wrong-role',
       conflict_role: landlord ? 'landlord' : null,
@@ -104,6 +128,10 @@ export const requireLandlord = cache(async function requireLandlord() {
     .maybeSingle();
 
   if (error || !landlord) {
+    // No email fallback here (unlike requireStudent → landlords): students
+    // .auth_user_id is NOT NULL (migration 026), so orphan student rows
+    // can't exist, and students are not public-read — a cross-user email
+    // probe would be RLS-filtered anyway. The auth_user_id match is enough.
     const { data: student } = await supabase
       .from('students')
       .select('email')


### PR DESCRIPTION
## Summary
`requireStudent`'s wrong-role probe matched landlords only by `auth_user_id`. An **orphan landlord** row (`auth_user_id = NULL`, from pre-linked/seeded data) whose email matches the signed-in student therefore produced `conflict_role: null` — the login page rendered with no banner and the user fell back into a silent bounce loop (the exact failure mode in #148, landlord_id=0103).

This adds an email fallback to the probe, mirroring the `prevent_dual_role` trigger (036/051) which keys on `lower(email)`.

## Why it's safe under RLS
`landlords` is **public-read** (`USING (true)`, migration 006), so the email probe is not RLS-filtered from the token-scoped client. The email is matched case-insensitively via `ILIKE`, with `%`/`_`/`\` escaped so an address is matched literally.

## Deliberate asymmetry — `requireLandlord` is *not* mirrored
The issue suggested mirroring the fix into `requireLandlord`'s student probe, but that would be dead code:
- `students.auth_user_id` is `UNIQUE NOT NULL` (migration 026) → **orphan students are schema-impossible**, so the `auth_user_id` match already catches every conflict.
- `students` is **not** public-read (`"Students read own row" USING (auth_user_id = auth.uid())`) → a cross-user email probe would be RLS-blocked regardless.

A code comment documents this so it doesn't read as an oversight.

## Out of scope (noted in #148)
The "switch to landlord login" CTA still dead-ends for a *true* orphan landlord (no auth linkage) — the right destination is the `link_orphan_landlord` signup flow. That needs a third banner variant and is left for a follow-up.

## Test plan
- [x] New unit test: orphan landlord matched by email → `conflict_role: 'landlord'`
- [x] Existing wrong-role tests still pass (linked landlord, true orphan/no rows)
- [x] `npm run test` → 142 passing · `npm run lint` clean
- [ ] Live: with an orphan landlord row whose email matches the signed-in auth user, `/student/account` should redirect to `/student/login?roleConflict=landlord&email=…` and render the banner (needs prod-like data; not verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)