### PR TITLE
fix(ci): make applied-to-prod migration gate fail-closed (#173)

### DIFF
--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -30,6 +30,10 @@ jobs:
     # with no migration gate, so merging ahead of the migration darks
     # any route that SELECTs the new column (incident 2026-05-02, PR #85).
     # See CLAUDE.md > Database (Supabase) > Migration ordering.
+    # Fail-closed: if the gate can't verify (missing creds, empty API
+    # response), it FAILS rather than warn-and-pass (#173). Steps only run
+    # when the PR actually adds a new migration file, so non-migration PRs
+    # are unaffected.
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -67,9 +71,8 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${SUPABASE_ACCESS_TOKEN:-}" ] || [ -z "${SUPABASE_PROJECT_REF:-}" ]; then
-            echo "::warning::SUPABASE_ACCESS_TOKEN secret or SUPABASE_PROJECT_REF variable not configured — gate will warn-but-pass until they're set. See PR description for setup."
-            : > /tmp/applied-names.txt
-            exit 0
+            echo "::error::This PR adds a migration but the gate cannot verify it: the SUPABASE_ACCESS_TOKEN secret and/or SUPABASE_PROJECT_REF variable are not configured. Set both under Settings → Secrets and variables → Actions. The gate is fail-closed and will not pass an unverifiable migration. See CLAUDE.md > Database (Supabase) > Migration ordering."
+            exit 1
           fi
           # Tolerate both response shapes: bare array (REST API) or
           # { migrations: [...] } envelope (some clients/proxies).
@@ -92,8 +95,8 @@ jobs:
         run: |
           set -euo pipefail
           if [ ! -s /tmp/applied-names.txt ]; then
-            echo "::warning::No applied-migration list available — skipping enforcement (see prior step)."
-            exit 0
+            echo "::error::Could not read the list of migrations applied to prod (empty API response). Refusing to pass — the gate is fail-closed. Inspect the Supabase API response in the previous step."
+            exit 1
           fi
           missing=0
           while IFS= read -r f; do


### PR DESCRIPTION
## Summary
The `applied-to-prod` gate (PR #87) was passing PRs that add unapplied migrations. Sentinel PR #172 (adding `999_ci_gate_verification.sql`, intentionally never applied) completed green in ~7s — too fast to have called the Supabase API at all.

**Root cause:** the matching logic was fine, but two guard branches were fail-**open** (`exit 0`):
1. Missing `SUPABASE_ACCESS_TOKEN` secret / `SUPABASE_PROJECT_REF` variable → `::warning::` + pass.
2. Empty applied-migrations list → `::warning::` + pass.

The 7s runtime points squarely at (1): the credentials aren't configured, so the gate has been a no-op.

## Fix
Both branches now fail-**closed** (`exit 1`) with an actionable `::error::`. A safety gate that can't verify must not pass.

## ⚠️ Action required to make the gate green on migration PRs
This change means **migration PRs will now fail until these are set** (Settings → Secrets and variables → Actions):
- `SUPABASE_ACCESS_TOKEN` — **secret** (a Supabase personal access token)
- `SUPABASE_PROJECT_REF` — **variable** (the prod project ref)

That's the intended behavior (#173) — but heads-up that PR #170 and any future migration PR will be blocked until the credentials exist. Non-migration PRs are unaffected (the fetch/verify steps are gated on `new_files != ''`).

## Verification
- Re-ran the verify-step grep logic locally: unapplied `999_…` → `exit 1` (fail); applied `048_…` → `exit 0` (pass). ✅
- YAML edits are confined to `run:` literal blocks + one comment; indentation unchanged.
- Best validated by re-running the #172 sentinel against this branch once the secrets are set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)