### PR TITLE
chore(ui): foundational cleanups — drop AUTH PROGRAMME pill, iris palette sweep, delete dialog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,9 +375,14 @@ curl -X POST -H "x-cron-secret: $CRON_SECRET" \
 - **Functional React + server components by default.** Add `'use client'`
   only when the file needs hooks, browser APIs, or event handlers.
 - **Path alias `@/...`** maps to `src/...` (e.g. `@/lib/requireStudent`).
-- **Tailwind v4** with custom palette: `gold`, `blue`, `night`, `parchment`,
-  `stone`. Display face EB Garamond, body face Source Sans 3 (both Greek +
-  Latin subsets, self-hosted via `next/font/google`).
+- **Tailwind v4** with a Stripe-style iris palette (tokens in
+  `src/app/globals.css`): `blue` #635BFF (primary / CTAs / logo), `night`
+  #0a2540 (ink / dark surfaces), `stone` #fff (canvas), `parchment` #f6f4ff
+  (cards / surfaces), plus accents `magenta` #ff5fa2 and `yellow` #ffcb57.
+  Legacy aliases (`navy`, `gray-dark`, `gray-light`, `font-heading`) still
+  resolve via `globals.css` but new code should use the canonical tokens
+  (`night`, `parchment`, `blue`, `font-display`). Inter for both display and
+  body (Latin + Greek subsets, self-hosted via `next/font/google`).
 - **next-intl** for all user-visible strings. Greek strings stay in
   `src/messages/el.json`, English in `src/messages/en.json`. Adding a key
   to one without the other will fire the `missing-message` synthetic canary.

--- a/src/app/[locale]/admin/metrics/page.js
+++ b/src/app/[locale]/admin/metrics/page.js
@@ -43,7 +43,7 @@ export default function AdminMetricsPage() {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <p className="text-gray-dark/50">Loading metrics…</p>
+        <p className="text-night/50">Loading metrics…</p>
       </div>
     );
   }
@@ -67,15 +67,15 @@ export default function AdminMetricsPage() {
   return (
     <div className="max-w-5xl mx-auto px-4 py-10">
       <div className="flex items-center justify-between mb-8">
-        <h1 className="font-heading text-2xl font-bold text-navy">Internal Metrics</h1>
+        <h1 className="font-display text-2xl font-bold text-night">Internal Metrics</h1>
         {cached && (
-          <span className="text-xs text-gray-dark/40 bg-gray-100 rounded-full px-3 py-1">cached</span>
+          <span className="text-xs text-night/40 bg-gray-100 rounded-full px-3 py-1">cached</span>
         )}
       </div>
 
       {/* Revenue KPIs */}
       <section className="mb-8">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-dark/40 mb-3">Revenue</h2>
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-night/40 mb-3">Revenue</h2>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           <KpiCard label="MRR" value={metrics.mrrFormatted} />
           <KpiCard label="ARR" value={metrics.arrFormatted} />
@@ -86,7 +86,7 @@ export default function AdminMetricsPage() {
 
       {/* Landlord KPIs */}
       <section className="mb-8">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-dark/40 mb-3">Landlords</h2>
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-night/40 mb-3">Landlords</h2>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           <KpiCard label="Total" value={metrics.totalLandlords} />
           <KpiCard label="Paid" value={metrics.paidLandlords} />
@@ -101,7 +101,7 @@ export default function AdminMetricsPage() {
 
       {/* Churn & Listings */}
       <section className="mb-8">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-dark/40 mb-3">Retention & Listings</h2>
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-night/40 mb-3">Retention & Listings</h2>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           <KpiCard
             label="Monthly Churn"
@@ -116,7 +116,7 @@ export default function AdminMetricsPage() {
 
       {/* Inquiries */}
       <section className="mb-8">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-dark/40 mb-3">Inquiries</h2>
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-night/40 mb-3">Inquiries</h2>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           <KpiCard label="This Month" value={metrics.inquiriesThisMonth} />
           <KpiCard label="Last Month" value={metrics.inquiriesLastMonth} />
@@ -130,14 +130,14 @@ export default function AdminMetricsPage() {
 
       {/* Tier Breakdown */}
       <section>
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-dark/40 mb-3">Tier Breakdown</h2>
-        <div className="border border-gray-200 rounded-xl overflow-hidden">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-night/40 mb-3">Tier Breakdown</h2>
+        <div className="border border-gray-200 rounded-sm overflow-hidden">
           <table className="w-full text-sm">
             <thead className="bg-gray-50">
               <tr>
-                <th className="text-left px-4 py-3 font-semibold text-navy/70">Plan</th>
-                <th className="text-right px-4 py-3 font-semibold text-navy/70">Landlords</th>
-                <th className="text-right px-4 py-3 font-semibold text-navy/70">Share</th>
+                <th className="text-left px-4 py-3 font-semibold text-night/70">Plan</th>
+                <th className="text-right px-4 py-3 font-semibold text-night/70">Landlords</th>
+                <th className="text-right px-4 py-3 font-semibold text-night/70">Share</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100">
@@ -149,9 +149,9 @@ export default function AdminMetricsPage() {
                   : 0;
                 return (
                   <tr className="hover:bg-gray-50">
-                    <td className="px-4 py-3 text-gray-dark">Starter (Free)</td>
-                    <td className="px-4 py-3 text-right font-mono text-gray-dark">{count}</td>
-                    <td className="px-4 py-3 text-right text-gray-dark/50">{share}%</td>
+                    <td className="px-4 py-3 text-night">Starter (Free)</td>
+                    <td className="px-4 py-3 text-right font-mono text-night">{count}</td>
+                    <td className="px-4 py-3 text-right text-night/50">{share}%</td>
                   </tr>
                 );
               })()}
@@ -165,9 +165,9 @@ export default function AdminMetricsPage() {
                   const label = planNames[planId] || planId.replace(/_/g, ' ');
                   return (
                     <tr key={planId} className="hover:bg-gray-50">
-                      <td className="px-4 py-3 text-gray-dark capitalize">{label}</td>
-                      <td className="px-4 py-3 text-right font-mono text-gray-dark">{count}</td>
-                      <td className="px-4 py-3 text-right text-gray-dark/50">{share}%</td>
+                      <td className="px-4 py-3 text-night capitalize">{label}</td>
+                      <td className="px-4 py-3 text-right font-mono text-night">{count}</td>
+                      <td className="px-4 py-3 text-right text-night/50">{share}%</td>
                     </tr>
                   );
                 })}
@@ -181,14 +181,14 @@ export default function AdminMetricsPage() {
 
 function KpiCard({ label, value, trend, note }) {
   return (
-    <div className="bg-gray-50 border border-gray-100 rounded-xl p-4">
-      <p className="text-xs text-gray-dark/50 mb-1">{label}</p>
+    <div className="bg-gray-50 border border-gray-100 rounded-sm p-4">
+      <p className="text-xs text-night/50 mb-1">{label}</p>
       <div className="flex items-end gap-2">
-        <p className="font-heading text-xl font-bold text-navy">{value}</p>
+        <p className="font-display text-xl font-bold text-night">{value}</p>
         {trend === 'up' && <span className="text-xs text-green-600 mb-0.5">↑</span>}
         {trend === 'down' && <span className="text-xs text-red-500 mb-0.5">↓</span>}
       </div>
-      {note && <p className="text-[11px] text-gray-dark/30 mt-0.5">{note}</p>}
+      {note && <p className="text-[11px] text-night/30 mt-0.5">{note}</p>}
     </div>
   );
 }

--- a/src/app/[locale]/admin/verifications/page.js
+++ b/src/app/[locale]/admin/verifications/page.js
@@ -80,7 +80,7 @@ export default function AdminVerificationsPage() {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <p className="text-gray-dark/50">Loading…</p>
+        <p className="text-night/50">Loading…</p>
       </div>
     );
   }
@@ -96,14 +96,14 @@ export default function AdminVerificationsPage() {
   return (
     <div className="max-w-4xl mx-auto px-4 py-10">
       <div className="flex items-center justify-between mb-8">
-        <h1 className="font-heading text-2xl font-bold text-navy">Verification Requests</h1>
+        <h1 className="font-display text-2xl font-bold text-night">Verification Requests</h1>
         <div className="flex gap-2">
           {['pending', 'approved', 'rejected'].map((s) => (
             <button
               key={s}
               onClick={() => handleFilterChange(s)}
               className={`text-sm px-3 py-1.5 rounded-lg border transition-colors capitalize ${
-                statusFilter === s ? 'bg-navy text-white border-navy' : 'border-gray-200 text-gray-dark/60 hover:border-navy/40'
+                statusFilter === s ? 'bg-night text-white border-night' : 'border-gray-200 text-night/60 hover:border-night/40'
               }`}
             >
               {s}
@@ -113,29 +113,29 @@ export default function AdminVerificationsPage() {
       </div>
 
       {requests.length === 0 ? (
-        <div className="text-center py-16 border-2 border-dashed border-gray-200 rounded-xl">
-          <p className="text-gray-dark/50">No {statusFilter} verification requests.</p>
+        <div className="text-center py-16 border-2 border-dashed border-gray-200 rounded-sm">
+          <p className="text-night/50">No {statusFilter} verification requests.</p>
         </div>
       ) : (
         <div className="space-y-5">
           {requests.map((req) => (
-            <div key={req.id} className="border border-gray-200 rounded-xl p-5 bg-white">
+            <div key={req.id} className="border border-gray-200 rounded-sm p-5 bg-white">
               <div className="flex flex-col sm:flex-row sm:items-start gap-4">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
-                    <span className="font-heading font-semibold text-navy">{req.landlord_name}</span>
+                    <span className="font-display font-semibold text-night">{req.landlord_name}</span>
                     <StatusBadge status={req.status} />
                   </div>
-                  <p className="text-xs text-gray-dark/50 mb-1">
+                  <p className="text-xs text-night/50 mb-1">
                     Submitted {new Date(req.submitted_at).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}
                   </p>
                   {req.reviewed_at && (
-                    <p className="text-xs text-gray-dark/40">
+                    <p className="text-xs text-night/40">
                       Reviewed {new Date(req.reviewed_at).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}
                     </p>
                   )}
                   {req.review_notes && (
-                    <p className="text-sm text-gray-dark/60 mt-1 italic">{req.review_notes}</p>
+                    <p className="text-sm text-night/60 mt-1 italic">{req.review_notes}</p>
                   )}
                 </div>
 
@@ -144,7 +144,7 @@ export default function AdminVerificationsPage() {
                     href={req.document_url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="shrink-0 text-sm px-3 py-1.5 rounded-lg border border-gray-200 text-gray-dark/70 hover:border-navy hover:text-navy transition-colors"
+                    className="shrink-0 text-sm px-3 py-1.5 rounded-lg border border-gray-200 text-night/70 hover:border-night hover:text-night transition-colors"
                   >
                     View document ↗
                   </a>
@@ -158,7 +158,7 @@ export default function AdminVerificationsPage() {
                     value={notesMap[req.id] || ''}
                     onChange={(e) => setNotesMap((prev) => ({ ...prev, [req.id]: e.target.value }))}
                     rows={2}
-                    className="w-full rounded-lg border border-gray-200 bg-gray-light px-3 py-2 text-sm text-gray-dark focus:outline-none focus:ring-2 focus:ring-yellow/50 focus:border-yellow resize-none"
+                    className="w-full rounded-lg border border-gray-200 bg-parchment px-3 py-2 text-sm text-night focus:outline-none focus:ring-2 focus:ring-yellow/50 focus:border-yellow resize-none"
                   />
                   <div className="flex gap-2">
                     <button

--- a/src/app/[locale]/property/[city]/alerts/manage/page.js
+++ b/src/app/[locale]/property/[city]/alerts/manage/page.js
@@ -20,11 +20,11 @@ function FilterSummary({ filters }) {
   if (filters.amenities?.length > 0) parts.push(filters.amenities.join(', '));
   if (filters.faculty) parts.push(`Faculty: ${filters.faculty}`);
 
-  if (parts.length === 0) return <span className="text-gray-dark/50 italic">All listings</span>;
+  if (parts.length === 0) return <span className="text-night/50 italic">All listings</span>;
   return (
     <div className="flex flex-wrap gap-1.5 mt-1">
       {parts.map((p, i) => (
-        <span key={i} className="inline-block text-xs px-2.5 py-1 rounded-full border border-gray-200 bg-gray-light text-gray-dark/70">
+        <span key={i} className="inline-block text-xs px-2.5 py-1 rounded-full border border-gray-200 bg-parchment text-night/70">
           {p}
         </span>
       ))}
@@ -89,8 +89,8 @@ function ManageContent() {
   if (loading) {
     return (
       <div className="mx-auto max-w-lg px-4 py-16 text-center">
-        <div className="h-6 w-48 bg-gray-light rounded animate-pulse mx-auto mb-4" />
-        <div className="h-4 w-32 bg-gray-light rounded animate-pulse mx-auto" />
+        <div className="h-6 w-48 bg-parchment rounded animate-pulse mx-auto mb-4" />
+        <div className="h-4 w-32 bg-parchment rounded animate-pulse mx-auto" />
       </div>
     );
   }
@@ -98,9 +98,9 @@ function ManageContent() {
   if (notFound) {
     return (
       <div className="mx-auto max-w-lg px-4 py-16 text-center">
-        <h1 className="font-heading text-2xl font-bold text-navy mb-3">{t('notFound')}</h1>
-        <p className="text-gray-dark/60 mb-6">{t('notFoundDesc')}</p>
-        <Link href="/property/thessaloniki/results" className="inline-block bg-yellow text-white font-heading font-semibold px-6 py-3 rounded-lg hover:bg-yellow/90 transition-colors">
+        <h1 className="font-display text-2xl font-bold text-night mb-3">{t('notFound')}</h1>
+        <p className="text-night/60 mb-6">{t('notFoundDesc')}</p>
+        <Link href="/property/thessaloniki/results" className="inline-block bg-yellow text-white font-display font-semibold px-6 py-3 rounded-lg hover:bg-yellow/90 transition-colors">
           {t('browseListings')}
         </Link>
       </div>
@@ -115,9 +115,9 @@ function ManageContent() {
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
           </svg>
         </div>
-        <h1 className="font-heading text-2xl font-bold text-navy mb-3">{t('unsubscribed')}</h1>
-        <p className="text-gray-dark/60 mb-6">{t('unsubscribedDesc')}</p>
-        <Link href="/property/thessaloniki/results" className="inline-block bg-navy text-white font-heading font-semibold px-6 py-3 rounded-lg hover:bg-navy/90 transition-colors">
+        <h1 className="font-display text-2xl font-bold text-night mb-3">{t('unsubscribed')}</h1>
+        <p className="text-night/60 mb-6">{t('unsubscribedDesc')}</p>
+        <Link href="/property/thessaloniki/results" className="inline-block bg-night text-white font-display font-semibold px-6 py-3 rounded-lg hover:bg-night/90 transition-colors">
           {t('browseListings')}
         </Link>
       </div>
@@ -130,33 +130,33 @@ function ManageContent() {
 
   return (
     <div className="mx-auto max-w-lg px-4 py-12">
-      <h1 className="font-heading text-2xl md:text-3xl font-bold text-navy mb-2">{t('title')}</h1>
-      <p className="text-gray-dark/60 mb-8">{t('desc')}</p>
+      <h1 className="font-display text-2xl md:text-3xl font-bold text-night mb-2">{t('title')}</h1>
+      <p className="text-night/60 mb-8">{t('desc')}</p>
 
-      <div className="bg-white rounded-xl border border-gray-200 p-6 space-y-5">
+      <div className="bg-white rounded-sm border border-gray-200 p-6 space-y-5">
         {/* Label */}
         <div>
-          <p className="uppercase tracking-wider text-xs font-heading font-semibold text-gray-dark/40 mb-1">{t('alertName')}</p>
-          <p className="text-navy font-medium">{alert?.label || t('unnamedAlert')}</p>
+          <p className="uppercase tracking-wider text-xs font-display font-semibold text-night/40 mb-1">{t('alertName')}</p>
+          <p className="text-night font-medium">{alert?.label || t('unnamedAlert')}</p>
         </div>
 
         {/* Frequency */}
         <div>
-          <p className="uppercase tracking-wider text-xs font-heading font-semibold text-gray-dark/40 mb-1">{t('frequency')}</p>
-          <p className="text-navy font-medium capitalize">{alert?.frequency || 'daily'}</p>
+          <p className="uppercase tracking-wider text-xs font-display font-semibold text-night/40 mb-1">{t('frequency')}</p>
+          <p className="text-night font-medium capitalize">{alert?.frequency || 'daily'}</p>
         </div>
 
         {/* Filters */}
         <div>
-          <p className="uppercase tracking-wider text-xs font-heading font-semibold text-gray-dark/40 mb-1">{t('filters')}</p>
+          <p className="uppercase tracking-wider text-xs font-display font-semibold text-night/40 mb-1">{t('filters')}</p>
           <FilterSummary filters={alert?.filters || {}} />
         </div>
 
         {/* Created */}
         {createdDate && (
           <div>
-            <p className="uppercase tracking-wider text-xs font-heading font-semibold text-gray-dark/40 mb-1">{t('createdOn')}</p>
-            <p className="text-gray-dark/60 text-sm">{createdDate}</p>
+            <p className="uppercase tracking-wider text-xs font-display font-semibold text-night/40 mb-1">{t('createdOn')}</p>
+            <p className="text-night/60 text-sm">{createdDate}</p>
           </div>
         )}
 
@@ -179,7 +179,7 @@ export default function ManageAlertsPage() {
   return (
     <Suspense fallback={
       <div className="mx-auto max-w-lg px-4 py-16 text-center">
-        <div className="h-6 w-48 bg-gray-light rounded animate-pulse mx-auto" />
+        <div className="h-6 w-48 bg-parchment rounded animate-pulse mx-auto" />
       </div>
     }>
       <ManageContent />

--- a/src/app/[locale]/property/[city]/landlord/dashboard/page.js
+++ b/src/app/[locale]/property/[city]/landlord/dashboard/page.js
@@ -320,7 +320,7 @@ function ListingRow({ listing }) {
 function InquiryRow({ inquiry }) {
   const status = inquiry.status || 'pending';
   const statusVariant =
-    status === 'pending' ? 'verified'
+    status === 'pending' ? 'pending'
     : status === 'replied' ? 'info'
     : 'amenity';
   const statusLabel =
@@ -330,10 +330,11 @@ function InquiryRow({ inquiry }) {
   const date = inquiry.created_at
     ? new Date(inquiry.created_at).toLocaleDateString()
     : '';
+  const inquiryId = inquiry.inquiry_id || inquiry.id;
 
   return (
     <Link
-      href="/property/thessaloniki/landlord/inquiries"
+      href={`/property/thessaloniki/landlord/inquiries/${inquiryId}/chat`}
       className="block rounded-sm border border-night/10 p-3 hover:border-blue transition-colors"
     >
       <div className="flex items-start justify-between gap-3 mb-1">

--- a/src/app/[locale]/property/[city]/landlord/inquiries/page.js
+++ b/src/app/[locale]/property/[city]/landlord/inquiries/page.js
@@ -86,7 +86,7 @@ export default function LandlordInquiriesPage() {
 }
 
 function statusVariant(status) {
-  if (status === 'pending') return 'verified';
+  if (status === 'pending') return 'pending';
   if (status === 'replied') return 'info';
   return 'amenity';
 }

--- a/src/app/[locale]/property/[city]/landlord/listings/page.js
+++ b/src/app/[locale]/property/[city]/landlord/listings/page.js
@@ -13,6 +13,7 @@ import Button from '@/components/ui/Button';
 import Card from '@/components/ui/Card';
 import Pill from '@/components/ui/Pill';
 import Icon from '@/components/ui/Icon';
+import ConfirmDialog from '@/components/ui/ConfirmDialog';
 
 /*
   Propylaea landlord listings index. Shows full list of the landlord's
@@ -26,6 +27,8 @@ export default function LandlordListingsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [deleting, setDeleting] = useState(null);
+  // The listing pending delete-confirmation, or null when the dialog is closed.
+  const [confirmTarget, setConfirmTarget] = useState(null);
   useEffect(() => {
     (async () => {
       const supabase = getSupabaseBrowser();
@@ -49,12 +52,13 @@ export default function LandlordListingsPage() {
     })();
   }, []);
 
-  async function handleDelete(listingId) {
-    if (!confirm(t('deleteConfirm'))) return;
+  async function performDelete(listingId) {
+    setError('');
     setDeleting(listingId);
     try {
       if (!accessToken) {
         setDeleting(null);
+        setConfirmTarget(null);
         router.replace('/property/thessaloniki/landlord/login');
         return;
       }
@@ -65,12 +69,15 @@ export default function LandlordListingsPage() {
       if (res.ok) {
         setListings((prev) => prev.filter((l) => l.listing_id !== listingId));
       } else {
-        alert(t('deleteError'));
+        setError(t('deleteError'));
       }
     } catch (err) {
       console.error('[LandlordListings] delete failed:', err);
-      alert(t('deleteError'));
+      setError(t('deleteError'));
     } finally {
+      // Close the dialog regardless of outcome — on failure the page-level
+      // error banner surfaces the reason.
+      setConfirmTarget(null);
       setDeleting(null);
     }
   }
@@ -115,13 +122,30 @@ export default function LandlordListingsPage() {
                 <ListingRow
                   listing={listing}
                   deleting={deleting === listing.listing_id}
-                  onDelete={() => handleDelete(listing.listing_id)}
+                  onDelete={() => setConfirmTarget(listing)}
                   t={t}
                 />
               </li>
             ))}
           </ul>
         </Card>
+      )}
+
+      {confirmTarget && (
+        <ConfirmDialog
+          title={t('deleteTitle')}
+          body={t('deleteBody', {
+            address: confirmTarget.location?.address || t('noAddress'),
+          })}
+          confirmLabel={
+            deleting === confirmTarget.listing_id ? t('deleting') : t('delete')
+          }
+          cancelLabel={t('cancel')}
+          busy={deleting === confirmTarget.listing_id}
+          destructive
+          onConfirm={() => performDelete(confirmTarget.listing_id)}
+          onCancel={() => setConfirmTarget(null)}
+        />
       )}
     </LandlordShell>
   );

--- a/src/app/[locale]/property/[city]/landlord/onboarding/page.js
+++ b/src/app/[locale]/property/[city]/landlord/onboarding/page.js
@@ -121,8 +121,8 @@ export default function LandlordOnboardingPage() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="animate-pulse space-y-4 w-full max-w-md px-4">
-          <div className="h-8 w-48 bg-gray-light rounded mx-auto" />
-          <div className="h-32 bg-gray-light rounded-xl" />
+          <div className="h-8 w-48 bg-parchment rounded mx-auto" />
+          <div className="h-32 bg-parchment rounded-sm" />
         </div>
       </div>
     );
@@ -130,10 +130,10 @@ export default function LandlordOnboardingPage() {
 
   return (
     <div className="min-h-screen bg-stone flex flex-col items-center justify-center px-4 py-12">
-      <h1 className="font-heading text-3xl font-bold text-navy mb-2 text-center">
+      <h1 className="font-display text-3xl font-bold text-night mb-2 text-center">
         Choose your plan
       </h1>
-      <p className="text-sm text-gray-dark/60 text-center mb-10">
+      <p className="text-sm text-night/60 text-center mb-10">
         Pick the tier that fits your needs. You can upgrade anytime.
       </p>
 
@@ -155,11 +155,11 @@ export default function LandlordOnboardingPage() {
               )}
 
               <div className="p-6 border-b border-gray-100">
-                <h2 className="font-heading text-xl font-bold text-navy mb-1">{tier.name}</h2>
+                <h2 className="font-display text-xl font-bold text-night mb-1">{tier.name}</h2>
                 <div className="flex items-baseline gap-0.5">
-                  <span className="font-heading text-3xl font-bold text-navy">{tier.price}</span>
+                  <span className="font-display text-3xl font-bold text-night">{tier.price}</span>
                   {tier.period && (
-                    <span className="text-gray-dark/50 text-sm">{tier.period}</span>
+                    <span className="text-night/50 text-sm">{tier.period}</span>
                   )}
                 </div>
               </div>
@@ -167,8 +167,8 @@ export default function LandlordOnboardingPage() {
               <ul className="p-6 space-y-3 flex-1">
                 {tier.features.map((f) => (
                   <li key={f.label} className="flex flex-col gap-0.5">
-                    <span className="text-xs text-gray-dark/50 uppercase tracking-wide">{f.label}</span>
-                    <span className="text-sm font-medium text-navy">{f.value}</span>
+                    <span className="text-xs text-night/50 uppercase tracking-wide">{f.label}</span>
+                    <span className="text-sm font-medium text-night">{f.value}</span>
                   </li>
                 ))}
               </ul>
@@ -177,9 +177,9 @@ export default function LandlordOnboardingPage() {
                 <button
                   onClick={() => handleChoose(tier.key)}
                   disabled={pendingTier !== null}
-                  className={`w-full py-3 rounded-xl font-heading font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                  className={`w-full py-3 rounded-sm font-display font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                     tier.key === 'free'
-                      ? 'bg-navy text-white hover:bg-navy/90'
+                      ? 'bg-night text-white hover:bg-night/90'
                       : 'bg-yellow text-white hover:bg-yellow/90'
                   }`}
                 >
@@ -197,7 +197,7 @@ export default function LandlordOnboardingPage() {
         </p>
       )}
 
-      <p className="text-xs text-gray-dark/40 mt-8">
+      <p className="text-xs text-night/40 mt-8">
         Paid plans use secure checkout via Stripe. Cancel anytime.
       </p>
     </div>

--- a/src/app/[locale]/property/[city]/listing/[id]/page.js
+++ b/src/app/[locale]/property/[city]/listing/[id]/page.js
@@ -90,14 +90,15 @@ export default async function ListingPage({ params, searchParams }) {
       <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-10">
         {/* Left column */}
         <div>
-          {/* Hero stripe — verified seal + programme tag + address */}
+          {/* Hero stripe — verified seal + address */}
           <div className="flex flex-col md:flex-row md:items-start gap-5 mb-8">
             {isVerified && <VerifiedSeal size={52} />}
             <div className="flex-1">
-              <div className="flex flex-wrap items-center gap-2 mb-3">
-                {isVerified && <Pill variant="verified">{t('verified')}</Pill>}
-                <Pill variant="programme">{t('authMedicalProgramme')}</Pill>
-              </div>
+              {isVerified && (
+                <div className="flex flex-wrap items-center gap-2 mb-3">
+                  <Pill variant="verified">{t('verified')}</Pill>
+                </div>
+              )}
               <p className="label-caps text-night/50">
                 {listing.neighborhood} &middot; Thessaloniki
               </p>

--- a/src/app/[locale]/property/[city]/results/page.js
+++ b/src/app/[locale]/property/[city]/results/page.js
@@ -25,7 +25,9 @@ const PROPERTY_TYPE_GROUPS = [
   { labelKey: 'type2Bed', values: ['2-Bedroom'] },
   { labelKey: 'typePrivateRoom', values: ['Room in shared apartment'] },
 ];
-const BUDGET_MIN = 150;
+// Floor matches the quiz slider (src/app/.../quiz/page.js) so the two
+// surfaces agree on the minimum selectable budget.
+const BUDGET_MIN = 250;
 const BUDGET_MAX = 1200;
 const DEFAULT_BUDGET = 900;
 
@@ -647,7 +649,7 @@ function FilterPanel({
           }`}
         >
           <Icon name="shieldCheck" className="w-4 h-4" />
-          {t('verified')} only
+          {t('verifiedLandlordsOnly')}
         </button>
       </section>
 

--- a/src/components/BauhausLoader.js
+++ b/src/components/BauhausLoader.js
@@ -10,7 +10,7 @@ import { useEffect, useState } from 'react';
   where GlobeLoader still runs.
 
   Geometry (200×200 box):
-   - navy square inset 30 (rotates over dur*2)
+   - night square inset 30 (rotates over dur*2)
    - gold circle 32×32 orbiting around the square (dur)
    - white diamond pulsing in the centre (dur)
 
@@ -113,7 +113,7 @@ export default function BauhausLoader({
 
         <div
           className={`mt-9 min-h-[22px] text-center text-sm ${
-            dim ? 'text-gray-dark/60' : 'text-gray-dark'
+            dim ? 'text-night/60' : 'text-night'
           }`}
         >
           {status}

--- a/src/components/BillingSection.js
+++ b/src/components/BillingSection.js
@@ -7,7 +7,7 @@ import { useAccessToken } from '@/lib/useAccessToken';
 const TIER_STYLES = {
   none: 'bg-gray-100 text-gray-700',
   verified: 'bg-emerald-100 text-emerald-700',
-  verified_pro: 'bg-navy/10 text-navy',
+  verified_pro: 'bg-night/10 text-night',
 };
 
 export default function BillingSection() {
@@ -95,8 +95,8 @@ export default function BillingSection() {
   if (loading) {
     return (
       <div className="animate-pulse space-y-3">
-        <div className="h-6 w-32 bg-gray-light rounded" />
-        <div className="h-24 bg-gray-light rounded-xl" />
+        <div className="h-6 w-32 bg-parchment rounded" />
+        <div className="h-24 bg-parchment rounded-sm" />
       </div>
     );
   }
@@ -108,7 +108,7 @@ export default function BillingSection() {
     <div className="space-y-6">
       {/* Subscription status for verified landlords */}
       {sub && (
-        <div className="border border-gray-200 rounded-xl p-5 bg-white">
+        <div className="border border-gray-200 rounded-sm p-5 bg-white">
           <div className="flex items-center justify-between">
             <div>
               <div className="flex items-center gap-2">
@@ -116,7 +116,7 @@ export default function BillingSection() {
                   {currentTier === 'verified_pro' ? t('tierVerifiedPro') : t('tierVerified')}
                 </span>
               </div>
-              <p className="text-sm text-gray-dark/60 mt-1">
+              <p className="text-sm text-night/60 mt-1">
                 {t('billingAnnual')} {t('billingSuffix')}
                 {sub.cancelAtPeriodEnd && ` — ${t('cancelAtPeriodEnd')}`}
                 {sub.currentPeriodEnd && (
@@ -127,7 +127,7 @@ export default function BillingSection() {
             <button
               onClick={handleManageBilling}
               disabled={actionLoading}
-              className="text-sm px-4 py-2 rounded-lg border border-gray-200 text-gray-dark/70 hover:border-navy hover:text-navy transition-colors disabled:opacity-50"
+              className="text-sm px-4 py-2 rounded-lg border border-gray-200 text-night/70 hover:border-night hover:text-night transition-colors disabled:opacity-50"
             >
               {t('manageBilling')}
             </button>
@@ -140,7 +140,7 @@ export default function BillingSection() {
         <div>
           <div className="grid gap-4 sm:grid-cols-2">
             {/* Verified */}
-            <div className="border border-gray-200 rounded-xl p-5 bg-white">
+            <div className="border border-gray-200 rounded-sm p-5 bg-white">
               <div className="flex items-center gap-2 mb-2">
                 <span className="inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full bg-emerald-500 text-white">
                   <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" /></svg>
@@ -148,10 +148,10 @@ export default function BillingSection() {
                 </span>
               </div>
               <div className="mt-2">
-                <span className="text-2xl font-bold text-navy">&euro;49</span>
-                <span className="text-sm text-gray-dark/60">{t('perYear')}</span>
+                <span className="text-2xl font-bold text-night">&euro;49</span>
+                <span className="text-sm text-night/60">{t('perYear')}</span>
               </div>
-              <ul className="mt-3 space-y-1.5 text-sm text-gray-dark/70">
+              <ul className="mt-3 space-y-1.5 text-sm text-night/70">
                 <li>{t('benefitBadge')}</li>
                 <li>{t('benefitSearchBoost')}</li>
               </ul>
@@ -165,18 +165,18 @@ export default function BillingSection() {
             </div>
 
             {/* Verified Pro */}
-            <div className="border-2 border-navy rounded-xl p-5 bg-navy/5">
+            <div className="border-2 border-night rounded-sm p-5 bg-night/5">
               <div className="flex items-center gap-2 mb-2">
-                <span className="inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full bg-navy text-white">
+                <span className="inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full bg-night text-white">
                   <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" /></svg>
                   {t('tierVerifiedPro')}
                 </span>
               </div>
               <div className="mt-2">
-                <span className="text-2xl font-bold text-navy">&euro;99</span>
-                <span className="text-sm text-gray-dark/60">{t('perYear')}</span>
+                <span className="text-2xl font-bold text-night">&euro;99</span>
+                <span className="text-sm text-night/60">{t('perYear')}</span>
               </div>
-              <ul className="mt-3 space-y-1.5 text-sm text-gray-dark/70">
+              <ul className="mt-3 space-y-1.5 text-sm text-night/70">
                 <li>{t('benefitBadge')}</li>
                 <li>{t('benefitPriorityPlacement')}</li>
                 <li>{t('benefitAnalytics')}</li>
@@ -184,7 +184,7 @@ export default function BillingSection() {
               <button
                 onClick={() => handleCheckout('verified_pro')}
                 disabled={actionLoading}
-                className="mt-4 w-full text-sm px-3 py-2 rounded-lg bg-navy text-white font-medium hover:bg-navy/90 transition-colors disabled:opacity-50"
+                className="mt-4 w-full text-sm px-3 py-2 rounded-lg bg-night text-white font-medium hover:bg-night/90 transition-colors disabled:opacity-50"
               >
                 {t('getVerifiedPro')}
               </button>
@@ -195,19 +195,19 @@ export default function BillingSection() {
 
       {/* Upgrade option for Verified → Verified Pro */}
       {currentTier === 'verified' && (
-        <div className="border-2 border-navy rounded-xl p-5 bg-navy/5">
-          <h3 className="font-heading font-semibold text-navy text-base mb-2">
+        <div className="border-2 border-night rounded-sm p-5 bg-night/5">
+          <h3 className="font-display font-semibold text-night text-base mb-2">
             {t('upgradeToVerifiedPro')}
           </h3>
-          <p className="text-sm text-gray-dark/60 mb-3">{t('upgradeProDescription')}</p>
-          <ul className="mb-4 space-y-1.5 text-sm text-gray-dark/70">
+          <p className="text-sm text-night/60 mb-3">{t('upgradeProDescription')}</p>
+          <ul className="mb-4 space-y-1.5 text-sm text-night/70">
             <li>{t('benefitPriorityPlacement')}</li>
             <li>{t('benefitAnalytics')}</li>
           </ul>
           <button
             onClick={() => handleCheckout('verified_pro')}
             disabled={actionLoading}
-            className="text-sm px-4 py-2 rounded-lg bg-navy text-white font-medium hover:bg-navy/90 transition-colors disabled:opacity-50"
+            className="text-sm px-4 py-2 rounded-lg bg-night text-white font-medium hover:bg-night/90 transition-colors disabled:opacity-50"
           >
             {t('upgradeButton99')}
           </button>

--- a/src/components/ListingCard.js
+++ b/src/components/ListingCard.js
@@ -9,7 +9,7 @@ import { formatPropertyType } from '@/lib/propertyType';
 /*
   Propylaea listing card — matches page 06 of the reference design.
   Parchment frame, photo with gold verified seal overlay, small-caps
-  neighborhood, EB Garamond address, type + price row, programme pills.
+  neighborhood, EB Garamond address, type + price row, amenity pills.
 */
 
 function isValidPhotoUrl(url) {
@@ -104,7 +104,6 @@ export default function ListingCard({ listing, fromQuery = '', groundFloorDealbr
           {listing.bills_included && (
             <Pill variant="amenity">{t('billsIncluded')}</Pill>
           )}
-          {isVerified && <Pill variant="programme">{t('authProgramme')}</Pill>}
         </div>
       </div>
     </Link>

--- a/src/components/ListingForm.js
+++ b/src/components/ListingForm.js
@@ -274,7 +274,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
 
   const inputClass =
     'w-full border border-gray-200 rounded-lg px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-yellow/40 focus:border-yellow';
-  const labelClass = 'block text-sm font-medium text-gray-dark mb-1';
+  const labelClass = 'block text-sm font-medium text-night mb-1';
 
   return (
     <>
@@ -288,7 +288,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
       <form onSubmit={handleSubmit} className="space-y-8">
       {/* Location */}
       <section>
-        <h2 className="font-heading font-semibold text-navy mb-4 text-sm uppercase tracking-wider">
+        <h2 className="font-display font-semibold text-night mb-4 text-sm uppercase tracking-wider">
           {t('locationSection')}
         </h2>
         <div className="space-y-4">
@@ -312,10 +312,10 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
               placeholder={t('titlePlaceholder')}
             />
             <div className="mt-1.5 flex justify-between items-start gap-3">
-              <p className="text-xs text-gray-dark/50 leading-relaxed">
+              <p className="text-xs text-night/50 leading-relaxed">
                 {t('titleHint')}
               </p>
-              <span className="text-xs text-gray-dark/40 tabular-nums shrink-0">
+              <span className="text-xs text-night/40 tabular-nums shrink-0">
                 {codepointLength(form.title)}/{TITLE_MAX_LENGTH}
               </span>
             </div>
@@ -390,7 +390,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
               />
             </div>
           </div>
-          <p className="text-xs text-gray-dark/50">
+          <p className="text-xs text-night/50">
             {t('coordsOptional')}
             {' '}
             {t.rich('coordsHelp', {
@@ -411,7 +411,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
 
       {/* Property details */}
       <section>
-        <h2 className="font-heading font-semibold text-navy mb-4 text-sm uppercase tracking-wider">
+        <h2 className="font-display font-semibold text-night mb-4 text-sm uppercase tracking-wider">
           {t('detailsSection')}
         </h2>
         <div className="space-y-4">
@@ -474,7 +474,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
               className={inputClass + ' resize-none'}
               placeholder={t('descriptionPlaceholder')}
             />
-            <p className="mt-1.5 text-xs text-gray-dark/50 leading-relaxed">
+            <p className="mt-1.5 text-xs text-night/50 leading-relaxed">
               {t('descriptionTip')}
             </p>
           </div>
@@ -483,7 +483,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
 
       {/* Pricing */}
       <section>
-        <h2 className="font-heading font-semibold text-navy mb-4 text-sm uppercase tracking-wider">
+        <h2 className="font-display font-semibold text-night mb-4 text-sm uppercase tracking-wider">
           {t('pricingSection')}
         </h2>
         <div className="space-y-4">
@@ -519,7 +519,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
               onChange={(e) => set('bills_included', e.target.checked)}
               className="w-4 h-4 accent-yellow"
             />
-            <span className="text-sm text-gray-dark">{t('billsIncluded')}</span>
+            <span className="text-sm text-night">{t('billsIncluded')}</span>
           </label>
 
         </div>
@@ -527,7 +527,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
 
       {/* Availability */}
       <section>
-        <h2 className="font-heading font-semibold text-navy mb-4 text-sm uppercase tracking-wider">
+        <h2 className="font-display font-semibold text-night mb-4 text-sm uppercase tracking-wider">
           {t('availabilitySection')}
         </h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -564,7 +564,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
 
       {/* Photos */}
       <section>
-        <h2 className="font-heading font-semibold text-navy mb-4 text-sm uppercase tracking-wider">
+        <h2 className="font-display font-semibold text-night mb-4 text-sm uppercase tracking-wider">
           {t('photosSection')}
         </h2>
         <div className="space-y-4">
@@ -605,7 +605,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
                         setDragIndex(null);
                         setDragOverIndex(null);
                       }}
-                      className={`relative group aspect-[4/3] rounded-lg overflow-hidden bg-gray-light cursor-grab active:cursor-grabbing transition-all ${
+                      className={`relative group aspect-[4/3] rounded-lg overflow-hidden bg-parchment cursor-grab active:cursor-grabbing transition-all ${
                         i === 0 ? 'col-span-2' : ''
                       } ${isDragging ? 'opacity-40' : ''} ${
                         isDragOver ? 'ring-2 ring-yellow ring-offset-2' : ''
@@ -628,7 +628,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
                           type="button"
                           onClick={() => reorderPhoto(i, i - 1)}
                           disabled={i === 0}
-                          className="bg-white/95 hover:bg-white text-gray-dark rounded-full w-9 h-9 flex items-center justify-center shadow disabled:opacity-40 disabled:cursor-not-allowed"
+                          className="bg-white/95 hover:bg-white text-night rounded-full w-9 h-9 flex items-center justify-center shadow disabled:opacity-40 disabled:cursor-not-allowed"
                           aria-label={t('photosMoveLeft')}
                         >
                           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -639,7 +639,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
                           type="button"
                           onClick={() => reorderPhoto(i, i + 1)}
                           disabled={i === total - 1}
-                          className="bg-white/95 hover:bg-white text-gray-dark rounded-full w-9 h-9 flex items-center justify-center shadow disabled:opacity-40 disabled:cursor-not-allowed"
+                          className="bg-white/95 hover:bg-white text-night rounded-full w-9 h-9 flex items-center justify-center shadow disabled:opacity-40 disabled:cursor-not-allowed"
                           aria-label={t('photosMoveRight')}
                         >
                           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -650,7 +650,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
                       <button
                         type="button"
                         onClick={() => removePhoto(url)}
-                        className="absolute top-2 right-2 bg-white/95 hover:bg-white text-gray-dark rounded-full w-9 h-9 flex items-center justify-center opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:focus:opacity-100 transition-opacity shadow [@media(hover:none)]:opacity-100"
+                        className="absolute top-2 right-2 bg-white/95 hover:bg-white text-night rounded-full w-9 h-9 flex items-center justify-center opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:focus:opacity-100 transition-opacity shadow [@media(hover:none)]:opacity-100"
                         aria-label={t('photosRemove')}
                       >
                         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -662,7 +662,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
                 })}
               </div>
               {(form.photos || []).length > 1 && (
-                <p className="text-xs text-gray-dark/50">{t('photosReorderHint')}</p>
+                <p className="text-xs text-night/50">{t('photosReorderHint')}</p>
               )}
             </>
           )}
@@ -670,12 +670,12 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
           {/* Imported external photos (read-only) */}
           {(form.external_photo_urls || []).length > 0 && (
             <div>
-              <p className="text-xs font-medium text-gray-dark/60 mb-2">
+              <p className="text-xs font-medium text-night/60 mb-2">
                 {t('importedPhotos', { count: form.external_photo_urls.length })}
               </p>
               <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
                 {form.external_photo_urls.map((url, i) => (
-                  <div key={url} className="relative aspect-[4/3] rounded-lg overflow-hidden bg-gray-light">
+                  <div key={url} className="relative aspect-[4/3] rounded-lg overflow-hidden bg-parchment">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={url}
@@ -704,7 +704,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
               />
               <label
                 htmlFor="photo-upload"
-                className={`inline-flex items-center gap-2 px-4 py-2.5 border-2 border-dashed border-gray-200 rounded-lg text-sm text-gray-dark/60 hover:border-yellow/60 hover:text-navy cursor-pointer transition-colors ${uploading ? 'opacity-50 pointer-events-none' : ''}`}
+                className={`inline-flex items-center gap-2 px-4 py-2.5 border-2 border-dashed border-gray-200 rounded-lg text-sm text-night/60 hover:border-yellow/60 hover:text-night cursor-pointer transition-colors ${uploading ? 'opacity-50 pointer-events-none' : ''}`}
               >
                 {uploading ? (
                   <>
@@ -723,7 +723,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
                   </>
                 )}
               </label>
-              <p className="mt-1.5 text-xs text-gray-dark/50">
+              <p className="mt-1.5 text-xs text-night/50">
                 {photoLimit === null ? t('photosHintUnlimited') : t('photosHint')}
               </p>
             </div>
@@ -738,7 +738,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
       {/* Amenities */}
       {amenities.length > 0 && (
         <section>
-          <h2 className="font-heading font-semibold text-navy mb-4 text-sm uppercase tracking-wider">
+          <h2 className="font-display font-semibold text-night mb-4 text-sm uppercase tracking-wider">
             {t('amenitiesSection')}
           </h2>
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
@@ -750,7 +750,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
                   onChange={() => toggleAmenity(amenity.amenity_id)}
                   className="w-4 h-4 accent-yellow"
                 />
-                <span className="text-sm text-gray-dark">{amenity.name}</span>
+                <span className="text-sm text-night">{amenity.name}</span>
               </label>
             ))}
           </div>
@@ -766,7 +766,7 @@ export default function ListingForm({ initialValues = {}, onSubmit, submitLabel 
       <button
         type="submit"
         disabled={loading}
-        className="w-full sm:w-auto bg-yellow text-white font-heading font-semibold px-8 py-3 rounded-lg hover:bg-yellow/90 transition-colors disabled:opacity-50"
+        className="w-full sm:w-auto bg-yellow text-white font-display font-semibold px-8 py-3 rounded-lg hover:bg-yellow/90 transition-colors disabled:opacity-50"
       >
         {loading ? t('saving') : (submitLabel || t('saveListing'))}
       </button>

--- a/src/components/ListingsMap.js
+++ b/src/components/ListingsMap.js
@@ -33,7 +33,7 @@ export default function ListingsMap({ listings }) {
   );
 
   return (
-    <div className="h-full w-full rounded-xl overflow-hidden border border-gray-200">
+    <div className="h-full w-full rounded-sm overflow-hidden border border-gray-200">
       <MapContainer
         center={THESSALONIKI_CENTER}
         zoom={DEFAULT_ZOOM}
@@ -48,7 +48,7 @@ export default function ListingsMap({ listings }) {
           <Marker key={listing.listing_id} position={[listing.lat, listing.lng]}>
             <Popup>
               <div className="text-sm min-w-[160px] max-w-[220px]">
-                <p className="font-semibold text-navy mb-0.5 line-clamp-2">
+                <p className="font-semibold text-night mb-0.5 line-clamp-2">
                   {listing.title || listing.address}
                 </p>
                 <p className="text-gray-600 text-xs mb-1">

--- a/src/components/SaveSearchModal.js
+++ b/src/components/SaveSearchModal.js
@@ -69,7 +69,7 @@ export default function SaveSearchModal({ filters, faculty, onClose }) {
     >
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-navy/40 backdrop-blur-sm"
+        className="absolute inset-0 bg-night/40 backdrop-blur-sm"
         onClick={onClose}
         aria-hidden="true"
       />
@@ -78,12 +78,12 @@ export default function SaveSearchModal({ filters, faculty, onClose }) {
       <div className="relative bg-white rounded-2xl shadow-xl w-full max-w-md p-6 z-10">
         <div className="flex items-start justify-between mb-5">
           <div>
-            <h2 className="font-heading text-xl font-bold text-navy">{t('title')}</h2>
-            <p className="text-sm text-gray-dark/60 mt-0.5">{t('desc')}</p>
+            <h2 className="font-display text-xl font-bold text-night">{t('title')}</h2>
+            <p className="text-sm text-night/60 mt-0.5">{t('desc')}</p>
           </div>
           <button
             onClick={onClose}
-            className="text-gray-dark/40 hover:text-gray-dark/70 transition-colors cursor-pointer ml-4 shrink-0"
+            className="text-night/40 hover:text-night/70 transition-colors cursor-pointer ml-4 shrink-0"
             aria-label="Close"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -99,11 +99,11 @@ export default function SaveSearchModal({ filters, faculty, onClose }) {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
               </svg>
             </div>
-            <p className="font-heading text-lg font-semibold text-navy mb-1">{t('successTitle')}</p>
-            <p className="text-sm text-gray-dark/60">{t('successDesc')}</p>
+            <p className="font-display text-lg font-semibold text-night mb-1">{t('successTitle')}</p>
+            <p className="text-sm text-night/60">{t('successDesc')}</p>
             <button
               onClick={onClose}
-              className="mt-5 w-full py-2.5 rounded-lg bg-navy text-white font-heading font-semibold text-sm hover:bg-navy/90 transition-colors cursor-pointer"
+              className="mt-5 w-full py-2.5 rounded-lg bg-night text-white font-display font-semibold text-sm hover:bg-night/90 transition-colors cursor-pointer"
             >
               {t('done')}
             </button>
@@ -111,7 +111,7 @@ export default function SaveSearchModal({ filters, faculty, onClose }) {
         ) : (
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="block uppercase tracking-wider text-xs font-heading font-semibold text-gray-dark/50 mb-1.5">
+              <label className="block uppercase tracking-wider text-xs font-display font-semibold text-night/50 mb-1.5">
                 {t('emailLabel')} <span className="text-red-400">*</span>
               </label>
               <input
@@ -120,12 +120,12 @@ export default function SaveSearchModal({ filters, faculty, onClose }) {
                 value={form.email}
                 onChange={(e) => setForm((p) => ({ ...p, email: e.target.value }))}
                 placeholder={t('emailPlaceholder')}
-                className="w-full rounded-lg border border-gray-200 bg-gray-light px-3 py-2.5 text-sm text-gray-dark focus:outline-none focus:ring-2 focus:ring-yellow/50 focus:border-yellow"
+                className="w-full rounded-lg border border-gray-200 bg-parchment px-3 py-2.5 text-sm text-night focus:outline-none focus:ring-2 focus:ring-yellow/50 focus:border-yellow"
               />
             </div>
 
             <div>
-              <label className="block uppercase tracking-wider text-xs font-heading font-semibold text-gray-dark/50 mb-1.5">
+              <label className="block uppercase tracking-wider text-xs font-display font-semibold text-night/50 mb-1.5">
                 {t('labelLabel')}
               </label>
               <input
@@ -134,12 +134,12 @@ export default function SaveSearchModal({ filters, faculty, onClose }) {
                 onChange={(e) => setForm((p) => ({ ...p, label: e.target.value }))}
                 placeholder={t('labelPlaceholder')}
                 maxLength={80}
-                className="w-full rounded-lg border border-gray-200 bg-gray-light px-3 py-2.5 text-sm text-gray-dark focus:outline-none focus:ring-2 focus:ring-yellow/50 focus:border-yellow"
+                className="w-full rounded-lg border border-gray-200 bg-parchment px-3 py-2.5 text-sm text-night focus:outline-none focus:ring-2 focus:ring-yellow/50 focus:border-yellow"
               />
             </div>
 
             <div>
-              <label className="block uppercase tracking-wider text-xs font-heading font-semibold text-gray-dark/50 mb-1.5">
+              <label className="block uppercase tracking-wider text-xs font-display font-semibold text-night/50 mb-1.5">
                 {t('frequencyLabel')}
               </label>
               <div className="flex gap-2">
@@ -148,7 +148,7 @@ export default function SaveSearchModal({ filters, faculty, onClose }) {
                     key={freq}
                     type="button"
                     onClick={() => setForm((p) => ({ ...p, frequency: freq }))}
-                    className={`flex-1 py-2 rounded-lg text-sm border transition-colors cursor-pointer ${form.frequency === freq ? 'border-yellow bg-yellow/10 text-yellow font-medium' : 'border-gray-200 text-gray-dark/60 hover:border-yellow/40'}`}
+                    className={`flex-1 py-2 rounded-lg text-sm border transition-colors cursor-pointer ${form.frequency === freq ? 'border-yellow bg-yellow/10 text-yellow font-medium' : 'border-gray-200 text-night/60 hover:border-yellow/40'}`}
                   >
                     {t(freq)}
                   </button>
@@ -163,7 +163,7 @@ export default function SaveSearchModal({ filters, faculty, onClose }) {
             <button
               type="submit"
               disabled={submitting}
-              className="w-full py-3 rounded-lg bg-yellow text-white font-heading font-semibold text-sm hover:bg-yellow/90 transition-colors cursor-pointer disabled:opacity-60"
+              className="w-full py-3 rounded-lg bg-yellow text-white font-display font-semibold text-sm hover:bg-yellow/90 transition-colors cursor-pointer disabled:opacity-60"
             >
               {submitting ? t('saving') : t('submit')}
             </button>

--- a/src/components/listing/ContactGate.js
+++ b/src/components/listing/ContactGate.js
@@ -2,7 +2,6 @@ import { getTranslations } from 'next-intl/server';
 import { Link } from '@/i18n/navigation';
 import Card from '@/components/ui/Card';
 import Icon from '@/components/ui/Icon';
-import Pill from '@/components/ui/Pill';
 import AuthGateRescue from '@/components/AuthGateRescue';
 import { hasAuthCookie } from '@/lib/requireStudent';
 
@@ -34,9 +33,6 @@ export default async function ContactGate({ listing, locale, fromRaw }) {
               </span>
             )}
           </p>
-          <div className="mt-2">
-            <Pill variant="programme">{t('authMedicalProgramme')}</Pill>
-          </div>
           <p className="mt-5 text-night/70 text-sm leading-relaxed">
             {t('directTagline')}
           </p>

--- a/src/components/listing/ContactRail.js
+++ b/src/components/listing/ContactRail.js
@@ -7,7 +7,6 @@ import { useAccessToken } from '@/lib/useAccessToken';
 
 import Button from '@/components/ui/Button';
 import Card from '@/components/ui/Card';
-import Pill from '@/components/ui/Pill';
 import Icon from '@/components/ui/Icon';
 
 const ERROR_TO_KEY = {
@@ -102,9 +101,6 @@ export default function ContactRail({ listing }) {
                 </span>
               )}
             </p>
-            <div className="mt-2">
-              <Pill variant="programme">{t('authMedicalProgramme')}</Pill>
-            </div>
             <p className="mt-5 text-night/70 text-sm leading-relaxed">
               {t('directTagline')}
             </p>

--- a/src/components/property/ThessalonikiLanding.js
+++ b/src/components/property/ThessalonikiLanding.js
@@ -65,9 +65,7 @@ export default function ThessalonikiLanding() {
         <div className="relative mx-auto max-w-6xl px-5 pt-20 pb-24 md:pt-28 md:pb-32">
           <p className="label-caps text-yellow mb-8">{t('eyebrow')}</p>
           <h1 className="font-display text-4xl md:text-6xl lg:text-[4.5rem] leading-[1.05] max-w-3xl text-night">
-            {t('heroBefore')}{' '}
-            <span className="italic text-yellow">{t('heroItalic')}</span>{' '}
-            {t('heroAfter')}
+            {t('headline')}
           </h1>
           <p className="mt-6 max-w-xl text-night/70 text-lg md:text-xl leading-relaxed">
             {t('subtitle')}

--- a/src/components/ui/ConfirmDialog.js
+++ b/src/components/ui/ConfirmDialog.js
@@ -1,0 +1,122 @@
+'use client';
+
+import { useEffect, useId, useRef } from 'react';
+
+/*
+  Accessible confirm dialog — replaces native window.confirm() for
+  destructive in-app actions.
+
+  - Centered card on a dimmed night backdrop, parchment-toned surface.
+  - Focus-trapped: Tab/Shift+Tab cycle within the dialog; focus lands on
+    the Cancel button on open (safe default for destructive flows) and is
+    restored to the previously-focused element on close.
+  - Esc closes (mapped to onCancel). Backdrop click closes too, unless busy.
+  - `destructive` renders the confirm button in red.
+
+  Render conditionally by the parent (i.e. `{open && <ConfirmDialog … />}`)
+  or pass `open` — both work; the component no-ops when `open === false`.
+*/
+export default function ConfirmDialog({
+  open = true,
+  title,
+  body,
+  confirmLabel,
+  cancelLabel,
+  onConfirm,
+  onCancel,
+  busy = false,
+  destructive = false,
+}) {
+  const dialogRef = useRef(null);
+  const cancelRef = useRef(null);
+  const titleId = useId();
+
+  // Trap focus, wire Esc, and restore focus to the trigger on unmount.
+  useEffect(() => {
+    if (!open) return undefined;
+    const previouslyFocused = document.activeElement;
+    // Defer initial focus to after paint so the node exists.
+    cancelRef.current?.focus();
+
+    function onKeyDown(e) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        if (!busy) onCancel?.();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const node = dialogRef.current;
+      if (!node) return;
+      const focusable = node.querySelectorAll(
+        'button:not([disabled]), [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      if (previouslyFocused instanceof HTMLElement) previouslyFocused.focus();
+    };
+  }, [open, busy, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-night/60"
+        onClick={() => (busy ? null : onCancel?.())}
+        aria-hidden="true"
+      />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="relative z-10 w-full max-w-md rounded-sm border border-night/10 bg-parchment text-night p-6 md:p-7"
+      >
+        <h2
+          id={titleId}
+          className="font-display text-2xl text-night leading-tight"
+        >
+          {title}
+        </h2>
+        <p className="mt-3 text-sm text-night/70 leading-relaxed">{body}</p>
+
+        <div className="mt-7 flex flex-col-reverse sm:flex-row sm:justify-end gap-3">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={() => onCancel?.()}
+            disabled={busy}
+            className="label-caps px-4 py-2.5 rounded-sm border border-night/20 text-night/70 hover:border-night hover:text-night transition-colors disabled:opacity-50"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm?.()}
+            disabled={busy}
+            className={`label-caps px-4 py-2.5 rounded-sm text-white transition-colors disabled:opacity-50 ${
+              destructive
+                ? 'bg-red-600 hover:bg-red-700'
+                : 'bg-blue hover:bg-night'
+            }`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Pill.js
+++ b/src/components/ui/Pill.js
@@ -1,17 +1,17 @@
 /*
-  Propylaea Pill — small labels for amenities, programme tags, verified seals.
+  Propylaea Pill — small labels for amenities, statuses, verified seals.
   Variants:
     - verified  : Gold seal pill, reserved for VERIFIED and Aristotle partner marks
-    - programme : Blue outline — AUTH PROGRAMME tag
-    - amenity   : Parchment chip, used for amenities and bills-included
-    - info      : Blue filled info chip
+    - pending   : Magenta fill — unactioned state (e.g. a new, unanswered inquiry)
+    - amenity   : Parchment chip, used for amenities, bills-included, closed states
+    - info      : Blue filled info chip, used for replied/answered states
     - onDark    : Stone outline for dark surfaces
 */
 const VARIANTS = {
   verified:
     'bg-yellow text-white border border-yellow',
-  programme:
-    'border border-blue text-blue bg-transparent',
+  pending:
+    'bg-magenta text-white border border-magenta',
   amenity:
     'bg-parchment text-night border border-parchment',
   info:

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -258,6 +258,9 @@
       "listingColumn": "Listing",
       "view": "View",
       "deleteConfirm": "Delete this listing? This cannot be undone.",
+      "deleteTitle": "Delete listing",
+      "deleteBody": "Delete {address}? This permanently removes the listing and its inquiries. This cannot be undone.",
+      "cancel": "Cancel",
       "deleteError": "Failed to delete listing. Please try again.",
       "featuredError": "Failed to update featured status.",
       "noAddress": "No address",
@@ -430,9 +433,7 @@
   "propylaea": {
     "landing": {
       "eyebrow": "Ἀριστοτέλειον",
-      "heroBefore": "your home",
-      "heroItalic": "near",
-      "heroAfter": "campus.",
+      "headline": "Curated student housing in Thessaloniki.",
       "subtitle": "Curated student housing for medical students. Tell us what you need and we match you.",
       "ctaPrimary": "Take the quiz",
       "ctaSecondary": "Browse all listings",
@@ -545,8 +546,8 @@
       "minDurationAcademicName": "Academic year",
       "minDurationAcademicMonths": "9 mo",
       "verified": "Verified",
+      "verifiedLandlordsOnly": "Verified landlords only",
       "billsIncluded": "Bills included",
-      "authProgramme": "AUTh programme",
       "floorNotSpecified": "Floor not specified",
       "dealbreakers": "Your dealbreakers",
       "removeDealbreaker": "Remove {label}",
@@ -556,7 +557,6 @@
     },
     "listing": {
       "back": "Back to results",
-      "authMedicalProgramme": "AUTh Medical Programme",
       "verified": "Verified",
       "streetAddressA11y": "Street address",
       "rentGreek": "Ενοίκιο",


### PR DESCRIPTION
Eight small, independent foundational cleanups. Lint + test (168) + build all pass.

## Changes
1. **Remove the AUTH PROGRAMME pill.** Dropped the `programme` Pill variant and every render site (ListingCard, listing detail hero, ContactGate, ContactRail), plus the now-orphaned `authProgramme` / `authMedicalProgramme` i18n keys and unused `Pill` imports.
2. **Palette is canonical iris.** Corrected the stale palette/type line in `CLAUDE.md` to the real Stripe-iris tokens, and swept legacy aliases (`navy`, `gray-dark`, `gray-light`, `font-heading`, `rounded-xl`) → canonical tokens (`night`, `parchment`, `blue`, `font-display`, `rounded-sm`) across 9 files.
3. **`budget_min = 250`.** Results slider floor 150 → 250, matching the quiz (already 250).
4. **`pending` Pill variant + inquiry ladder.** New = `pending` (magenta), Replied = `info` (blue), Closed = `amenity` (parchment) — fixed the gold `verified` misuse for New in both the landlord inbox and dashboard.
5. **Dashboard inquiry link fix.** Recent-inquiry cards now deep-link to `…/landlord/inquiries/{id}/chat` instead of the inbox index.
6. **In-app delete dialog.** New focus-trapped `ConfirmDialog` (centered card, night/parchment, Esc to close, names the listing address, red destructive button + Cancel) replaces native `confirm()` on listing delete.
7. **City landing headline.** Thessaloniki landing → "Curated student housing in Thessaloniki."
8. **Relabel toggle.** Results "Verified only" → "Verified landlords only" (it filters by landlord verification).

## Verification
- `npm run lint` — 0 errors (1 pre-existing warning in `cf/worker-entry.mjs`).
- `npm run test` — 168/168 pass.
- `npm run build` — compiles successfully.
- Dev-server smoke test: `/property/thessaloniki` (headline confirmed), `/results` ("Verified landlords only" confirmed), `/landlord/dashboard`, and a listing detail page (programme pill gone) all return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)