### PR TITLE
feat(results): "Floor not specified" badge when ground-floor is a dealbreaker (#100)

### DIFF
--- a/src/app/[locale]/property/[city]/results/page.js
+++ b/src/app/[locale]/property/[city]/results/page.js
@@ -369,6 +369,7 @@ function ResultsContent() {
                       key={listing.listing_id}
                       listing={listing}
                       fromQuery={searchParams.toString()}
+                      groundFloorDealbreaker={filters.dealbreakers.includes('ground_floor')}
                     />
                   ))}
                 </div>

--- a/src/components/ListingCard.js
+++ b/src/components/ListingCard.js
@@ -16,11 +16,15 @@ function isValidPhotoUrl(url) {
   return typeof url === 'string' && url.startsWith('http');
 }
 
-export default function ListingCard({ listing, fromQuery = '' }) {
+export default function ListingCard({ listing, fromQuery = '', groundFloorDealbreaker = false }) {
   const t = useTranslations('propylaea.results');
   const tCard = useTranslations('listingCard');
   const locale = useLocale();
   const photo = listing.photos?.find(isValidPhotoUrl);
+  // When the student set "no ground floor" but this listing has no recorded
+  // floor, flag it so they ask before viewing rather than discovering on the
+  // day (NULL floors are kept in results, not filtered out — see #100).
+  const floorUnspecified = groundFloorDealbreaker && listing.floor == null;
   const isVerified =
     listing.verified_tier &&
     listing.verified_tier !== 'none' &&
@@ -94,6 +98,9 @@ export default function ListingCard({ listing, fromQuery = '' }) {
         </div>
 
         <div className="mt-4 flex flex-wrap gap-1.5">
+          {floorUnspecified && (
+            <Pill variant="info">{t('floorNotSpecified')}</Pill>
+          )}
           {listing.bills_included && (
             <Pill variant="amenity">{t('billsIncluded')}</Pill>
           )}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -546,6 +546,7 @@
       "verified": "Verified",
       "billsIncluded": "Bills included",
       "authProgramme": "AUTh programme",
+      "floorNotSpecified": "Floor not specified",
       "dealbreakers": "Your dealbreakers",
       "removeDealbreaker": "Remove {label}",
       "featuredTitle": "Aristotle Medical Housing Programme",


### PR DESCRIPTION
## Summary
The `ground_floor` dealbreaker excludes `floor === 0` and "ground floor"-tagged listings, but **keeps** listings with `floor === null` (the landlord didn't record a floor) — penalising missing data is the wrong default. That leaves a trust gap: a student who said "no ground floor" might tour a NULL-floor listing and discover on the day that it's ground floor.

`ListingCard` now renders a small "Floor not specified" badge (blue `info` pill) when `groundFloorDealbreaker` is active **and** `listing.floor == null`, prompting the student to ask before viewing.

## Implementation
- `ListingCard` takes a `groundFloorDealbreaker` prop; `results/page.js` passes `filters.dealbreakers.includes('ground_floor')`.
- New `propylaea.results.floorNotSpecified` message.

## Verification (dev server, real data)
- `?dealbreakers=ground_floor`: 11 cards (3 floor-0 listings correctly excluded), **6 badges** rendered on exactly the 6 null-floor listings (`0101001`–`0101006`); computed style `display:flex; visibility:visible; bg rgb(99,91,255)`. Floored listings (`0100xxx`/`0106xxx`) have no badge.
- No dealbreaker: 14 cards, **0 badges**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)