### PR TITLE
refactor(auth): centralize sign-out in signOutSafely helper (#144, #145)

### DIFF
--- a/__tests__/lib/withTimeout.test.js
+++ b/__tests__/lib/withTimeout.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { withTimeout } from '@/lib/withTimeout';
+import { signOutSafely } from '@/lib/authHelpers';
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('withTimeout', () => {
+  it('resolves with the underlying value when it settles in time', async () => {
+    vi.useFakeTimers();
+    await expect(withTimeout(Promise.resolve('ok'), 1000)).resolves.toBe('ok');
+  });
+
+  it('propagates the underlying rejection when it settles in time', async () => {
+    vi.useFakeTimers();
+    await expect(withTimeout(Promise.reject(new Error('boom')), 1000)).rejects.toThrow('boom');
+  });
+
+  it('rejects after the timeout when the promise never settles', async () => {
+    vi.useFakeTimers();
+    const assertion = expect(withTimeout(new Promise(() => {}), 5000)).rejects.toThrow(/timed out/i);
+    await vi.advanceTimersByTimeAsync(5000);
+    await assertion;
+  });
+});
+
+describe('signOutSafely', () => {
+  it('calls supabase.auth.signOut()', async () => {
+    const signOut = vi.fn().mockResolvedValue({ error: null });
+    await signOutSafely({ auth: { signOut } });
+    expect(signOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a rejected signOut instead of throwing', async () => {
+    const signOut = vi.fn().mockRejectedValue(new Error('network down'));
+    await expect(signOutSafely({ auth: { signOut } })).resolves.toBeUndefined();
+  });
+
+  it('resolves (does not hang) when signOut never settles', async () => {
+    vi.useFakeTimers();
+    const signOut = vi.fn(() => new Promise(() => {}));
+    const result = signOutSafely({ auth: { signOut } }, { timeoutMs: 5000 });
+    await vi.advanceTimersByTimeAsync(5000);
+    await expect(result).resolves.toBeUndefined();
+  });
+});

--- a/src/app/[locale]/property/[city]/landlord/login/page.js
+++ b/src/app/[locale]/property/[city]/landlord/login/page.js
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import { useRouter, Link } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 import { withTimeout } from '@/lib/withTimeout';
+import { signOutSafely } from '@/lib/authHelpers';
 import { useTranslations } from 'next-intl';
 
 import AuthShell from '@/components/landlord/AuthShell';
@@ -56,7 +57,7 @@ function LandlordLoginInner() {
       // the hung-refresh scenario can only happen when there IS one.
       const { data: { session: existing } } = await supabase.auth.getSession();
       if (existing) {
-        await withTimeout(supabase.auth.signOut(), 5000).catch(() => {});
+        await signOutSafely(supabase);
       }
 
       let lastErr;
@@ -93,7 +94,7 @@ function LandlordLoginInner() {
           }
 
           if (role === 'student') {
-            await supabase.auth.signOut().catch(() => {});
+            await signOutSafely(supabase);
             setStudentConflict(true);
             return;
           }

--- a/src/app/[locale]/property/[city]/landlord/signup/page.js
+++ b/src/app/[locale]/property/[city]/landlord/signup/page.js
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter, Link } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 import { withTimeout } from '@/lib/withTimeout';
+import { signOutSafely } from '@/lib/authHelpers';
 import { useLocale, useTranslations } from 'next-intl';
 
 import AuthShell from '@/components/landlord/AuthShell';
@@ -62,7 +63,7 @@ export default function LandlordSignupPage() {
           }),
         );
         if (!res.ok) {
-          await supabase.auth.signOut();
+          await signOutSafely(supabase);
           const body = await res.json().catch(() => ({}));
           if (res.status === 409 && body?.error === 'role_conflict') {
             setError(t('roleConflict'));

--- a/src/app/[locale]/student/login/page.js
+++ b/src/app/[locale]/student/login/page.js
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import { useRouter, Link } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 import { withTimeout } from '@/lib/withTimeout';
+import { signOutSafely } from '@/lib/authHelpers';
 import { useTranslations } from 'next-intl';
 
 import AuthShell from '@/components/landlord/AuthShell';
@@ -59,7 +60,7 @@ function StudentLoginInner() {
       // the hung-refresh scenario can only happen when there IS one.
       const { data: { session: existing } } = await supabase.auth.getSession();
       if (existing) {
-        await withTimeout(supabase.auth.signOut(), 5000).catch(() => {});
+        await signOutSafely(supabase);
       }
 
       let lastErr;

--- a/src/app/[locale]/student/signup/page.js
+++ b/src/app/[locale]/student/signup/page.js
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter, Link } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 import { withTimeout } from '@/lib/withTimeout';
+import { signOutSafely } from '@/lib/authHelpers';
 import { useLocale, useTranslations } from 'next-intl';
 
 import AuthShell from '@/components/landlord/AuthShell';
@@ -80,7 +81,7 @@ export default function StudentSignupPage() {
           }),
         );
         if (!res.ok) {
-          await supabase.auth.signOut();
+          await signOutSafely(supabase);
           const body = await res.json().catch(() => ({}));
           if (res.status === 409 && body?.error === 'role_conflict') {
             setError(t('roleConflict'));

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import { Link, useRouter, usePathname } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 import { withTimeout } from '@/lib/withTimeout';
+import { signOutSafely } from '@/lib/authHelpers';
 import UnreadBadge from './UnreadBadge';
 import TabTitleFlash from './TabTitleFlash';
 import { DEFAULT_CITY } from '@/lib/cityRoutes';
@@ -97,7 +98,7 @@ export default function Navbar() {
 
   async function handleSignOut() {
     const supabase = getSupabaseBrowser();
-    await supabase.auth.signOut();
+    await signOutSafely(supabase);
     router.push('/');
   }
 

--- a/src/components/landlord/LandlordShell.js
+++ b/src/components/landlord/LandlordShell.js
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { usePathname } from 'next/navigation';
 import { useRouter, Link } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { signOutSafely } from '@/lib/authHelpers';
 
 import Icon from '@/components/ui/Icon';
 import BauhausLoader from '@/components/BauhausLoader';
@@ -70,7 +71,7 @@ export default function LandlordShell({ title, eyebrow, actions, children }) {
 
   async function handleSignOut() {
     const supabase = getSupabaseBrowser();
-    await supabase.auth.signOut();
+    await signOutSafely(supabase);
     router.push('/property/thessaloniki/landlord/login');
   }
 

--- a/src/components/student/SignOutButton.js
+++ b/src/components/student/SignOutButton.js
@@ -3,6 +3,7 @@
 import { useTranslations } from 'next-intl';
 import { useRouter } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { signOutSafely } from '@/lib/authHelpers';
 
 import Icon from '@/components/ui/Icon';
 
@@ -12,7 +13,7 @@ export default function SignOutButton() {
 
   async function handleSignOut() {
     const supabase = getSupabaseBrowser();
-    await supabase.auth.signOut();
+    await signOutSafely(supabase);
     router.push('/');
   }
 

--- a/src/lib/authHelpers.js
+++ b/src/lib/authHelpers.js
@@ -1,0 +1,13 @@
+import { withTimeout } from '@/lib/withTimeout';
+
+/**
+ * Sign out without ever blocking the UI. A hung supabase.auth.signOut() (e.g.
+ * a stuck token refresh on the same HTTP/2 connection, or a dropped mobile
+ * network) is bounded by withTimeout and the rejection is swallowed — sign-out
+ * is always best-effort, and callers should proceed (navigate away) regardless
+ * of the outcome. Centralised so call sites can't drift back to an unbounded
+ * `await supabase.auth.signOut()`.
+ */
+export async function signOutSafely(supabase, { timeoutMs = 5000 } = {}) {
+  await withTimeout(supabase.auth.signOut(), timeoutMs).catch(() => {});
+}


### PR DESCRIPTION
## Summary
Introduces `signOutSafely(supabase, { timeoutMs = 5000 })` in `src/lib/authHelpers.js` — a `withTimeout`-bounded, error-swallowing sign-out — and adopts it at **every** call site. Sign-out is always best-effort; callers should navigate away regardless of the outcome, and a hung `signOut()` (stuck token refresh, dropped mobile network) must never freeze the UI.

## What changed
- **New:** `src/lib/authHelpers.js` (`signOutSafely`)
- **New:** `__tests__/lib/withTimeout.test.js` — covers `withTimeout` resolve / reject / timeout-escape (fake timers) and `signOutSafely` call / swallow-rejection / no-hang
- **Migrated 8 call sites:**
  - `student/signup`, `landlord/signup` — were unbounded `await supabase.auth.signOut()` (**#144** — could hang on the post-failure rollback)
  - `student/login`, `landlord/login` (×2) — were the duplicated `withTimeout(...).catch(()=>{})` pattern, plus one `.catch()`-only call with no timeout
  - `SignOutButton`, `Navbar`, `LandlordShell` — were unbounded authenticated sign-outs

## Behavior notes
- The authenticated buttons (Navbar/Shell/SignOutButton) previously had **no** try/catch around `signOut()`, so a failure was an unhandled rejection and the post-sign-out `router.push` still ran. Now the failure is swallowed and navigation proceeds deterministically — strictly an improvement for sign-out.
- Login/signup pages keep their `withTimeout` import (still used for `signInWithPassword` and the profile/session fetches).

## Test plan
- [x] `npm run test` → 147 passing (+6) · `npm run lint` clean
- [ ] Not browser-verified (sign-out happy paths unchanged; hang path needs a contrived network stall)

## Note for reviewer
Touches `student/login` and `landlord/login`, which also appear in #194 (#141) — the edits are on different lines (the pre-auth `signOut` clear vs. the session-sync POST), so no textual conflict is expected, but whichever merges second may want a quick rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)