### PR TITLE
test: verify applied-to-prod gate (fresh sentinel, DO NOT MERGE)

### DIFF
--- a/supabase/migrations/999_ci_gate_verification_20260529.sql
+++ b/supabase/migrations/999_ci_gate_verification_20260529.sql
@@ -1,0 +1,5 @@
+-- Sentinel migration for CI-gate verification (fresh, 2026-05-29).
+-- Intentionally NEVER applied to prod. The applied-to-prod gate MUST fail any
+-- PR that adds this file. Throwaway — do not merge; PR will be closed after
+-- the gate is confirmed to reject it.
+SELECT 1;


### PR DESCRIPTION
Throwaway sentinel branched off current main, adding an intentionally-unapplied migration `999_ci_gate_verification_20260529.sql`. With `SUPABASE_ACCESS_TOKEN`/`SUPABASE_PROJECT_REF` now configured, the `applied-to-prod` gate MUST fail this PR with "Migration … is not yet applied to production". Will be closed once verified — do not merge.