### PR TITLE
fix(auth): surface failed session-sync on student login (#141)

### DIFF
--- a/src/app/[locale]/student/login/page.js
+++ b/src/app/[locale]/student/login/page.js
@@ -78,13 +78,21 @@ function StudentLoginInner() {
           // Sync cookie eagerly so the next navigation's RSC sees auth without
           // waiting for SessionSync's onAuthStateChange to fire.
           if (data.session?.access_token) {
-            await withTimeout(
+            const sessionRes = await withTimeout(
               fetch('/api/auth/session', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ access_token: data.session.access_token }),
               }),
             );
+            // If the cookie sync returns non-2xx (401 bad token, 500, …), the
+            // destination RSC sees a guest and bounces straight back to login —
+            // which reads to the user as "my correct password didn't work".
+            // Surface it instead of navigating into a silent loop.
+            if (!sessionRes.ok) {
+              setError(t('sessionError'));
+              return;
+            }
 
             // Idempotent profile probe — ensures a students row exists
             // even if the signup trigger was skipped (e.g. pre-seeded

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -718,6 +718,7 @@
       "submitting": "Signing in…",
       "submittingAuth": "Signing you in…",
       "submittingRedirect": "Loading your account…",
+      "sessionError": "We signed you in, but couldn't start your session. Please try again.",
       "or": "or",
       "noAccount": "Don't have an account?",
       "signupLink": "Create one",


### PR DESCRIPTION
## Summary
On the student login page, the cookie-sync `POST /api/auth/session` that runs after a successful `signInWithPassword` was fire-and-forget — its response status was never checked. A non-2xx response (401 invalid token, 500, etc.) still fell through to `router.push('/student/account')`, where the destination RSC sees no cookie, `requireStudent()` returns null, and the user is bounced back to login. To the user this looks like "I typed the right password but it didn't work."

This checks `sessionRes.ok` and surfaces a clear error (new `student.login.sessionError` message) instead of navigating into a silent bounce loop.

## Scope note
The issue describes "both student and landlord login pages", but the landlord page no longer does this POST — it was refactored to probe `/api/auth/me` for the role check, and proceeds-on-probe-failure is intentional and documented there. So the unchecked-session-POST swallow only exists on the student page now.

## Test plan
- [x] `npm run test` → 141 passing · `npm run lint` clean · `en.json` valid
- [ ] **Not browser-verified**: the failure path needs a contrived non-2xx from `/api/auth/session` (e.g. an expired token mid-flow). The golden path (successful login) is unchanged. Worth a manual check by forcing the endpoint to 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)