### PR TITLE
fix(alerts): re-apply quiz dealbreakers in saved-search digest (#101)

### DIFF
--- a/__tests__/lib/dealbreakers.test.js
+++ b/__tests__/lib/dealbreakers.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { applyDealbreakers } from '@/lib/dealbreakers';
+
+// Minimal transformListing-shaped row; floor 2 / bills included / no amenities
+// unless overridden.
+const L = (over = {}) => ({
+  listing_id: over.listing_id ?? 'x',
+  floor: 'floor' in over ? over.floor : 2,
+  bills_included: 'bills_included' in over ? over.bills_included : true,
+  amenities: over.amenities ?? [],
+});
+
+describe('applyDealbreakers', () => {
+  it('returns the input untouched when there are no dealbreakers', () => {
+    const items = [L(), L({ floor: 0 })];
+    expect(applyDealbreakers(items, [])).toBe(items);
+    expect(applyDealbreakers(items, undefined)).toBe(items);
+  });
+
+  it('ground_floor excludes floor 0 and the "ground floor" tag, keeps null/upper floors', () => {
+    const items = [
+      L({ listing_id: 'ground', floor: 0 }),
+      L({ listing_id: 'tagged', floor: 3, amenities: ['Ground Floor'] }),
+      L({ listing_id: 'unset', floor: null }),
+      L({ listing_id: 'upper', floor: 2 }),
+    ];
+    expect(applyDealbreakers(items, ['ground_floor']).map((l) => l.listing_id)).toEqual(['unset', 'upper']);
+  });
+
+  it('bills_not_included keeps only listings with bills included', () => {
+    const items = [
+      L({ listing_id: 'incl', bills_included: true }),
+      L({ listing_id: 'excl', bills_included: false }),
+    ];
+    expect(applyDealbreakers(items, ['bills_not_included']).map((l) => l.listing_id)).toEqual(['incl']);
+  });
+
+  it('unfurnished requires the Furnished amenity (case-insensitive)', () => {
+    const items = [
+      L({ listing_id: 'furn', amenities: ['furnished', 'WiFi'] }),
+      L({ listing_id: 'bare', amenities: ['WiFi'] }),
+    ];
+    expect(applyDealbreakers(items, ['unfurnished']).map((l) => l.listing_id)).toEqual(['furn']);
+  });
+
+  it('no_ac requires the AC amenity', () => {
+    const items = [
+      L({ listing_id: 'ac', amenities: ['AC'] }),
+      L({ listing_id: 'noac', amenities: [] }),
+    ];
+    expect(applyDealbreakers(items, ['no_ac']).map((l) => l.listing_id)).toEqual(['ac']);
+  });
+
+  it('combines multiple dealbreakers with AND semantics', () => {
+    const items = [
+      L({ listing_id: 'good', floor: 2, bills_included: true, amenities: ['Furnished', 'AC'] }),
+      L({ listing_id: 'noac', floor: 2, bills_included: true, amenities: ['Furnished'] }),
+      L({ listing_id: 'ground', floor: 0, bills_included: true, amenities: ['Furnished', 'AC'] }),
+      L({ listing_id: 'nobills', floor: 2, bills_included: false, amenities: ['Furnished', 'AC'] }),
+    ];
+    const kept = applyDealbreakers(
+      items,
+      ['ground_floor', 'bills_not_included', 'unfurnished', 'no_ac'],
+    ).map((l) => l.listing_id);
+    expect(kept).toEqual(['good']);
+  });
+});

--- a/src/app/api/cron/saved-searches-digest/route.js
+++ b/src/app/api/cron/saved-searches-digest/route.js
@@ -4,6 +4,7 @@ import { getResend } from '@/lib/resend';
 import { isEmailSuppressed } from '@/lib/emailSuppressions';
 import { digestEmailHtml, digestEmailSubject } from '@/templates/email/digest';
 import { transformListing } from '@/lib/transformListing';
+import { applyDealbreakers } from '@/lib/dealbreakers';
 
 // Service-role client: claim_digest_send is GRANTed only to service_role
 // (migration 049). The CRON_SECRET check above gates the route; this
@@ -21,6 +22,7 @@ const LISTING_SELECT = `
   is_featured,
   description,
   photos,
+  floor,
   min_duration_months,
   created_at,
   rent!inner ( monthly_price, currency, bills_included, deposit ),
@@ -79,6 +81,10 @@ async function fetchMatchingListings(supabase, filters, since) {
       return filters.amenities.every((a) => has.includes(a.toLowerCase()));
     });
   }
+
+  // Re-apply the student's dealbreakers (#101) — without this a digest could
+  // email listings that violate filters they explicitly set in the quiz.
+  results = applyDealbreakers(results, filters.dealbreakers);
 
   return results;
 }

--- a/src/components/SaveSearchModal.js
+++ b/src/components/SaveSearchModal.js
@@ -32,6 +32,7 @@ export default function SaveSearchModal({ filters, faculty, onClose }) {
       neighborhoods: filters.selectedNeighborhoods?.length > 0 ? filters.selectedNeighborhoods : undefined,
       amenities: filters.selectedAmenities?.length > 0 ? filters.selectedAmenities : undefined,
       minDuration: filters.minDuration || undefined,
+      dealbreakers: filters.dealbreakers?.length > 0 ? filters.dealbreakers : undefined,
     };
 
     try {

--- a/src/lib/dealbreakers.js
+++ b/src/lib/dealbreakers.js
@@ -1,0 +1,32 @@
+// Quiz/results dealbreakers, re-applied to transformed listings. Mirrors the
+// translation in results/page.js#fetchListings:
+//   - unfurnished / no_ac  → require the "Furnished" / "AC" amenity
+//   - ground_floor         → exclude floor 0 and the "ground floor" amenity tag
+//                            (NULL floors are kept — not every listing records
+//                            one; surfaced separately by the "floor not
+//                            specified" badge)
+//   - bills_not_included   → require bills_included
+//
+// Used by the saved-searches digest so a digest never emails a listing the
+// student explicitly ruled out (#101). Operates on the flat transformListing
+// shape, so it needs `floor`, `bills_included`, and `amenities` populated.
+const REQUIRED_AMENITY = { unfurnished: 'Furnished', no_ac: 'AC' };
+
+export function applyDealbreakers(listings, dealbreakers) {
+  if (!Array.isArray(dealbreakers) || dealbreakers.length === 0) return listings;
+
+  const requiredAmenities = dealbreakers
+    .map((d) => REQUIRED_AMENITY[d])
+    .filter(Boolean)
+    .map((a) => a.toLowerCase());
+  const excludeGroundFloor = dealbreakers.includes('ground_floor');
+  const requireBillsIncluded = dealbreakers.includes('bills_not_included');
+
+  return listings.filter((listing) => {
+    const have = (listing.amenities || []).map((a) => a.toLowerCase());
+    if (!requiredAmenities.every((a) => have.includes(a))) return false;
+    if (requireBillsIncluded && listing.bills_included !== true) return false;
+    if (excludeGroundFloor && (listing.floor === 0 || have.includes('ground floor'))) return false;
+    return true;
+  });
+}


### PR DESCRIPTION
## Audit result (the issue asked for an audit + fix)
Traced the dealbreaker path end-to-end:

| Stage | File | Dealbreakers handled? |
|---|---|---|
| Live results | `results/page.js#fetchListings` | ✅ translated to `exclude_ground_floor` / `require_bills_included` / `exclude_amenities` |
| Save modal | `SaveSearchModal.js` | ❌ `filtersPayload` omitted `dealbreakers` entirely |
| Persist | `api/saved-searches/route.js` | n/a — stores whatever `filters` it's given (so nothing) |
| Digest | `api/cron/saved-searches-digest/route.js#fetchMatchingListings` | ❌ never applied them |

So a student who saved a search with dealbreakers could receive digest emails containing listings they explicitly ruled out. **Confirmed broken.**

## Fix
- **`SaveSearchModal`** now persists the raw `dealbreakers` array.
- **New `src/lib/dealbreakers.js#applyDealbreakers(listings, dealbreakers)`** — a pure function mirroring the live `results/page.js` mapping: require `Furnished`/`AC` amenities (unfurnished/no_ac), require `bills_included` (bills_not_included), exclude `floor === 0` and the "ground floor" amenity tag (NULL floors kept, consistent with the live API and #100). Applied in the digest after the existing amenity filter; `floor` added to the digest `LISTING_SELECT` to support it.
- **No DB migration** — `saved_searches.filters` is freeform JSON. Pre-existing rows have no `dealbreakers` key → `applyDealbreakers` returns them unchanged.

## Not refactored (deliberate)
`results/page.js` keeps its own dealbreaker→query-param translation (it targets the live SQL/RPC path, a different consumer). Unifying the two would be a larger refactor; flagged as possible follow-up. The amenity names (`Furnished`/`AC`) and the `ground floor` tag are duplicated between the two — kept in sync by the shared comment.

## Test plan
- [x] New `__tests__/lib/dealbreakers.test.js` — 6 cases (each dealbreaker + AND combination + no-op)
- [x] Existing `savedSearchesDigest.test.js` still green · full suite 147 passing · lint clean
- [ ] Not exercised against live data; logic verified by unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)