### PR TITLE
feat(favorites): student shortlist — heart toggle, /api/me/favorites, Saved panel

### DIFF
--- a/__tests__/api/meFavorites.test.js
+++ b/__tests__/api/meFavorites.test.js
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mocks set up before SUT import; reset in beforeEach so each test wires
+// its own behavior. Mirrors __tests__/api/meUnread.test.js.
+const extractToken = vi.fn();
+const getUserFromToken = vi.fn();
+const getSupabaseWithToken = vi.fn();
+
+vi.mock('@/lib/supabaseServer', () => ({
+  extractToken: (...args) => extractToken(...args),
+  getUserFromToken: (...args) => getUserFromToken(...args),
+  getSupabaseWithToken: (...args) => getSupabaseWithToken(...args),
+}));
+
+const { GET, POST, DELETE } = await import('@/app/api/me/favorites/route');
+
+// Fluent-builder mock for a supabase table. Terminal value resolves on
+// await (via then) or maybeSingle(). Captures select/eq/insert/delete/order
+// calls so tests can assert the route issued the right PostgREST query.
+function table(terminalData) {
+  const calls = { select: [], eq: [], insert: [], delete: [], order: [] };
+  const chain = {
+    calls,
+    select: (...a) => { calls.select.push(a); return chain; },
+    eq: (...a) => { calls.eq.push(a); return chain; },
+    insert: (...a) => { calls.insert.push(a); return chain; },
+    delete: (...a) => { calls.delete.push(a); return chain; },
+    order: (...a) => { calls.order.push(a); return chain; },
+    maybeSingle: () => Promise.resolve(terminalData),
+    then: (onFulfilled) => Promise.resolve(terminalData).then(onFulfilled),
+  };
+  return chain;
+}
+
+// Build a supabase client whose students lookup + student_favorites table
+// behave as configured. `student` = the row returned by the students probe
+// (null → not a student). `favTerminal` = what the student_favorites chain
+// resolves to (for insert/delete/select).
+function client({ student = { student_id: 's-1' }, favTerminal = { data: [], error: null } } = {}) {
+  const tables = {};
+  const sb = {
+    tables,
+    from(name) {
+      if (name === 'students') return table({ data: student });
+      if (name === 'student_favorites') {
+        tables.favorites = table(favTerminal);
+        return tables.favorites;
+      }
+      throw new Error(`unexpected table: ${name}`);
+    },
+  };
+  return sb;
+}
+
+// GET/DELETE read no body; POST reads request.json(). The route also reads
+// request.url for the DELETE query param.
+const req = ({ url = 'https://x/api/me/favorites', body } = {}) => ({
+  headers: { get: () => null },
+  url,
+  json: () => Promise.resolve(body ?? {}),
+});
+
+beforeEach(() => {
+  extractToken.mockReset();
+  getUserFromToken.mockReset();
+  getSupabaseWithToken.mockReset();
+});
+
+describe('/api/me/favorites auth gating', () => {
+  it('GET returns 401 when no token is present', async () => {
+    extractToken.mockReturnValue(null);
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+    expect(getUserFromToken).not.toHaveBeenCalled();
+  });
+
+  it('GET returns 401 when the token is invalid', async () => {
+    extractToken.mockReturnValue('bad');
+    getUserFromToken.mockResolvedValue(null);
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+    expect(getSupabaseWithToken).not.toHaveBeenCalled();
+  });
+
+  it('GET returns 401 when the caller is signed in but not a student', async () => {
+    extractToken.mockReturnValue('t');
+    getUserFromToken.mockResolvedValue({ id: 'u-land' });
+    getSupabaseWithToken.mockReturnValue(client({ student: null }));
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+
+  it('POST returns 401 when not signed in as a student', async () => {
+    extractToken.mockReturnValue('t');
+    getUserFromToken.mockResolvedValue({ id: 'u-land' });
+    getSupabaseWithToken.mockReturnValue(client({ student: null }));
+    const res = await POST(req({ body: { listing_id: '1234567' } }));
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/me/favorites', () => {
+  it('returns the student favourites and sets no-store', async () => {
+    extractToken.mockReturnValue('t');
+    getUserFromToken.mockResolvedValue({ id: 'u-1' });
+    const rows = [
+      { listing_id: '1234567', created_at: '2026-01-02T00:00:00Z' },
+      { listing_id: '7654321', created_at: '2026-01-01T00:00:00Z' },
+    ];
+    const sb = client({ favTerminal: { data: rows, error: null } });
+    getSupabaseWithToken.mockReturnValue(sb);
+
+    const res = await GET(req());
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json).toEqual({ favorites: rows });
+    expect(res.headers.get('cache-control')).toBe('private, no-store');
+    // Scoped to the caller's student_id, newest first.
+    expect(sb.tables.favorites.calls.eq).toEqual([['student_id', 's-1']]);
+    expect(sb.tables.favorites.calls.order).toEqual([
+      ['created_at', { ascending: false }],
+    ]);
+  });
+
+  it('returns 500 when the favourites read errors', async () => {
+    extractToken.mockReturnValue('t');
+    getUserFromToken.mockResolvedValue({ id: 'u-1' });
+    getSupabaseWithToken.mockReturnValue(
+      client({ favTerminal: { data: null, error: { message: 'boom' } } }),
+    );
+    const res = await GET(req());
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('POST /api/me/favorites', () => {
+  it('rejects a malformed listing_id with 400', async () => {
+    extractToken.mockReturnValue('t');
+    getUserFromToken.mockResolvedValue({ id: 'u-1' });
+    getSupabaseWithToken.mockReturnValue(client());
+    const res = await POST(req({ body: { listing_id: 'not-an-id' } }));
+    expect(res.status).toBe(400);
+  });
+
+  it('inserts the favourite scoped to the caller and returns 201', async () => {
+    extractToken.mockReturnValue('t');
+    getUserFromToken.mockResolvedValue({ id: 'u-1' });
+    const sb = client({ favTerminal: { error: null } });
+    getSupabaseWithToken.mockReturnValue(sb);
+
+    const res = await POST(req({ body: { listing_id: '1234567' } }));
+    expect(res.status).toBe(201);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    // student_id comes from the server-side students probe, never the body.
+    expect(sb.tables.favorites.calls.insert).toEqual([
+      [{ student_id: 's-1', listing_id: '1234567' }],
+    ]);
+  });
+
+  it('treats a duplicate (unique violation) as idempotent success', async () => {
+    extractToken.mockReturnValue('t');
+    getUserFromToken.mockResolvedValue({ id: 'u-1' });
+    getSupabaseWithToken.mockReturnValue(
+      client({ favTerminal: { error: { code: '23505' } } }),
+    );
+    const res = await POST(req({ body: { listing_id: '1234567' } }));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true, already: true });
+  });
+
+  it('maps a foreign-key violation to 404 (listing missing)', async () => {
+    extractToken.mockReturnValue('t');
+    getUserFromToken.mockResolvedValue({ id: 'u-1' });
+    getSupabaseWithToken.mockReturnValue(
+      client({ favTerminal: { error: { code: '23503' } } }),
+    );
+    const res = await POST(req({ body: { listing_id: '1234567' } }));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/me/favorites', () => {
+  it('rejects a malformed listing_id with 400', async () => {
+    extractToken.mockReturnValue('t');
+    getUserFromToken.mockResolvedValue({ id: 'u-1' });
+    getSupabaseWithToken.mockReturnValue(client());
+    const res = await DELETE(req({ url: 'https://x/api/me/favorites?listing_id=nope' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('deletes the favourite scoped to caller + listing and returns ok', async () => {
+    extractToken.mockReturnValue('t');
+    getUserFromToken.mockResolvedValue({ id: 'u-1' });
+    const sb = client({ favTerminal: { error: null } });
+    getSupabaseWithToken.mockReturnValue(sb);
+
+    const res = await DELETE(
+      req({ url: 'https://x/api/me/favorites?listing_id=1234567' }),
+    );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    expect(sb.tables.favorites.calls.delete).toEqual([[]]);
+    expect(sb.tables.favorites.calls.eq).toEqual([
+      ['student_id', 's-1'],
+      ['listing_id', '1234567'],
+    ]);
+  });
+});

--- a/src/app/[locale]/layout.js
+++ b/src/app/[locale]/layout.js
@@ -5,6 +5,7 @@ import { notFound } from 'next/navigation';
 import { routing } from '@/i18n/routing';
 import Navbar from '@/components/Navbar';
 import SessionSync from '@/components/SessionSync';
+import FavoritesProvider from '@/components/FavoritesProvider';
 import '../globals.css';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://studentx.uk';
@@ -83,8 +84,10 @@ export default async function LocaleLayout({ children, params }) {
       <body className="min-h-full flex flex-col font-sans bg-stone text-night">
         <NextIntlClientProvider locale={locale} messages={messages}>
           <SessionSync />
-          <Navbar />
-          <main className="flex-1">{children}</main>
+          <FavoritesProvider>
+            <Navbar />
+            <main className="flex-1">{children}</main>
+          </FavoritesProvider>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/src/app/[locale]/property/[city]/listing/[id]/page.js
+++ b/src/app/[locale]/property/[city]/listing/[id]/page.js
@@ -9,6 +9,7 @@ import { requireStudent } from '@/lib/requireStudent';
 import ContactRail from '@/components/listing/ContactRail';
 import ContactGate from '@/components/listing/ContactGate';
 import ViewTracker from '@/components/listing/ViewTracker';
+import FavoriteButton from '@/components/FavoriteButton';
 import Pill from '@/components/ui/Pill';
 import Card from '@/components/ui/Card';
 import Icon from '@/components/ui/Icon';
@@ -114,6 +115,14 @@ export default async function ListingPage({ params, searchParams }) {
                 </p>
               )}
             </div>
+
+            {/* Save / shortlist toggle. Renders for everyone — a
+                signed-out tap opens the sign-in gate (FavoritesProvider). */}
+            <FavoriteButton
+              listingId={listing.listing_id}
+              withLabel
+              className="md:self-start shrink-0"
+            />
           </div>
 
           {/* Bilingual field grid */}

--- a/src/app/[locale]/student/account/page.js
+++ b/src/app/[locale]/student/account/page.js
@@ -3,9 +3,11 @@ import { redirect } from 'next/navigation';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { Link } from '@/i18n/navigation';
 import { requireStudent } from '@/lib/requireStudent';
+import { transformListing } from '@/lib/transformListing';
 import Card from '@/components/ui/Card';
 import Icon from '@/components/ui/Icon';
 import SignOutButton from '@/components/student/SignOutButton';
+import SavedListings from '@/components/student/SavedListings';
 
 function formatDate(iso) {
   if (!iso) return '';
@@ -41,26 +43,112 @@ export default async function StudentAccountPage({ params }) {
   }
 
   const t = await getTranslations({ locale, namespace: 'student.account' });
+  const tFav = await getTranslations({ locale, namespace: 'student.favorites' });
   const { student } = auth;
 
   // Page shell renders synchronously — the user sees their name and the
-  // chrome on the first byte. The inquiry SELECT streams in via the
-  // <Suspense> boundary below; the inquiries query joins listings →
-  // location, rent and is the single slowest thing on this page, so
-  // moving it off the critical path noticeably cuts perceived post-login
-  // latency.
+  // chrome on the first byte. The saved-listings and inquiry SELECTs each
+  // stream in via their own <Suspense> boundary below; both join listings →
+  // location, rent and are the slowest things on this page, so keeping them
+  // off the critical path cuts perceived post-login latency.
   return (
     <div className="mx-auto max-w-3xl px-5 py-12 md:py-16">
       <div className="flex items-start justify-between gap-4 mb-2">
         <p className="label-caps text-yellow">{t('eyebrow')}</p>
         <SignOutButton />
       </div>
-      <h1 className="font-display text-3xl md:text-4xl text-night mb-2">{t('title')}</h1>
+      <h1 className="font-display text-3xl md:text-4xl text-night mb-2">{t('heading')}</h1>
       <p className="text-night/60 mb-10">{student.display_name} · {student.email}</p>
 
-      <Suspense fallback={<InquiriesSkeleton />}>
-        <InquiriesSection locale={locale} />
-      </Suspense>
+      {/* Saved / shortlist */}
+      <section className="mb-12">
+        <h2 className="font-display text-2xl text-night mb-5">{tFav('panelTitle')}</h2>
+        <Suspense fallback={<SavedSkeleton />}>
+          <SavedSection locale={locale} />
+        </Suspense>
+      </section>
+
+      {/* Inquiries */}
+      <section>
+        <h2 className="font-display text-2xl text-night mb-5">{t('title')}</h2>
+        <Suspense fallback={<InquiriesSkeleton />}>
+          <InquiriesSection locale={locale} />
+        </Suspense>
+      </section>
+    </div>
+  );
+}
+
+async function SavedSection({ locale }) {
+  // requireStudent is React.cache()'d, so this resolves from the
+  // per-request cache populated by the page shell — no extra round-trip.
+  const auth = await requireStudent();
+  if (!auth || auth.kind === 'wrong-role') return null;
+
+  const t = await getTranslations({ locale, namespace: 'student.favorites' });
+  const { supabase, student } = auth;
+
+  // RLS already restricts student_favorites to the caller's rows; the
+  // explicit student_id eq makes intent clear and uses the PK index. The
+  // nested embed pulls everything ListingCard needs in one query, matching
+  // transformListing's expected shape.
+  const { data, error } = await supabase
+    .from('student_favorites')
+    .select(`
+      listing_id,
+      created_at,
+      listings (
+        listing_id,
+        is_featured,
+        title,
+        description,
+        photos,
+        floor,
+        min_duration_months,
+        rent ( monthly_price, currency, bills_included, deposit ),
+        location ( address, neighborhood, lat, lng ),
+        property_types ( name ),
+        landlords ( name, contact_info, verified_tier, is_verified ),
+        listing_amenities ( amenities ( amenity_id, name ) ),
+        faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
+      )
+    `)
+    .eq('student_id', student.student_id)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return (
+      <p className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-sm px-4 py-3">
+        {t('loadError')}
+      </p>
+    );
+  }
+
+  // PostgREST returns the to-one listings embed as an object; guard for an
+  // array form and for rows whose listing was removed mid-flight.
+  const listings = (data ?? [])
+    .map((row) => (Array.isArray(row.listings) ? row.listings[0] : row.listings))
+    .filter(Boolean)
+    .map(transformListing);
+
+  return <SavedListings listings={listings} />;
+}
+
+function SavedSkeleton() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-5" aria-busy="true">
+      {[0, 1].map((i) => (
+        <div
+          key={i}
+          className="rounded-sm border border-night/10 bg-white overflow-hidden"
+        >
+          <div className="aspect-[4/3] bg-parchment animate-pulse" />
+          <div className="p-5 space-y-3">
+            <div className="h-3 w-28 bg-parchment rounded animate-pulse" />
+            <div className="h-5 w-3/4 bg-parchment rounded animate-pulse" />
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/app/api/me/favorites/route.js
+++ b/src/app/api/me/favorites/route.js
@@ -1,0 +1,136 @@
+import { NextResponse } from 'next/server';
+import { extractToken, getUserFromToken, getSupabaseWithToken } from '@/lib/supabaseServer';
+
+// Per-user data — never cache.
+const NO_STORE = { 'Cache-Control': 'private, no-store' };
+
+// listings.listing_id is a 7-digit text PK (migration 001). Reject
+// anything else before it reaches the DB / RLS layer.
+const LISTING_ID_RE = /^\d{7}$/;
+
+function unauthenticated() {
+  return NextResponse.json(
+    { error: 'UNAUTHENTICATED' },
+    { status: 401, headers: NO_STORE },
+  );
+}
+
+/**
+ * Resolve the caller to a student row from the Bearer token. Returns
+ * either { supabase, studentId } (token-scoped client + the caller's
+ * students PK) or { error } — a ready-to-return 401 — when there's no
+ * token, the token is invalid, or the caller isn't a student (e.g. a
+ * landlord). Mirrors the auth shape of /api/me/unread.
+ */
+async function resolveStudent(request) {
+  const token = extractToken(request);
+  if (!token) return { error: unauthenticated() };
+
+  const user = await getUserFromToken(token);
+  if (!user) return { error: unauthenticated() };
+
+  const supabase = getSupabaseWithToken(token);
+  const { data: student } = await supabase
+    .from('students')
+    .select('student_id')
+    .eq('auth_user_id', user.id)
+    .maybeSingle();
+
+  if (!student) return { error: unauthenticated() };
+  return { supabase, studentId: student.student_id };
+}
+
+// GET — list the signed-in student's favourites, newest first.
+export async function GET(request) {
+  const ctx = await resolveStudent(request);
+  if (ctx.error) return ctx.error;
+
+  const { data, error } = await ctx.supabase
+    .from('student_favorites')
+    .select('listing_id, created_at')
+    .eq('student_id', ctx.studentId)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return NextResponse.json(
+      { error: 'FETCH_FAILED' },
+      { status: 500, headers: NO_STORE },
+    );
+  }
+
+  return NextResponse.json({ favorites: data ?? [] }, { headers: NO_STORE });
+}
+
+// POST { listing_id } — add a favourite. Idempotent: re-hearting an
+// already-saved listing returns ok rather than surfacing the unique
+// violation.
+export async function POST(request) {
+  const ctx = await resolveStudent(request);
+  if (ctx.error) return ctx.error;
+
+  const body = await request.json().catch(() => ({}));
+  const listingId = typeof body.listing_id === 'string' ? body.listing_id.trim() : '';
+  if (!LISTING_ID_RE.test(listingId)) {
+    return NextResponse.json(
+      { error: 'INVALID_LISTING_ID' },
+      { status: 400, headers: NO_STORE },
+    );
+  }
+
+  const { error } = await ctx.supabase
+    .from('student_favorites')
+    .insert({ student_id: ctx.studentId, listing_id: listingId });
+
+  if (error) {
+    if (error.code === '23505') {
+      // unique_violation — already shortlisted. Treat as success.
+      return NextResponse.json({ ok: true, already: true }, { headers: NO_STORE });
+    }
+    if (error.code === '23503') {
+      // foreign_key_violation — the listing doesn't exist.
+      return NextResponse.json(
+        { error: 'LISTING_NOT_FOUND' },
+        { status: 404, headers: NO_STORE },
+      );
+    }
+    return NextResponse.json(
+      { error: 'SAVE_FAILED' },
+      { status: 500, headers: NO_STORE },
+    );
+  }
+
+  return NextResponse.json({ ok: true }, { status: 201, headers: NO_STORE });
+}
+
+// DELETE ?listing_id=… — remove a favourite. The id rides in the query
+// string (not a body) so the request stays body-less, which is the
+// safest shape for DELETE across the Workers runtime. RLS already binds
+// the delete to the caller's rows; the explicit student_id eq is
+// belt-and-braces and lets the planner use the PK index.
+export async function DELETE(request) {
+  const ctx = await resolveStudent(request);
+  if (ctx.error) return ctx.error;
+
+  const listingId = (new URL(request.url).searchParams.get('listing_id') || '').trim();
+  if (!LISTING_ID_RE.test(listingId)) {
+    return NextResponse.json(
+      { error: 'INVALID_LISTING_ID' },
+      { status: 400, headers: NO_STORE },
+    );
+  }
+
+  const { error } = await ctx.supabase
+    .from('student_favorites')
+    .delete()
+    .eq('student_id', ctx.studentId)
+    .eq('listing_id', listingId);
+
+  if (error) {
+    return NextResponse.json(
+      { error: 'DELETE_FAILED' },
+      { status: 500, headers: NO_STORE },
+    );
+  }
+
+  return NextResponse.json({ ok: true }, { headers: NO_STORE });
+}

--- a/src/components/FavoriteButton.js
+++ b/src/components/FavoriteButton.js
@@ -1,0 +1,74 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import Icon from '@/components/ui/Icon';
+import { useFavorites } from '@/components/FavoritesProvider';
+
+/*
+  Heart / save toggle for a single listing. Two looks:
+
+    - default (icon only) — a translucent pill that floats over the
+      ListingCard photo. Sits OUTSIDE the card's <Link> (as a sibling)
+      so it's not a button nested in an anchor; the click still needs
+      preventDefault/stopPropagation because the card is a large link.
+    - withLabel — an outlined button with text, for the listing detail
+      page hero.
+
+  State + persistence live in FavoritesProvider; this component is pure
+  presentation over isFavorited()/toggle().
+*/
+export default function FavoriteButton({ listingId, withLabel = false, className = '' }) {
+  const t = useTranslations('student.favorites');
+  const { isFavorited, toggle } = useFavorites();
+  const saved = isFavorited(listingId);
+
+  const ariaLabel = saved ? t('removeAria') : t('saveAria');
+
+  function handleClick(e) {
+    // The card itself is a link; don't navigate when the heart is tapped.
+    e.preventDefault();
+    e.stopPropagation();
+    toggle(listingId);
+  }
+
+  if (withLabel) {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        aria-pressed={saved}
+        aria-label={ariaLabel}
+        className={`inline-flex items-center gap-2 rounded-sm border px-4 py-2.5 font-sans font-semibold uppercase tracking-[0.08em] text-xs transition-colors ${
+          saved
+            ? 'border-magenta bg-magenta/5 text-magenta'
+            : 'border-night/20 text-night/70 hover:border-magenta hover:text-magenta'
+        } ${className}`}
+      >
+        <Icon
+          name="heart"
+          className="w-4 h-4"
+          fill={saved ? 'currentColor' : 'none'}
+        />
+        {saved ? t('saved') : t('save')}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-pressed={saved}
+      aria-label={ariaLabel}
+      className={`inline-flex items-center justify-center w-9 h-9 rounded-full bg-white/85 backdrop-blur-sm shadow-[0_1px_6px_-1px_rgba(10,20,54,0.3)] transition-all hover:bg-white hover:scale-105 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-magenta ${className}`}
+    >
+      <Icon
+        name="heart"
+        className={`w-[18px] h-[18px] transition-colors ${
+          saved ? 'text-magenta' : 'text-night/45'
+        }`}
+        fill={saved ? 'currentColor' : 'none'}
+      />
+    </button>
+  );
+}

--- a/src/components/FavoritesProvider.js
+++ b/src/components/FavoritesProvider.js
@@ -1,0 +1,236 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from 'react';
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/navigation';
+import { useAccessToken } from '@/lib/useAccessToken';
+import Card from '@/components/ui/Card';
+import Icon from '@/components/ui/Icon';
+
+/*
+  Client context backing the favourites / shortlist heart toggles.
+
+  Mounted once, high in the tree (src/app/[locale]/layout.js), so every
+  ListingCard heart on /results, the heart on the listing detail page,
+  and the Saved panel on /student/account all read and mutate one shared
+  Set of favourited listing ids. That keeps results-page cards from each
+  firing their own request and lets an unheart on the account page reflect
+  instantly everywhere.
+
+  Auth state comes from useAccessToken():
+    null  → session still resolving — clicks are ignored (sub-200ms window)
+    ''    → signed out — a heart click opens the sign-in gate
+    token → signed in — toggles hit /api/me/favorites optimistically
+
+  A logged-in non-student (a landlord) gets a 401 from the API; we roll
+  back the optimistic change and open the same gate.
+*/
+
+const NOOP = {
+  favorites: new Set(),
+  loaded: false,
+  isFavorited: () => false,
+  toggle: () => {},
+};
+
+const FavoritesContext = createContext(null);
+
+export function useFavorites() {
+  // Defensive: if a heart ever renders outside the provider (e.g. an
+  // isolated test) fall back to an inert object rather than throwing.
+  return useContext(FavoritesContext) ?? NOOP;
+}
+
+export default function FavoritesProvider({ children }) {
+  const token = useAccessToken();
+  const [favorites, setFavorites] = useState(() => new Set());
+  const [loaded, setLoaded] = useState(false);
+  const [gateOpen, setGateOpen] = useState(false);
+
+  // Per-listing in-flight guard so a double-click can't race itself.
+  const pendingRef = useRef(new Set());
+
+  // Load (or clear) the favourite set whenever auth state settles. All
+  // state writes live inside the async task so they run after commit
+  // rather than synchronously in the effect body.
+  useEffect(() => {
+    if (token === null) return; // still resolving — nothing to do yet
+
+    let cancelled = false;
+    (async () => {
+      // Signed out — drop any prior user's set.
+      if (token === '') {
+        if (!cancelled) {
+          setFavorites(new Set());
+          setLoaded(true);
+        }
+        return;
+      }
+      try {
+        const res = await fetch('/api/me/favorites', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const data = res.ok ? await res.json().catch(() => ({})) : {};
+        if (cancelled) return;
+        setFavorites(new Set((data.favorites || []).map((f) => f.listing_id)));
+        setLoaded(true);
+      } catch {
+        if (cancelled) return;
+        setFavorites(new Set());
+        setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const isFavorited = useCallback((id) => favorites.has(id), [favorites]);
+
+  const toggle = useCallback(async (id) => {
+    if (!token) {
+      // '' → explicit guest, open the gate. null → still loading, ignore.
+      if (token === '') setGateOpen(true);
+      return;
+    }
+    if (pendingRef.current.has(id)) return;
+    pendingRef.current.add(id);
+
+    // `favorites` is current here: toggle is recreated whenever it
+    // changes (see deps), and clicks only fire after commit.
+    const wasSaved = favorites.has(id);
+    setFavorites((prev) => {
+      const next = new Set(prev);
+      if (wasSaved) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+    const rollback = () =>
+      setFavorites((prev) => {
+        const next = new Set(prev);
+        if (wasSaved) next.add(id);
+        else next.delete(id);
+        return next;
+      });
+
+    try {
+      const res = wasSaved
+        ? await fetch(`/api/me/favorites?listing_id=${encodeURIComponent(id)}`, {
+            method: 'DELETE',
+            headers: { Authorization: `Bearer ${token}` },
+          })
+        : await fetch('/api/me/favorites', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ listing_id: id }),
+          });
+
+      if (!res.ok) {
+        rollback();
+        if (res.status === 401) setGateOpen(true);
+      }
+    } catch {
+      rollback();
+    } finally {
+      pendingRef.current.delete(id);
+    }
+  }, [token, favorites]);
+
+  const value = useMemo(
+    () => ({ favorites, loaded, isFavorited, toggle }),
+    [favorites, loaded, isFavorited, toggle],
+  );
+
+  return (
+    <FavoritesContext.Provider value={value}>
+      {children}
+      <FavoriteAuthGate open={gateOpen} onClose={() => setGateOpen(false)} />
+    </FavoritesContext.Provider>
+  );
+}
+
+/*
+  Sign-in gate shown when a signed-out visitor taps a heart. Same gate
+  the Contact flow uses — context-specific title/body plus the shared
+  student.gate sign-up / sign-in buttons that carry ?next= back to the
+  page they were on. Locale resolves via the client provider ('en').
+
+  Only rendered when open (post-click), so reading window.location for
+  the return path is hydration-safe and captures the full filtered URL
+  (pathname + query) without pulling useSearchParams high into the tree.
+*/
+function FavoriteAuthGate({ open, onClose }) {
+  const t = useTranslations('student.gate');
+  const tFav = useTranslations('student.favorites');
+
+  if (!open) return null;
+
+  const raw =
+    typeof window !== 'undefined'
+      ? window.location.pathname + window.location.search
+      : '';
+  const safeNext = raw.startsWith('/') ? raw : '';
+  const nextQuery = safeNext ? `?next=${encodeURIComponent(safeNext)}` : '';
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-night/60" onClick={onClose} />
+      <Card tone="white" className="relative z-10 w-full max-w-md p-8 text-center">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={tFav('close')}
+          className="absolute top-4 right-4 p-1 text-night/50 hover:text-night transition-colors"
+        >
+          <Icon name="x" className="w-5 h-5" />
+        </button>
+
+        <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-magenta/15 mb-5">
+          <Icon name="heart" className="w-6 h-6 text-magenta" fill="currentColor" />
+        </div>
+
+        <h2 className="font-display text-2xl text-night leading-tight mb-3">
+          {tFav('gateTitle')}
+        </h2>
+        <p className="text-night/70 leading-relaxed mb-8">{tFav('gateBody')}</p>
+
+        <div className="space-y-3">
+          <Link
+            href={`/student/signup${nextQuery}`}
+            className="inline-flex items-center justify-center w-full bg-blue text-white font-sans font-semibold uppercase tracking-[0.08em] text-xs px-5 py-3 rounded hover:bg-night transition-colors"
+          >
+            {t('signUp')}
+          </Link>
+          <Link
+            href={`/student/login${nextQuery}`}
+            className="inline-flex items-center justify-center w-full border border-blue text-blue font-sans font-semibold uppercase tracking-[0.08em] text-xs px-5 py-3 rounded hover:bg-blue hover:text-white transition-colors"
+          >
+            {t('signIn')}
+          </Link>
+        </div>
+
+        <p className="mt-6 text-sm text-night/50">
+          {t('landlordHint')}{' '}
+          <Link
+            href="/property/thessaloniki/landlord/login"
+            className="text-blue hover:text-night font-medium"
+          >
+            {t('landlordLink')} →
+          </Link>
+        </p>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/ListingCard.js
+++ b/src/components/ListingCard.js
@@ -3,6 +3,7 @@ import { useTranslations, useLocale } from 'next-intl';
 import { Link } from '@/i18n/navigation';
 import Pill from '@/components/ui/Pill';
 import Icon from '@/components/ui/Icon';
+import FavoriteButton from '@/components/FavoriteButton';
 import { variantUrl } from '@/lib/photoVariants';
 import { formatPropertyType } from '@/lib/propertyType';
 
@@ -38,74 +39,84 @@ export default function ListingCard({ listing, fromQuery = '', groundFloorDealbr
     : `/property/thessaloniki/listing/${listing.listing_id}`;
 
   return (
-    <Link
-      href={href}
-      className={`group block bg-white rounded-sm overflow-hidden transition-all focus-visible:outline-2 focus-visible:outline-yellow focus-visible:outline-offset-2 ${
-        isVerified
-          ? 'border-2 border-yellow/60 shadow-[0_0_12px_-2px_rgba(255,203,87,0.4)] hover:shadow-[0_0_18px_-2px_rgba(255,203,87,0.55)]'
-          : 'border border-night/10 hover:border-blue/40 hover:shadow-[0_2px_18px_-8px_rgba(10,20,54,0.25)]'
-      }`}
-    >
-      {/* Photo */}
-      <div className="relative aspect-[4/3] bg-parchment">
-        {isVerified && (
-          <span className="absolute top-3 right-3 z-10">
-            <Pill variant="verified">{tCard('verified')}</Pill>
-          </span>
-        )}
-        {photo ? (
-          <Image
-            src={variantUrl(photo, 'card')}
-            alt={listing.address}
-            fill
-            className="object-cover"
-            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-          />
-        ) : (
-          <div className="flex items-center justify-center h-full text-night/20">
-            <Icon name="photo" className="w-10 h-10" />
-          </div>
-        )}
-      </div>
+    <div className="relative">
+      <Link
+        href={href}
+        className={`group block bg-white rounded-sm overflow-hidden transition-all focus-visible:outline-2 focus-visible:outline-yellow focus-visible:outline-offset-2 ${
+          isVerified
+            ? 'border-2 border-yellow/60 shadow-[0_0_12px_-2px_rgba(255,203,87,0.4)] hover:shadow-[0_0_18px_-2px_rgba(255,203,87,0.55)]'
+            : 'border border-night/10 hover:border-blue/40 hover:shadow-[0_2px_18px_-8px_rgba(10,20,54,0.25)]'
+        }`}
+      >
+        {/* Photo */}
+        <div className="relative aspect-[4/3] bg-parchment">
+          {isVerified && (
+            <span className="absolute top-3 right-3 z-10">
+              <Pill variant="verified">{tCard('verified')}</Pill>
+            </span>
+          )}
+          {photo ? (
+            <Image
+              src={variantUrl(photo, 'card')}
+              alt={listing.address}
+              fill
+              className="object-cover"
+              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+            />
+          ) : (
+            <div className="flex items-center justify-center h-full text-night/20">
+              <Icon name="photo" className="w-10 h-10" />
+            </div>
+          )}
+        </div>
 
-      {/* Body */}
-      <div className="p-5">
-        <p className="label-caps text-night/50">
-          {listing.neighborhood} &middot; Thessaloniki
-        </p>
-        <h3 className="mt-1.5 font-display text-2xl text-night leading-tight line-clamp-2">
-          {listing.title || listing.address}
-        </h3>
+        {/* Body */}
+        <div className="p-5">
+          <p className="label-caps text-night/50">
+            {listing.neighborhood} &middot; Thessaloniki
+          </p>
+          <h3 className="mt-1.5 font-display text-2xl text-night leading-tight line-clamp-2">
+            {listing.title || listing.address}
+          </h3>
 
-        <div className="mt-4 flex items-baseline justify-between gap-3">
-          <span className="label-caps text-night/60">
-            {formatPropertyType(listing.property_type, locale)}
-          </span>
-          <span className="font-display text-xl text-blue">
-            {listing.monthly_price != null ? (
-              <>
-                €{listing.monthly_price}
+          <div className="mt-4 flex items-baseline justify-between gap-3">
+            <span className="label-caps text-night/60">
+              {formatPropertyType(listing.property_type, locale)}
+            </span>
+            <span className="font-display text-xl text-blue">
+              {listing.monthly_price != null ? (
+                <>
+                  €{listing.monthly_price}
+                  <span className="text-sm text-night/50">
+                    {tCard('perMonth')}
+                  </span>
+                </>
+              ) : (
                 <span className="text-sm text-night/50">
-                  {tCard('perMonth')}
+                  {tCard('priceOnRequest')}
                 </span>
-              </>
-            ) : (
-              <span className="text-sm text-night/50">
-                {tCard('priceOnRequest')}
-              </span>
-            )}
-          </span>
-        </div>
+              )}
+            </span>
+          </div>
 
-        <div className="mt-4 flex flex-wrap gap-1.5">
-          {floorUnspecified && (
-            <Pill variant="info">{t('floorNotSpecified')}</Pill>
-          )}
-          {listing.bills_included && (
-            <Pill variant="amenity">{t('billsIncluded')}</Pill>
-          )}
+          <div className="mt-4 flex flex-wrap gap-1.5">
+            {floorUnspecified && (
+              <Pill variant="info">{t('floorNotSpecified')}</Pill>
+            )}
+            {listing.bills_included && (
+              <Pill variant="amenity">{t('billsIncluded')}</Pill>
+            )}
+          </div>
         </div>
-      </div>
-    </Link>
+      </Link>
+
+      {/* Save toggle — sibling of the card link (not nested in the
+          anchor), floated over the photo's top-left. Right corner is
+          reserved for the verified seal. */}
+      <FavoriteButton
+        listingId={listing.listing_id}
+        className="absolute top-3 left-3 z-10"
+      />
+    </div>
   );
 }

--- a/src/components/student/SavedListings.js
+++ b/src/components/student/SavedListings.js
@@ -1,0 +1,51 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/navigation';
+import ListingCard from '@/components/ListingCard';
+import Card from '@/components/ui/Card';
+import Icon from '@/components/ui/Icon';
+import { useFavorites } from '@/components/FavoritesProvider';
+
+/*
+  Renders the student's saved listings as a ListingCard grid. The server
+  (SavedSection on the account page) does the DB read and hands over a
+  plain, already-transformed listings array; this client wrapper exists so
+  an unheart here removes the card immediately (optimistic) rather than
+  lingering until the next refresh.
+
+  Before the provider has loaded its set we trust the server snapshot and
+  show everything; once loaded we intersect with the live set so optimistic
+  removals (and a re-heart) reflect right away.
+*/
+export default function SavedListings({ listings }) {
+  const t = useTranslations('student.favorites');
+  const { favorites, loaded } = useFavorites();
+
+  const visible = loaded
+    ? listings.filter((l) => favorites.has(l.listing_id))
+    : listings;
+
+  if (visible.length === 0) {
+    return (
+      <Card tone="parchment" className="p-12 text-center">
+        <Icon name="heart" className="w-12 h-12 mx-auto text-night/30 mb-3" />
+        <p className="font-display text-xl text-night/60 mb-5">{t('empty')}</p>
+        <Link
+          href="/property/thessaloniki/results"
+          className="inline-flex items-center justify-center bg-blue text-white font-sans font-semibold uppercase tracking-[0.08em] text-xs px-5 py-3 rounded hover:bg-night transition-colors"
+        >
+          {t('emptyCta')}
+        </Link>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+      {visible.map((listing) => (
+        <ListingCard key={listing.listing_id} listing={listing} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/Icon.js
+++ b/src/components/ui/Icon.js
@@ -65,6 +65,9 @@ const PATHS = {
     </>
   ),
   star: <path d="m12 3 2.9 5.9 6.5.9-4.7 4.6 1.1 6.5L12 17.8l-5.8 3.1 1.1-6.5L2.6 9.8l6.5-.9Z" />,
+  // Renders outline by default (fill="none" from the <svg>). Pass
+  // fill="currentColor" to fill it for the saved/active state.
+  heart: <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.29 1.49 4.04 3 5.5l7 7Z" />,
   book: (
     <>
       <path d="M6 4h11a2 2 0 0 1 2 2v14H7a2 2 0 0 1-2-2V5a1 1 0 0 1 1-1Z" />

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -751,6 +751,7 @@
     },
     "account": {
       "portal": "Student portal",
+      "heading": "Your account",
       "title": "My inquiries",
       "eyebrow": "Account",
       "empty": "You haven't sent any inquiries yet.",
@@ -814,6 +815,19 @@
       "errorListingMissing": "This listing is no longer available.",
       "errorCapExceeded": "This listing has reached its inquiry limit. Try another.",
       "errorNotStudent": "Your account isn't set up as a student. Sign out and create a student account."
+    },
+    "favorites": {
+      "save": "Save",
+      "saved": "Saved",
+      "saveAria": "Save this listing",
+      "removeAria": "Remove from saved listings",
+      "panelTitle": "Saved listings",
+      "empty": "You haven't saved any listings yet.",
+      "emptyCta": "Browse listings",
+      "loadError": "Couldn't load your saved listings. Try refreshing the page.",
+      "gateTitle": "Sign in to save listings",
+      "gateBody": "Create a free student account to build your shortlist and pick up right where you left off — it takes about a minute.",
+      "close": "Close"
     }
   },
   "loaders": {

--- a/supabase/migrations/053_student_favorites.sql
+++ b/supabase/migrations/053_student_favorites.sql
@@ -1,0 +1,61 @@
+-- ============================================================
+-- Migration 053: Student favourites / shortlist.
+-- ============================================================
+--
+-- A student can shortlist ("heart") listings. One row per
+-- (student, listing) pair; re-hearting is a no-op (the composite
+-- primary key gives the UNIQUE the feature spec asks for).
+--
+-- Ownership model mirrors the rest of the student surface: the row's
+-- student_id must resolve to the caller's own students row
+-- (auth_user_id = auth.uid()). RLS enforces that for SELECT / INSERT /
+-- DELETE; there is no UPDATE path (favourites are add/remove only).
+--
+-- FKs cascade so the table self-heals: deleting a student (which
+-- cascades from auth.users via students.auth_user_id) or a listing
+-- removes its favourite rows automatically.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS student_favorites (
+  student_id  UUID        NOT NULL REFERENCES students(student_id)  ON DELETE CASCADE,
+  listing_id  TEXT        NOT NULL REFERENCES listings(listing_id)  ON DELETE CASCADE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (student_id, listing_id)
+);
+
+-- The composite PK indexes (student_id, listing_id) — covering the
+-- "list my favourites" read (leading column student_id). Postgres does
+-- NOT auto-index the listing_id FK column, so add one: it keeps the
+-- ON DELETE CASCADE from a listing delete off a sequential scan.
+CREATE INDEX IF NOT EXISTS idx_student_favorites_listing_id
+  ON student_favorites(listing_id);
+
+ALTER TABLE student_favorites ENABLE ROW LEVEL SECURITY;
+
+-- A student can only see / create / remove their OWN favourites. The
+-- subquery resolves the caller's student_id under the existing
+-- "Students read own row" policy on students (auth_user_id = auth.uid()),
+-- so it returns exactly the caller's id and nothing else.
+CREATE POLICY "Students read own favorites"
+  ON student_favorites FOR SELECT
+  USING (
+    student_id IN (
+      SELECT student_id FROM students WHERE auth_user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Students insert own favorites"
+  ON student_favorites FOR INSERT
+  WITH CHECK (
+    student_id IN (
+      SELECT student_id FROM students WHERE auth_user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Students delete own favorites"
+  ON student_favorites FOR DELETE
+  USING (
+    student_id IN (
+      SELECT student_id FROM students WHERE auth_user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## What

Students can shortlist ("heart") listings and review them on their account page. Closes the gap of "save for later" on a curated directory.

## ⚠️ Migration — apply to prod BEFORE merging

This PR includes **`supabase/migrations/053_student_favorites.sql`** (a new `student_favorites` table + RLS). Per the repo convention, **do not merge until the migration is applied to prod** — Cloudflare deploys on push-to-main and the Saved panel + `/api/me/favorites` SELECT/INSERT/DELETE will 500 in the gap otherwise. I left it unapplied for review.

```
student_favorites(student_id UUID → students, listing_id TEXT → listings, created_at)
  PRIMARY KEY (student_id, listing_id)   -- this is the UNIQUE(student_id, listing_id)
  both FKs ON DELETE CASCADE
  RLS: SELECT / INSERT / DELETE limited to the caller's own rows
       (student_id ∈ students WHERE auth_user_id = auth.uid())
```

## How

- **API — `/api/me/favorites`** (`GET` list / `POST` add / `DELETE ?listing_id=`). Token-scoped via `getSupabaseWithToken` so RLS does the enforcement; returns **401 when not signed in as a student** (mirrors `/api/me/unread`). `POST` is idempotent on the unique violation (re-heart = ok); a FK violation → 404.
- **`FavoritesProvider`** (mounted once in `[locale]/layout.js`) holds one shared, optimistic set of favourited ids so every results-page heart, the detail-page button, and the Saved panel agree — and an unheart reflects instantly everywhere instead of each card firing its own request. Auth state comes from `useAccessToken()`.
- **`FavoriteButton`** — icon-only heart floated over the `ListingCard` photo (rendered as a **sibling of the card `<Link>`**, not nested in the anchor), and a labelled variant in the listing detail hero. Optimistic toggle.
- **Signed-out tap → the same sign-in gate the Contact flow uses**: a dialog with the shared `student.gate` sign-up / sign-in buttons carrying `?next=` back to the current URL (locale resolves via the client intl provider). Necessary because the hearts live in client components on `/results`.
- **"Saved listings" panel** on `/student/account` reuses `ListingCard` (server fetch → `transformListing` → client `SavedListings` so optimistic removals drop the card without a refresh).
- All user-facing copy under `student.favorites` in `en.json` (+ `student.account.heading`); added an inline `heart` to the shared `Icon` set. **Did not** reintroduce the removed AUTH PROGRAMME pill.

## Tests / checks

- `__tests__/api/meFavorites.test.js` — auth gating (no token / bad token / non-student → 401), listing-id guard (400), idempotent insert (23505 → ok), FK→404, and that delete is scoped to `student_id` + `listing_id`.
- `npm run lint` ✓ · `npm run test` ✓ (174 passing) · `npm run build` ✓.

## Verification notes

Lint/test/build are green and the route compiles into the build manifest. The full signed-in round-trip (heart on /results → appears under Saved → unheart → refresh persists) needs **migration 053 applied first**, since the table doesn't exist until then — so please apply the migration during review, then exercise the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)