### PR TITLE
feat(listing-form): name failed files in photo-upload error (#129)

### DIFF
--- a/src/components/ListingForm.js
+++ b/src/components/ListingForm.js
@@ -192,7 +192,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
       const CONCURRENCY = 3;
       const queue = [...toUpload];
       const uploaded = [];
-      let anyFailure = false;
+      const failed = [];
 
       async function worker() {
         while (queue.length > 0) {
@@ -202,7 +202,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
             const cardUrl = await processOne(file);
             uploaded.push(cardUrl);
           } catch (err) {
-            anyFailure = true;
+            failed.push(file.name);
             console.error('[ListingForm] photo processing failed:', file.name, err);
           }
         }
@@ -210,8 +210,16 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
       await Promise.all(
         Array.from({ length: Math.min(CONCURRENCY, toUpload.length) }, worker)
       );
-      if (anyFailure) {
-        setPhotoError(t('photosError'));
+      if (failed.length > 0) {
+        // Name the failed files (capped so a whole-batch failure doesn't wall
+        // the toast) so the landlord knows which to re-add, not just "some".
+        const MAX_NAMES = 5;
+        const names =
+          failed.slice(0, MAX_NAMES).join(', ') +
+          (failed.length > MAX_NAMES ? `, +${failed.length - MAX_NAMES} more` : '');
+        setPhotoError(
+          t('photosPartialError', { succeeded: uploaded.length, total: toUpload.length, names })
+        );
       }
 
       if (uploaded.length > 0) {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -323,6 +323,7 @@
       "photosUploading": "Uploading…",
       "photosRemove": "Remove",
       "photosError": "Some files could not be uploaded.",
+      "photosPartialError": "{succeeded} of {total} photos uploaded. Failed: {names}",
       "photosFileTooLarge": "File too large (max {max} MB): {names}",
       "photosInvalidType": "Only JPG, PNG and WebP are allowed.",
       "photosTooMany": "Photo limit reached.",


### PR DESCRIPTION
## Summary
When a landlord uploaded a batch of photos and some failed, the toast only said "Some files could not be uploaded" — no count, no filenames. `handlePhotoFiles` already caught per-file failures but only flipped a boolean and logged to console.

Now it collects the failed filenames and shows: **"{succeeded} of {total} photos uploaded. Failed: bedroom_4.jpg"** via a new `landlord.listingForm.photosPartialError` message. The name list is capped at 5 with "+N more" so a whole-batch failure doesn't wall the toast.

## Scope (per issue)
- In: count + filenames in the existing toast.
- Out: per-file inline retry UI; distinguishing failure cause (resize vs upload vs network).

## Test plan
- [x] `npm run lint` clean · `en.json` valid · full suite 141 passing
- [ ] **Not browser-verified** — reproducing needs a landlord session + an induced upload failure (e.g. revoked storage perms mid-batch). Logic is a small change to the existing error path; happy-path upload is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)