### PR TITLE
fix(listing): vertically center photo in fullscreen lightbox

### DIFF
--- a/src/components/listing/ListingLightbox.js
+++ b/src/components/listing/ListingLightbox.js
@@ -103,8 +103,10 @@ export default function ListingLightbox({ photos, title, startIndex = 0, onClose
       transition={{ duration: 0.18 }}
       className="fixed inset-0 z-[70] flex flex-col bg-blue/95"
     >
-      {/* Top bar — counter + close */}
-      <div className="flex items-center justify-between px-5 py-4 text-white">
+      {/* Top bar — counter + close. Overlaid (absolute) so it doesn't consume
+          flow height; the photo track reserves matching room via its top
+          padding, keeping the image centered in the full viewport. */}
+      <div className="absolute inset-x-0 top-0 z-10 flex items-center justify-between px-5 py-4 text-white">
         <span className="font-display text-lg tabular-nums" aria-live="polite">
           {t('counter', { current: index + 1, total: photos.length })}
         </span>
@@ -119,8 +121,11 @@ export default function ListingLightbox({ photos, title, startIndex = 0, onClose
         </button>
       </div>
 
-      {/* Photo track */}
-      <div className="relative flex-1 overflow-hidden">
+      {/* Photo track — full viewport height with symmetric vertical padding
+          (~72px, matching the overlaid top bar) so the object-contain image
+          and the prev/next arrows both center in the full viewport with equal
+          head/foot whitespace. */}
+      <div className="relative flex-1 overflow-hidden py-18">
         <motion.div
           className="flex h-full"
           drag={zoomed ? false : 'x'}


### PR DESCRIPTION
Center the fullscreen lightbox photo vertically — symmetric head/foot whitespace; visual-only, no logic change.

## What

The fullscreen photo lightbox (`src/components/listing/ListingLightbox.js`) rendered with all whitespace above the photo while the image touched the bottom of the viewport. The top counter/close bar consumed flow height, so the `object-contain` image was centered only within the area *below* the bar rather than the full viewport.

## Fix

- Overlay the top counter/close bar (`absolute inset-x-0 top-0 z-10`) so it no longer consumes vertical flow space.
- Give the photo track symmetric vertical padding (`py-18`, ~72px matching the bar height) so the image — and the prev/next arrows — center in the full viewport with equal head/foot whitespace, while still reserving room so the image never slides under the bar.

Two Tailwind class edits only. No behavior change: keyboard nav, swipe/drag, pinch-zoom, counter, close button, prev/next arrows, focus trap, and Escape handling are all untouched.

## Validation

- `npm run lint` — pass (0 errors; 1 pre-existing unrelated warning in `cf/worker-entry.mjs`)
- `npm run test` — pass (174/174)
- `npm run build` — pass (compiled successfully)

No `en.json` strings added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)