### PR TITLE
feat(ux): directory carousel, photo lightbox, mobile sticky Inquire CTA

### DIFF
--- a/src/app/[locale]/property/[city]/listing/[id]/page.js
+++ b/src/app/[locale]/property/[city]/listing/[id]/page.js
@@ -1,11 +1,11 @@
 import { notFound } from 'next/navigation';
-import Image from 'next/image';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { Link } from '@/i18n/navigation';
 
 import { getListingForRender } from '@/lib/listingForRender';
 import { requireStudent } from '@/lib/requireStudent';
 
+import ListingGallery from '@/components/listing/ListingGallery';
 import ContactRail from '@/components/listing/ContactRail';
 import ContactGate from '@/components/listing/ContactGate';
 import ViewTracker from '@/components/listing/ViewTracker';
@@ -14,7 +14,6 @@ import Pill from '@/components/ui/Pill';
 import Card from '@/components/ui/Card';
 import Icon from '@/components/ui/Icon';
 import VerifiedSeal from '@/components/ui/VerifiedSeal';
-import { variantUrl } from '@/lib/photoVariants';
 import { formatPropertyType } from '@/lib/propertyType';
 import OrnamentRule from '@/components/ui/OrnamentRule';
 
@@ -53,7 +52,7 @@ export default async function ListingPage({ params, searchParams }) {
   const distances = deriveDestinations(listing.faculty_distances || [], t);
 
   return (
-    <div className="mx-auto max-w-6xl px-5 py-8 md:py-12">
+    <div className="mx-auto max-w-6xl px-5 pt-8 pb-28 sm:pb-12 md:py-12">
       {isAuthed && <ViewTracker listingId={listing.listing_id} />}
 
       {/* Back link — server-rendered Link. Threads the prior /results
@@ -67,19 +66,13 @@ export default async function ListingPage({ params, searchParams }) {
         {t('back')}
       </Link>
 
-      {/* Photo gallery — responsive grid showing every uploaded photo */}
+      {/* Photo gallery — inline main image + thumbnail strip → lightbox */}
       <section className="mb-10">
         {photos.length > 0 ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            {photos.map((src, i) => (
-              <PhotoTile
-                key={src}
-                src={src}
-                alt={`${listing.address} — photo ${i + 1}`}
-                priority={i === 0}
-              />
-            ))}
-          </div>
+          <ListingGallery
+            photos={photos}
+            title={listing.title || listing.address || 'Listing'}
+          />
         ) : (
           <div className="aspect-[16/9] rounded-sm bg-parchment flex items-center justify-center">
             <Icon name="photo" className="w-16 h-16 text-night/20" />
@@ -109,7 +102,7 @@ export default async function ListingPage({ params, searchParams }) {
               {listing.address && (
                 <p
                   className="mt-2 label-caps text-night/60"
-                  aria-label={tListing('streetAddressA11y')}
+                  aria-label={t('streetAddressA11y')}
                 >
                   {listing.address}
                 </p>
@@ -240,21 +233,6 @@ export default async function ListingPage({ params, searchParams }) {
           <ContactGate listing={listing} locale={locale} fromRaw={fromRaw} />
         )}
       </div>
-    </div>
-  );
-}
-
-function PhotoTile({ src, alt, priority = false }) {
-  return (
-    <div className="relative aspect-[4/3] rounded-sm overflow-hidden bg-parchment">
-      <Image
-        src={variantUrl(src, 'full')}
-        alt={alt}
-        fill
-        className="object-cover"
-        sizes="(max-width: 768px) 100vw, 50vw"
-        priority={priority}
-      />
     </div>
   );
 }

--- a/src/components/listing/ContactGate.js
+++ b/src/components/listing/ContactGate.js
@@ -1,5 +1,6 @@
 import { getTranslations } from 'next-intl/server';
 import { Link } from '@/i18n/navigation';
+import Button from '@/components/ui/Button';
 import Card from '@/components/ui/Card';
 import Icon from '@/components/ui/Icon';
 import AuthGateRescue from '@/components/AuthGateRescue';
@@ -17,6 +18,7 @@ export default async function ContactGate({ listing, locale, fromRaw }) {
   const nextQuery = `?next=${encodeURIComponent(nextPath)}`;
 
   return (
+    <>
     <aside>
       <div className="lg:sticky lg:top-6">
         <Card tone="white" className="p-6">
@@ -74,5 +76,35 @@ export default async function ContactGate({ listing, locale, fromRaw }) {
         </Card>
       </div>
     </aside>
+
+      {/* Mobile sticky inquire bar — phones only; routes guests into the
+          same sign-in gate the desktop card offers. */}
+      <div
+        role="region"
+        aria-label={t('stickyBarLabel')}
+        className="sm:hidden fixed inset-x-0 bottom-0 z-40 flex items-center justify-between gap-4 border-t border-night/10 bg-white/95 px-5 py-3 backdrop-blur"
+        style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))' }}
+      >
+        <p className="font-display text-2xl text-blue leading-none">
+          {listing.monthly_price != null ? (
+            <>
+              €{listing.monthly_price}
+              <span className="text-sm text-night/50">/mo</span>
+            </>
+          ) : (
+            <span className="text-sm text-night/50">
+              {tListing('priceOnRequest')}
+            </span>
+          )}
+        </p>
+        <Button
+          href={`/student/signup${nextQuery}`}
+          variant="gold"
+          className="shrink-0"
+        >
+          {t('inquire')}
+        </Button>
+      </div>
+    </>
   );
 }

--- a/src/components/listing/ContactRail.js
+++ b/src/components/listing/ContactRail.js
@@ -120,6 +120,31 @@ export default function ContactRail({ listing }) {
         </div>
       </aside>
 
+      {/* Mobile sticky inquire bar — phones only; opens the same composer.
+          Hidden once the composer modal (z-50) is open, which sits above it. */}
+      <div
+        role="region"
+        aria-label={t('stickyBarLabel')}
+        className="sm:hidden fixed inset-x-0 bottom-0 z-40 flex items-center justify-between gap-4 border-t border-night/10 bg-white/95 px-5 py-3 backdrop-blur"
+        style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))' }}
+      >
+        <p className="font-display text-2xl text-blue leading-none">
+          {listing.monthly_price != null ? (
+            <>
+              €{listing.monthly_price}
+              <span className="text-sm text-night/50">/mo</span>
+            </>
+          ) : (
+            <span className="text-sm text-night/50">
+              {tListing('priceOnRequest')}
+            </span>
+          )}
+        </p>
+        <Button variant="gold" onClick={() => setOpen(true)} className="shrink-0">
+          {t('inquire')}
+        </Button>
+      </div>
+
       {open && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
           <div

--- a/src/components/listing/ListingGallery.js
+++ b/src/components/listing/ListingGallery.js
@@ -1,0 +1,117 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import { AnimatePresence } from 'motion/react';
+import { useTranslations } from 'next-intl';
+import { variantUrl } from '@/lib/photoVariants';
+import ListingLightbox from '@/components/listing/ListingLightbox';
+
+/*
+  Listing photo gallery (Item 8) — replaces the old tall 2-column grid.
+
+  An inline main image (next/image, real alt) plus a thumbnail strip. The
+  last thumbnail collapses into a "+N" tile when there are more photos than
+  fit. Tapping the main image (or the "+N" tile) opens the full-screen
+  ListingLightbox, which handles swipe / zoom / counter / keyboard / focus
+  trap. Thumbnails select which photo the main image shows.
+*/
+
+const MAX_THUMBS = 5;
+
+export default function ListingGallery({ photos, title }) {
+  const t = useTranslations('propylaea.gallery');
+  const [active, setActive] = useState(0);
+  const [lightboxIndex, setLightboxIndex] = useState(null);
+
+  const open = (i) => setLightboxIndex(i);
+  const close = () => setLightboxIndex(null);
+
+  const visible = photos.slice(0, MAX_THUMBS);
+  const hiddenCount = photos.length - MAX_THUMBS;
+
+  return (
+    <>
+      {/* Main image — click opens the lightbox at the active photo */}
+      <button
+        type="button"
+        onClick={() => open(active)}
+        aria-label={t('openLightbox')}
+        className="group relative block w-full aspect-[16/10] rounded-sm overflow-hidden bg-parchment cursor-zoom-in focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue"
+      >
+        <Image
+          src={variantUrl(photos[active], 'full')}
+          alt={t('photoAlt', { title, number: active + 1 })}
+          fill
+          priority
+          sizes="(max-width: 1024px) 100vw, 1024px"
+          className="object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+        />
+      </button>
+
+      {/* Thumbnail strip */}
+      {photos.length > 1 && (
+        <div className="mt-3 grid grid-cols-5 gap-2 sm:gap-3">
+          {visible.map((src, i) => {
+            const isMoreTile = i === MAX_THUMBS - 1 && hiddenCount > 0;
+            if (isMoreTile) {
+              return (
+                <button
+                  key={src}
+                  type="button"
+                  onClick={() => open(i)}
+                  aria-label={t('moreLabel', { count: hiddenCount + 1 })}
+                  className="relative aspect-square rounded-sm overflow-hidden bg-night focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue"
+                >
+                  <Image
+                    src={variantUrl(src, 'thumb')}
+                    alt=""
+                    fill
+                    sizes="20vw"
+                    className="object-cover opacity-40"
+                  />
+                  <span className="absolute inset-0 flex items-center justify-center font-display text-lg text-white">
+                    {t('moreCount', { count: hiddenCount + 1 })}
+                  </span>
+                </button>
+              );
+            }
+            return (
+              <button
+                key={src}
+                type="button"
+                onClick={() => setActive(i)}
+                aria-label={t('thumbnailAlt', { title, number: i + 1 })}
+                aria-current={i === active ? 'true' : undefined}
+                className={`relative aspect-square rounded-sm overflow-hidden bg-parchment transition-all focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue ${
+                  i === active
+                    ? 'ring-2 ring-blue ring-offset-2 ring-offset-stone'
+                    : 'opacity-80 hover:opacity-100'
+                }`}
+              >
+                <Image
+                  src={variantUrl(src, 'thumb')}
+                  alt=""
+                  fill
+                  sizes="20vw"
+                  className="object-cover"
+                />
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      <AnimatePresence>
+        {lightboxIndex !== null && (
+          <ListingLightbox
+            photos={photos}
+            title={title}
+            startIndex={lightboxIndex}
+            onClose={close}
+          />
+        )}
+      </AnimatePresence>
+    </>
+  );
+}

--- a/src/components/listing/ListingLightbox.js
+++ b/src/components/listing/ListingLightbox.js
@@ -101,7 +101,7 @@ export default function ListingLightbox({ photos, title, startIndex = 0, onClose
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.18 }}
-      className="fixed inset-0 z-[70] flex flex-col bg-night/95"
+      className="fixed inset-0 z-[70] flex flex-col bg-blue/95"
     >
       {/* Top bar — counter + close */}
       <div className="flex items-center justify-between px-5 py-4 text-white">

--- a/src/components/listing/ListingLightbox.js
+++ b/src/components/listing/ListingLightbox.js
@@ -1,0 +1,254 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
+import { motion, useMotionValue } from 'motion/react';
+import { useTranslations } from 'next-intl';
+import Icon from '@/components/ui/Icon';
+import { variantUrl } from '@/lib/photoVariants';
+
+/*
+  Full-screen photo lightbox for the listing detail page (Item 8).
+
+  - Swipe between photos with the same motion-drag mechanic as the
+    directory carousel: dragConstraints lock the track x to ~0, the spring
+    `animate.translateX` drives the page, and onDragEnd snaps the index.
+  - Tap (or the zoom button) toggles zoom on the active photo; pinch on
+    touch devices scales it; when zoomed the photo pans and track-swipe is
+    suspended.
+  - Esc closes, Arrow keys navigate, focus is trapped, body scroll locked.
+  - Keeps next/image (object-contain) + real alt text — no background-image.
+*/
+
+const SPRING = { type: 'spring', mass: 3, stiffness: 400, damping: 50 };
+const DRAG_BUFFER = 50;
+const MAX_ZOOM = 4;
+const TAP_ZOOM = 2.5;
+
+function touchDistance(touches) {
+  const [a, b] = touches;
+  return Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+}
+
+export default function ListingLightbox({ photos, title, startIndex = 0, onClose }) {
+  const t = useTranslations('propylaea.gallery');
+  const [index, setIndex] = useState(startIndex);
+  const [scale, setScale] = useState(1);
+
+  const dragX = useMotionValue(0);
+  const dialogRef = useRef(null);
+  const closeBtnRef = useRef(null);
+
+  const zoomed = scale > 1;
+  const maxIndex = photos.length - 1;
+
+  const go = useCallback(
+    (next) => {
+      setScale(1);
+      setIndex((i) => Math.max(0, Math.min(next, maxIndex)));
+    },
+    [maxIndex],
+  );
+
+  // Lock body scroll while open; restore focus to the trigger on close.
+  useEffect(() => {
+    const previouslyFocused = document.activeElement;
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    closeBtnRef.current?.focus();
+    return () => {
+      document.body.style.overflow = prevOverflow;
+      if (previouslyFocused instanceof HTMLElement) previouslyFocused.focus();
+    };
+  }, []);
+
+  const onKeyDown = (e) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      go(index + 1);
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      go(index - 1);
+    } else if (e.key === 'Tab') {
+      // Minimal focus trap across the dialog's interactive controls.
+      const focusables = dialogRef.current?.querySelectorAll(
+        'button:not([disabled]):not([tabindex="-1"])',
+      );
+      if (!focusables || focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
+  return (
+    <motion.div
+      ref={dialogRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('lightboxLabel')}
+      onKeyDown={onKeyDown}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.18 }}
+      className="fixed inset-0 z-[70] flex flex-col bg-night/95"
+    >
+      {/* Top bar — counter + close */}
+      <div className="flex items-center justify-between px-5 py-4 text-white">
+        <span className="font-display text-lg tabular-nums" aria-live="polite">
+          {t('counter', { current: index + 1, total: photos.length })}
+        </span>
+        <button
+          ref={closeBtnRef}
+          type="button"
+          onClick={onClose}
+          aria-label={t('close')}
+          className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        >
+          <Icon name="x" className="w-6 h-6" />
+        </button>
+      </div>
+
+      {/* Photo track */}
+      <div className="relative flex-1 overflow-hidden">
+        <motion.div
+          className="flex h-full"
+          drag={zoomed ? false : 'x'}
+          dragConstraints={{ left: 0, right: 0 }}
+          style={{ x: dragX }}
+          animate={{ translateX: `-${index * 100}%` }}
+          transition={SPRING}
+          onDragEnd={() => {
+            const x = dragX.get();
+            if (x <= -DRAG_BUFFER) go(index + 1);
+            else if (x >= DRAG_BUFFER) go(index - 1);
+          }}
+        >
+          {photos.map((src, i) => (
+            <div
+              key={src}
+              className="relative shrink-0 w-full h-full"
+              aria-hidden={i === index ? undefined : 'true'}
+            >
+              <ZoomableImage
+                src={variantUrl(src, 'full')}
+                alt={t('photoAlt', { title, number: i + 1 })}
+                active={i === index}
+                scale={i === index ? scale : 1}
+                setScale={setScale}
+                t={t}
+              />
+            </div>
+          ))}
+        </motion.div>
+
+        {/* Prev / next — hidden while zoomed so panning isn't obstructed */}
+        {photos.length > 1 && !zoomed && (
+          <>
+            <ArrowButton
+              dir="prev"
+              label={t('prev')}
+              disabled={index === 0}
+              onClick={() => go(index - 1)}
+            />
+            <ArrowButton
+              dir="next"
+              label={t('next')}
+              disabled={index >= maxIndex}
+              onClick={() => go(index + 1)}
+            />
+          </>
+        )}
+      </div>
+    </motion.div>
+  );
+}
+
+function ZoomableImage({ src, alt, active, scale, setScale, t }) {
+  const pinch = useRef({ startDist: 0, startScale: 1 });
+  const zoomed = scale > 1;
+
+  function onClick() {
+    if (!active) return;
+    setScale(zoomed ? 1 : TAP_ZOOM);
+  }
+
+  function onTouchStart(e) {
+    if (e.touches.length === 2) {
+      pinch.current = { startDist: touchDistance(e.touches), startScale: scale };
+    }
+  }
+  function onTouchMove(e) {
+    if (e.touches.length === 2 && pinch.current.startDist > 0) {
+      e.preventDefault();
+      const ratio = touchDistance(e.touches) / pinch.current.startDist;
+      const next = Math.min(MAX_ZOOM, Math.max(1, pinch.current.startScale * ratio));
+      setScale(next);
+    }
+  }
+  function onTouchEnd(e) {
+    if (e.touches.length < 2) {
+      pinch.current.startDist = 0;
+      if (scale < 1.1) setScale(1);
+    }
+  }
+
+  return (
+    <div
+      className="relative w-full h-full flex items-center justify-center"
+      style={{ touchAction: zoomed ? 'none' : 'pan-y' }}
+      onTouchStart={onTouchStart}
+      onTouchMove={onTouchMove}
+      onTouchEnd={onTouchEnd}
+    >
+      <motion.button
+        type="button"
+        onClick={onClick}
+        aria-label={zoomed ? t('zoomOut') : t('zoomIn')}
+        tabIndex={active ? 0 : -1}
+        drag={zoomed}
+        dragConstraints={{ left: -400, right: 400, top: -400, bottom: 400 }}
+        dragElastic={0.1}
+        animate={{ scale }}
+        transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+        className={`relative w-full h-full ${zoomed ? 'cursor-grab active:cursor-grabbing' : 'cursor-zoom-in'}`}
+      >
+        <Image
+          src={src}
+          alt={alt}
+          fill
+          sizes="100vw"
+          draggable={false}
+          className="object-contain select-none pointer-events-none"
+        />
+      </motion.button>
+    </div>
+  );
+}
+
+function ArrowButton({ dir, label, disabled, onClick }) {
+  const isPrev = dir === 'prev';
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      className={`absolute top-1/2 -translate-y-1/2 ${
+        isPrev ? 'left-3' : 'right-3'
+      } inline-flex items-center justify-center w-11 h-11 rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors disabled:opacity-25 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white`}
+    >
+      <Icon name="chevronRight" className={`w-6 h-6 ${isPrev ? 'rotate-180' : ''}`} />
+    </button>
+  );
+}

--- a/src/components/property/DirectoryCarousel.js
+++ b/src/components/property/DirectoryCarousel.js
@@ -1,0 +1,270 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { motion, useMotionValue, useReducedMotion } from 'motion/react';
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/navigation';
+import ListingCard from '@/components/ListingCard';
+import Icon from '@/components/ui/Icon';
+
+/*
+  Item 7 — directory carousel.
+
+  A horizontal CARD carousel of ListingCards for the Thessaloniki landing.
+  Adapted from the reference SwipeCarousel (motion drag + spring snap) but:
+    - renders ListingCards (not background-image divs),
+    - uses container-relative percentage widths (no w-screen overflow),
+    - auto-advance pauses on hover/focus and is disabled under
+      prefers-reduced-motion,
+    - iris palette + arrow-key support + labelled pager controls.
+
+  Drag mechanic mirrors the reference: dragConstraints lock the track's x
+  to ~0 (elastic tactile feedback only); the page position is driven by
+  the spring `animate.translateX`. translateX is a percentage of the track
+  box (== the viewport column width), so `-index * cardWidthPct` advances by
+  exactly one card per index step.
+*/
+
+const SPRING = { type: 'spring', mass: 3, stiffness: 400, damping: 50 };
+const DRAG_BUFFER = 50;
+const AUTO_DELAY = 6000;
+const MAX_CARDS = 9;
+
+function perViewFor(width) {
+  if (width >= 1024) return 3;
+  if (width >= 640) return 2;
+  return 1;
+}
+
+export default function DirectoryCarousel() {
+  const t = useTranslations('propylaea.carousel');
+  const prefersReduced = useReducedMotion();
+
+  const [listings, setListings] = useState([]);
+  const [status, setStatus] = useState('loading'); // loading | ready | empty
+  const [perView, setPerView] = useState(1);
+  const [index, setIndex] = useState(0);
+  const [paused, setPaused] = useState(false);
+
+  const dragX = useMotionValue(0);
+
+  // Fetch the featured slice. /api/listings already returns verified-tier
+  // → featured → price-ordered rows, so the head of the list is the
+  // "featured" set we want to surface.
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/listings')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled) return;
+        const rows = (data?.listings || []).slice(0, MAX_CARDS);
+        setListings(rows);
+        setStatus(rows.length > 0 ? 'ready' : 'empty');
+      })
+      .catch(() => {
+        if (!cancelled) setStatus('empty');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Track how many cards fit so the translate math + clamping stay correct
+  // across breakpoints. Set in an effect (not a render-time read of window)
+  // to keep SSR output stable.
+  useEffect(() => {
+    const update = () => setPerView(perViewFor(window.innerWidth));
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
+  const maxIndex = Math.max(0, listings.length - perView);
+
+  // Clamp when perView grows (resize) so we never strand past the last page.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setIndex((i) => Math.min(i, maxIndex));
+  }, [maxIndex]);
+
+  // Auto-advance — disabled under reduced motion, while hovered/focused, or
+  // when everything already fits on one page.
+  useEffect(() => {
+    if (prefersReduced || paused || maxIndex < 1) return;
+    const id = setInterval(() => {
+      setIndex((i) => (i >= maxIndex ? 0 : i + 1));
+    }, AUTO_DELAY);
+    return () => clearInterval(id);
+  }, [prefersReduced, paused, maxIndex]);
+
+  const go = (next) => setIndex(Math.max(0, Math.min(next, maxIndex)));
+
+  const onDragEnd = () => {
+    const x = dragX.get();
+    if (x <= -DRAG_BUFFER) go(index + 1);
+    else if (x >= DRAG_BUFFER) go(index - 1);
+  };
+
+  const onKeyDown = (e) => {
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      go(index + 1);
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      go(index - 1);
+    }
+  };
+
+  if (status === 'empty') return null;
+
+  const cardWidthPct = 100 / perView;
+  const pageCount = maxIndex + 1;
+
+  return (
+    <section
+      role="region"
+      aria-roledescription="carousel"
+      aria-label={t('regionLabel')}
+      className="mx-auto max-w-6xl px-5 py-16 md:py-20"
+    >
+      {/* Header: bilingual accent + view-all, with pager arrows on sm+ */}
+      <div className="flex items-end justify-between gap-4 mb-8">
+        <div>
+          <p className="label-caps text-yellow mb-2">{t('eyebrow')}</p>
+          <h2 className="font-display text-3xl md:text-4xl text-night leading-tight">
+            {t('title')} <span className="italic text-yellow">{t('titleItalic')}</span>
+          </h2>
+        </div>
+        <div className="flex items-center gap-3 shrink-0">
+          <Link
+            href="/property/thessaloniki/results"
+            className="hidden sm:inline label-caps text-blue hover:text-night transition-colors"
+          >
+            {t('viewAll')} →
+          </Link>
+          {pageCount > 1 && (
+            <div className="hidden sm:flex items-center gap-2">
+              <PagerArrow
+                dir="prev"
+                label={t('prev')}
+                disabled={index === 0}
+                onClick={() => go(index - 1)}
+              />
+              <PagerArrow
+                dir="next"
+                label={t('next')}
+                disabled={index >= maxIndex}
+                onClick={() => go(index + 1)}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Viewport. tabIndex + onKeyDown give the track arrow-key control. */}
+      <div
+        className="relative overflow-hidden focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue rounded-sm"
+        tabIndex={0}
+        onKeyDown={onKeyDown}
+        onMouseEnter={() => setPaused(true)}
+        onMouseLeave={() => setPaused(false)}
+        onFocusCapture={() => setPaused(true)}
+        onBlurCapture={() => setPaused(false)}
+      >
+        {status === 'loading' ? (
+          <div className="flex">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div
+                key={i}
+                className="shrink-0 px-2.5"
+                style={{ width: `${cardWidthPct}%` }}
+              >
+                <SkeletonCard />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <motion.div
+            className="flex cursor-grab active:cursor-grabbing"
+            drag="x"
+            dragConstraints={{ left: 0, right: 0 }}
+            style={{ x: dragX }}
+            animate={{ translateX: `-${index * cardWidthPct}%` }}
+            transition={SPRING}
+            onDragEnd={onDragEnd}
+          >
+            {listings.map((listing, i) => (
+              <div
+                key={listing.listing_id}
+                role="group"
+                aria-roledescription="slide"
+                aria-label={t('slidePosition', { index: i + 1, total: listings.length })}
+                className="shrink-0 px-2.5"
+                style={{ width: `${cardWidthPct}%` }}
+              >
+                {/* motion suppresses the click after a drag, so the card
+                    link only navigates on a clean tap — no extra guard. */}
+                <ListingCard listing={listing} fromQuery="" />
+              </div>
+            ))}
+          </motion.div>
+        )}
+
+        {/* Edge fades hint at off-screen cards (faded into the stone canvas). */}
+        <div className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-stone to-transparent" />
+        <div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-stone to-transparent" />
+      </div>
+
+      {/* Pager dots */}
+      {pageCount > 1 && status === 'ready' && (
+        <div className="mt-6 flex justify-center gap-2">
+          {Array.from({ length: pageCount }).map((_, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() => go(i)}
+              aria-label={t('goToSlide', { number: i + 1 })}
+              aria-current={i === index ? 'true' : undefined}
+              className={`h-2.5 rounded-full transition-all focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue ${
+                i === index ? 'w-6 bg-blue' : 'w-2.5 bg-night/20 hover:bg-night/40'
+              }`}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PagerArrow({ dir, label, disabled, onClick }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      className="inline-flex items-center justify-center w-10 h-10 rounded-full border border-night/15 text-night/70 transition-colors hover:border-blue hover:text-blue disabled:opacity-30 disabled:hover:border-night/15 disabled:hover:text-night/70 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue"
+    >
+      <Icon
+        name="chevronRight"
+        className={`w-4 h-4 ${dir === 'prev' ? 'rotate-180' : ''}`}
+      />
+    </button>
+  );
+}
+
+function SkeletonCard() {
+  return (
+    <div className="rounded-sm border border-night/10 bg-white overflow-hidden animate-pulse">
+      <div className="aspect-[4/3] bg-parchment" />
+      <div className="p-5 space-y-3">
+        <div className="h-3 w-28 bg-parchment rounded" />
+        <div className="h-5 w-3/4 bg-parchment rounded" />
+        <div className="flex justify-between">
+          <div className="h-3 w-20 bg-parchment rounded" />
+          <div className="h-4 w-16 bg-parchment rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/property/ThessalonikiLanding.js
+++ b/src/components/property/ThessalonikiLanding.js
@@ -6,6 +6,7 @@ import Button from '@/components/ui/Button';
 import Card from '@/components/ui/Card';
 import OrnamentRule from '@/components/ui/OrnamentRule';
 import StripeGradientMesh from '@/components/property/StripeGradientMesh';
+import DirectoryCarousel from '@/components/property/DirectoryCarousel';
 
 /*
   Propylaea landing — the Thessaloniki city home at /property/thessaloniki.
@@ -92,6 +93,9 @@ export default function ThessalonikiLanding() {
           <StatTile value={t('statBrokerageValue')} label={t('statBrokerage')} />
         </div>
       </section>
+
+      {/* Featured listings carousel */}
+      <DirectoryCarousel />
 
       <div className="mx-auto max-w-6xl px-5">
         <OrnamentRule />

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -425,6 +425,17 @@
       "step3English": "Reach out directly",
       "step3Body": "No brokers. No hidden fees."
     },
+    "carousel": {
+      "eyebrow": "Επιλεγμένες αγγελίες",
+      "title": "Featured",
+      "titleItalic": "homes.",
+      "viewAll": "Browse all listings",
+      "regionLabel": "Featured listings",
+      "slidePosition": "Listing {index} of {total}",
+      "prev": "Previous listings",
+      "next": "Next listings",
+      "goToSlide": "Go to slide {number}"
+    },
     "hub": {
       "description": "Curated student housing across Greece, Cyprus, the UK and Ireland. Pick a city to begin.",
       "headerStat": "Global students empowered by StudentX:",
@@ -546,10 +557,26 @@
       "directTagline": "Direct with the landlord. No brokers, no fees.",
       "sendInquiry": "Send inquiry",
       "replyWithin24h": "Usually replies within 24 hours",
+      "inquire": "Inquire",
+      "stickyBarLabel": "Listing inquiry",
       "notFound": {
         "title": "Listing not found",
         "description": "This student housing listing could not be found."
       }
+    },
+    "gallery": {
+      "openLightbox": "Open photo gallery",
+      "photoAlt": "{title} — photo {number}",
+      "thumbnailAlt": "{title} — thumbnail {number}",
+      "moreCount": "+{count}",
+      "moreLabel": "View {count} more photos",
+      "lightboxLabel": "Photo gallery",
+      "counter": "{current} / {total}",
+      "prev": "Previous photo",
+      "next": "Next photo",
+      "close": "Close gallery",
+      "zoomIn": "Zoom in",
+      "zoomOut": "Zoom out"
     },
     "landlord": {
       "nav": {


### PR DESCRIPTION
Session 4 of `docs/ux-plan.md` — items **7, 8, 9**. Three related UI pieces across the directory landing + listing-detail surfaces. No migration. JS, server-components-by-default with `'use client'` only where hooks/drag/zoom are needed. Iris palette throughout.

## Item 7 — Directory carousel
`src/components/property/DirectoryCarousel.js`, rendered on the Thessaloniki landing between the stat tiles and "How it works".

A horizontal **card** carousel of `ListingCard`s. Adapted from the supplied motion `SwipeCarousel` reference, but production-hardened:
- Renders `ListingCard`s as slides (not background-image divs).
- **Container-relative `%` widths** (responsive 1 / 2 / 3 per view) — never overflows the page column; no `w-screen`.
- Iris palette (`night` / `parchment` / `blue`), edge gradient fades into the stone canvas.
- Auto-advance (6s) **pauses on hover + focus** and is **disabled under `prefers-reduced-motion`**.
- **Keyboard** arrow-key control, `role="region"` + `aria-roledescription="carousel"`, labelled pager dots (`aria-label` + `aria-current`) and prev/next buttons.
- Data reuses `/api/listings` (the verified-tier → featured → price order means the head of the list is the featured set). Renders nothing if there are no listings.

Drag mechanic = the reference's: `dragConstraints` lock the track `x` to ~0 (elastic feedback), the spring `animate.translateX` drives the page, `onDragEnd` snaps the index.

## Item 8 — Listing photo gallery + lightbox
`src/components/listing/ListingGallery.js` + `src/components/listing/ListingLightbox.js`, replacing the tall 2-column grid on the listing detail page.

- Inline **main image** (`next/image`, `object-cover`, real alt) + a **thumbnail strip**; the 5th tile collapses into a **"+N"** tile when there are more photos.
- Tapping the main image (or the "+N" tile) opens a **full-screen lightbox** that:
  - **swipes** between photos (same motion-drag mechanic — `dragX`, spring, index-snap on `onDragEnd`),
  - **tap / pinch zoom** with pan-when-zoomed (track swipe suspended while zoomed),
  - shows a **"3 / 12" counter**, **closes on Esc**, **traps focus** (inactive slides' zoom buttons are `tabindex=-1`), **locks body scroll**, supports **keyboard arrows**.
  - Keeps `next/image` optimization + alt — **no background-image**.
- The lightbox mounts lazily (via `AnimatePresence`), so it's not in the initial SSR payload.

## Item 9 — Mobile sticky Inquire CTA
A phones-only (`sm:hidden`) bottom-fixed bar with the price + an **Inquire** button.
- `ContactRail` (authed): opens the **existing composer modal** (`setOpen(true)`) — same `/api/inquiries/start` flow.
- `ContactGate` (guest): routes into the **same sign-in gate** the desktop card offers.
- Page gets mobile bottom padding for clearance; safe-area-inset aware.

The **favourite heart** on the listing page (PR #211) is untouched.

## Drive-by fix
The listing detail page read `streetAddressA11y` from the `listing` namespace, but that key only exists under `propylaea.listing` — so it threw `MISSING_MESSAGE` (broken screen-reader label + console spam) on **every** listing render. Switched it to the correct `t` namespace. It's in a file this PR already edits.

## Verification
- `npm run lint` ✅ (only the pre-existing `cf/worker-entry.mjs` anon-default-export warning), `npm run test` ✅ 174/174, `npm run build` ✅ compiled successfully.
- `npm run dev`: landing renders the carousel region (`aria-roledescription="carousel"`); a 23-photo listing renders the main image + 5 thumbs + "+19" tile + the guest sticky bar; dev log is **clean of MISSING_MESSAGE / errors** after the fix.
- Drag/zoom are runtime-only and weren't exercised headlessly — worth a quick phone-width pass on the deploy preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)