### PR TITLE
feat(landlord-dashboard): average first-response-time stat

### DIFF
--- a/__tests__/lib/landlordResponseTime.test.js
+++ b/__tests__/lib/landlordResponseTime.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatDuration,
+  computeFirstResponseStats,
+} from '@/lib/landlordResponseTime';
+
+const MIN = 60 * 1000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+describe('formatDuration', () => {
+  it('returns null for nullish / invalid / negative input', () => {
+    expect(formatDuration(null)).toBeNull();
+    expect(formatDuration(undefined)).toBeNull();
+    expect(formatDuration(NaN)).toBeNull();
+    expect(formatDuration(-5)).toBeNull();
+  });
+
+  it('renders sub-minute as <1m', () => {
+    expect(formatDuration(0)).toBe('<1m');
+    expect(formatDuration(30 * 1000)).toBe('<1m');
+  });
+
+  it('renders minutes under an hour', () => {
+    expect(formatDuration(12 * MIN)).toBe('12m');
+    expect(formatDuration(59 * MIN)).toBe('59m');
+  });
+
+  it('renders hours, with minutes when present', () => {
+    expect(formatDuration(4 * HOUR)).toBe('4h');
+    expect(formatDuration(4 * HOUR + 30 * MIN)).toBe('4h 30m');
+  });
+
+  it('rolls a 60-minute rounding edge up to the next hour', () => {
+    // 4h 59m30s rounds the minutes to 60 → should read 5h, not "4h 60m".
+    expect(formatDuration(4 * HOUR + 59.6 * MIN)).toBe('5h');
+  });
+
+  it('renders days, with hours when present', () => {
+    expect(formatDuration(DAY)).toBe('1d');
+    expect(formatDuration(DAY + 3 * HOUR)).toBe('1d 3h');
+    expect(formatDuration(2 * DAY)).toBe('2d');
+  });
+});
+
+describe('computeFirstResponseStats', () => {
+  const base = '2026-01-01T00:00:00.000Z';
+  const at = (ms) => new Date(new Date(base).getTime() + ms).toISOString();
+
+  it('returns empty stats when there are no replies', () => {
+    const inquiries = [{ inquiry_id: 'a', created_at: base }];
+    expect(computeFirstResponseStats(inquiries, [])).toEqual({
+      avgMs: null,
+      count: 0,
+      formatted: null,
+    });
+  });
+
+  it('uses the EARLIEST landlord message per inquiry regardless of order', () => {
+    const inquiries = [{ inquiry_id: 'a', created_at: base }];
+    const messages = [
+      { inquiry_id: 'a', created_at: at(5 * HOUR) }, // later reply first
+      { inquiry_id: 'a', created_at: at(2 * HOUR) }, // earliest = 2h
+    ];
+    const out = computeFirstResponseStats(inquiries, messages);
+    expect(out.count).toBe(1);
+    expect(out.avgMs).toBe(2 * HOUR);
+    expect(out.formatted).toBe('2h');
+  });
+
+  it('excludes inquiries with no landlord reply (not counted as zero)', () => {
+    const inquiries = [
+      { inquiry_id: 'a', created_at: base }, // replied at 2h
+      { inquiry_id: 'b', created_at: base }, // never replied
+    ];
+    const messages = [{ inquiry_id: 'a', created_at: at(2 * HOUR) }];
+    const out = computeFirstResponseStats(inquiries, messages);
+    // Only inquiry 'a' contributes; average is 2h, not 1h.
+    expect(out.count).toBe(1);
+    expect(out.avgMs).toBe(2 * HOUR);
+  });
+
+  it('averages across multiple replied inquiries', () => {
+    const inquiries = [
+      { inquiry_id: 'a', created_at: base },
+      { inquiry_id: 'b', created_at: base },
+    ];
+    const messages = [
+      { inquiry_id: 'a', created_at: at(2 * HOUR) },
+      { inquiry_id: 'b', created_at: at(4 * HOUR) },
+    ];
+    const out = computeFirstResponseStats(inquiries, messages);
+    expect(out.count).toBe(2);
+    expect(out.avgMs).toBe(3 * HOUR);
+    expect(out.formatted).toBe('3h');
+  });
+
+  it('ignores negative gaps from clock skew', () => {
+    const inquiries = [
+      { inquiry_id: 'a', created_at: at(10 * HOUR) }, // reply predates inquiry
+      { inquiry_id: 'b', created_at: base },
+    ];
+    const messages = [
+      { inquiry_id: 'a', created_at: at(2 * HOUR) }, // negative → dropped
+      { inquiry_id: 'b', created_at: at(6 * HOUR) },
+    ];
+    const out = computeFirstResponseStats(inquiries, messages);
+    expect(out.count).toBe(1);
+    expect(out.avgMs).toBe(6 * HOUR);
+  });
+
+  it('tolerates missing / malformed rows', () => {
+    expect(computeFirstResponseStats(null, null)).toEqual({
+      avgMs: null,
+      count: 0,
+      formatted: null,
+    });
+    const inquiries = [{ inquiry_id: 'a', created_at: base }, {}, null];
+    const messages = [{ inquiry_id: 'a', created_at: at(HOUR) }, { created_at: at(HOUR) }];
+    const out = computeFirstResponseStats(inquiries, messages);
+    expect(out.count).toBe(1);
+    expect(out.formatted).toBe('1h');
+  });
+});

--- a/src/app/[locale]/property/[city]/landlord/dashboard/page.js
+++ b/src/app/[locale]/property/[city]/landlord/dashboard/page.js
@@ -35,6 +35,7 @@ export default function LandlordDashboardPage() {
   const [recentInquiries, setRecentInquiries] = useState([]);
   const [pendingInquiryCount, setPendingInquiryCount] = useState(0);
   const [analytics, setAnalytics] = useState(null);
+  const [responseTime, setResponseTime] = useState(null);
   const [verifiedTier, setVerifiedTier] = useState('none');
   const [isVerified, setIsVerified] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -83,6 +84,18 @@ export default function LandlordDashboardPage() {
     } catch {}
   }
 
+  async function fetchResponseTime(token) {
+    try {
+      const res = await fetch('/api/landlord/response-time', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const { responseTime: data } = await res.json();
+        setResponseTime(data);
+      }
+    } catch {}
+  }
+
   async function fetchSubscription(token) {
     try {
       const res = await fetch('/api/landlord/billing/subscription', {
@@ -105,6 +118,7 @@ export default function LandlordDashboardPage() {
         fetchListings(session.access_token),
         fetchAnalytics(session.access_token),
         fetchInquiries(session.access_token),
+        fetchResponseTime(session.access_token),
         fetchSubscription(session.access_token),
       ]);
       setLoading(false);
@@ -114,6 +128,8 @@ export default function LandlordDashboardPage() {
   const activeListings = listings.length;
   const conversionPct = analytics?.conversion_rate ?? 0;
   const views30d = analytics?.views_last_30_days ?? 0;
+  const hasReplies = (responseTime?.count ?? 0) > 0;
+  const responseTimeValue = hasReplies ? responseTime.formatted : '—';
 
   return (
     <LandlordShell
@@ -134,7 +150,7 @@ export default function LandlordDashboardPage() {
       )}
 
       {/* Stats row */}
-      <section className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-10">
+      <section className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 mb-10">
         <StatTile
           label={t('statListings')}
           value={activeListings}
@@ -155,6 +171,12 @@ export default function LandlordDashboardPage() {
           label={t('statConversion')}
           value={`${conversionPct}%`}
           loading={loading}
+        />
+        <StatTile
+          label={t('statResponseTime')}
+          value={responseTimeValue}
+          loading={loading}
+          caption={!loading && !hasReplies ? t('statResponseTimeEmpty') : undefined}
         />
       </section>
 
@@ -244,7 +266,7 @@ export default function LandlordDashboardPage() {
   );
 }
 
-function StatTile({ label, value, loading, accent }) {
+function StatTile({ label, value, loading, accent, caption }) {
   return (
     <Card
       tone={accent ? 'night' : 'parchment'}
@@ -267,6 +289,11 @@ function StatTile({ label, value, loading, accent }) {
           value
         )}
       </p>
+      {!loading && caption && (
+        <p className={`mt-2 text-xs ${accent ? 'text-stone/60' : 'text-night/40'}`}>
+          {caption}
+        </p>
+      )}
     </Card>
   );
 }

--- a/src/app/api/landlord/response-time/route.js
+++ b/src/app/api/landlord/response-time/route.js
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { getSupabase } from '@/lib/supabase';
+import { extractToken, getUserFromToken, getSupabaseWithToken } from '@/lib/supabaseServer';
+import { getLandlordResponseTime } from '@/lib/landlordResponseTime';
+
+async function getLandlordId(userId) {
+  const { data } = await getSupabase()
+    .from('landlords')
+    .select('landlord_id')
+    .eq('auth_user_id', userId)
+    .single();
+  return data?.landlord_id ?? null;
+}
+
+export async function GET(request) {
+  const token = extractToken(request);
+  if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const user = await getUserFromToken(token);
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const landlordId = await getLandlordId(user.id);
+  if (!landlordId) return NextResponse.json({ error: 'Landlord profile not found' }, { status: 404 });
+
+  const authedSupabase = getSupabaseWithToken(token);
+
+  // Landlord's listing IDs (RLS-scoped to this landlord).
+  const { data: listings } = await authedSupabase
+    .from('listings')
+    .select('listing_id')
+    .eq('landlord_id', landlordId);
+
+  const listingIds = (listings || []).map((l) => l.listing_id);
+
+  try {
+    const stats = await getLandlordResponseTime(authedSupabase, listingIds);
+    return NextResponse.json({ responseTime: stats });
+  } catch (err) {
+    console.error('Failed to compute landlord response time:', err);
+    return NextResponse.json({ error: 'Failed to compute response time' }, { status: 500 });
+  }
+}

--- a/src/lib/landlordResponseTime.js
+++ b/src/lib/landlordResponseTime.js
@@ -1,0 +1,143 @@
+/**
+ * Landlord first-response-time stat.
+ *
+ * "First response time" for one inquiry = the gap between when the inquiry
+ * was created and when the landlord posted their FIRST reply in the chat
+ * thread (the earliest `inquiry_messages` row with sender_role = 'landlord').
+ * The landlord's average is the mean of that gap across every inquiry that
+ * received at least one landlord reply. Inquiries with no landlord reply are
+ * excluded entirely (they are NOT counted as a zero or as a penalty).
+ *
+ * The computation uses existing tables only (`inquiries` + `inquiry_messages`)
+ * and honours RLS — pass in a token-scoped Supabase client so the landlord
+ * only ever sees their own inquiries' messages.
+ */
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/**
+ * Human-readable duration. Pure — exported for unit testing.
+ *   < 1 min   → "<1m"
+ *   < 1 hour  → "12m"
+ *   < 1 day   → "4h" or "4h 30m"
+ *   >= 1 day  → "1d" or "1d 3h"
+ * Returns null for nullish / non-finite / negative input.
+ *
+ * @param {number|null|undefined} ms
+ * @returns {string|null}
+ */
+export function formatDuration(ms) {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return null;
+
+  if (ms < MINUTE) return '<1m';
+
+  if (ms < HOUR) {
+    const minutes = Math.round(ms / MINUTE);
+    return `${minutes}m`;
+  }
+
+  if (ms < DAY) {
+    const hours = Math.floor(ms / HOUR);
+    const minutes = Math.round((ms % HOUR) / MINUTE);
+    // Avoid "4h 60m" rounding edge.
+    if (minutes === 0 || minutes === 60) return `${minutes === 60 ? hours + 1 : hours}h`;
+    return `${hours}h ${minutes}m`;
+  }
+
+  const days = Math.floor(ms / DAY);
+  const hours = Math.round((ms % DAY) / HOUR);
+  if (hours === 0 || hours === 24) return `${hours === 24 ? days + 1 : days}d`;
+  return `${days}d ${hours}h`;
+}
+
+/**
+ * Reduce raw inquiry + landlord-message rows into the average first-response
+ * stat. Pure — exported for unit testing (no DB access).
+ *
+ * @param {Array<{ inquiry_id: string, created_at: string }>} inquiries
+ * @param {Array<{ inquiry_id: string, created_at: string }>} landlordMessages
+ *        every inquiry_messages row with sender_role = 'landlord' for the
+ *        given inquiries (any order — we take the min per inquiry).
+ * @returns {{ avgMs: number|null, count: number, formatted: string|null }}
+ *          `count` is the number of replied inquiries that contributed;
+ *          `avgMs`/`formatted` are null when count === 0.
+ */
+export function computeFirstResponseStats(inquiries, landlordMessages) {
+  const createdAtById = new Map();
+  for (const inq of inquiries || []) {
+    if (inq && inq.inquiry_id && inq.created_at) {
+      createdAtById.set(inq.inquiry_id, new Date(inq.created_at).getTime());
+    }
+  }
+
+  // Earliest landlord message timestamp per inquiry.
+  const firstReplyById = new Map();
+  for (const msg of landlordMessages || []) {
+    if (!msg || !msg.inquiry_id || !msg.created_at) continue;
+    const ts = new Date(msg.created_at).getTime();
+    if (!Number.isFinite(ts)) continue;
+    const existing = firstReplyById.get(msg.inquiry_id);
+    if (existing == null || ts < existing) {
+      firstReplyById.set(msg.inquiry_id, ts);
+    }
+  }
+
+  const deltas = [];
+  for (const [inquiryId, firstReplyTs] of firstReplyById) {
+    const createdTs = createdAtById.get(inquiryId);
+    if (createdTs == null || !Number.isFinite(createdTs)) continue;
+    const delta = firstReplyTs - createdTs;
+    // Guard against clock skew producing a negative gap.
+    if (delta >= 0) deltas.push(delta);
+  }
+
+  if (deltas.length === 0) {
+    return { avgMs: null, count: 0, formatted: null };
+  }
+
+  const avgMs = deltas.reduce((sum, d) => sum + d, 0) / deltas.length;
+  return { avgMs, count: deltas.length, formatted: formatDuration(avgMs) };
+}
+
+/**
+ * Fetch + compute the landlord's average first-response time over the
+ * inquiries on the given listings. Honours RLS via the passed client.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ *        token-scoped client (so RLS limits rows to this landlord).
+ * @param {string[]} listingIds  the landlord's listing ids.
+ * @returns {Promise<{ avgMs: number|null, count: number, formatted: string|null }>}
+ */
+export async function getLandlordResponseTime(supabase, listingIds) {
+  const ids = (listingIds || []).filter(Boolean);
+  if (ids.length === 0) {
+    return { avgMs: null, count: 0, formatted: null };
+  }
+
+  const { data: inquiries, error: inqError } = await supabase
+    .from('inquiries')
+    .select('inquiry_id, created_at')
+    .in('listing_id', ids);
+
+  if (inqError) throw inqError;
+
+  const inquiryIds = (inquiries || []).map((i) => i.inquiry_id).filter(Boolean);
+  if (inquiryIds.length === 0) {
+    return { avgMs: null, count: 0, formatted: null };
+  }
+
+  // Bulk fetch — one query for all inquiries, ordered so the first row per
+  // inquiry is already the earliest reply (the reducer also defends this).
+  const { data: messages, error: msgError } = await supabase
+    .from('inquiry_messages')
+    .select('inquiry_id, created_at')
+    .eq('sender_role', 'landlord')
+    .in('inquiry_id', inquiryIds)
+    .order('created_at', { ascending: true });
+
+  if (msgError) throw msgError;
+
+  return computeFirstResponseStats(inquiries, messages);
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -600,6 +600,8 @@
         "statInquiries": "Pending inquiries",
         "statViews": "Views this month",
         "statConversion": "Conversion rate",
+        "statResponseTime": "Avg. response time",
+        "statResponseTimeEmpty": "No replies yet",
         "quickNewListing": "+ New listing",
         "quickInquiries": "View inquiries",
         "quickVerify": "Get verified",


### PR DESCRIPTION
Adds an **Avg. response time** stat to the landlord dashboard.

## What it shows
The mean, over the landlord's inquiries that received a reply, of (first landlord reply timestamp − inquiry created_at). Rendered as a 5th stat card next to Active listings / Pending inquiries / Views / Conversion. When there are zero replied inquiries it shows `—` with a "No replies yet" caption.

## How it's computed
- For each of the landlord's inquiries, the **first** landlord `inquiry_messages` row (`sender_role = 'landlord'`, earliest `created_at`) minus `inquiries.created_at`.
- Those per-inquiry gaps are averaged. **Inquiries with no landlord reply are excluded** (not counted as zero).
- Negative gaps from clock skew are dropped.

Uses **existing tables only** (`inquiries` + `inquiry_messages`) — **no migration**. The fetch is a single bulk `.in('inquiry_id', [...])` query (no N+1), through the token-scoped Supabase client so RLS limits rows to the calling landlord.

## Files
- `src/lib/landlordResponseTime.js` (new) — pure `formatDuration` + `computeFirstResponseStats`, plus `getLandlordResponseTime(supabase, listingIds)`.
- `src/app/api/landlord/response-time/route.js` (new) — landlord-authed GET mirroring the analytics route's auth pattern; returns `{ responseTime: { avgMs, count, formatted } }`.
- `src/app/[locale]/property/[city]/landlord/dashboard/page.js` — fetches the endpoint and renders the new stat card (`StatTile` gained an optional `caption`).
- `src/messages/en.json` — `statResponseTime`, `statResponseTimeEmpty` (additive).
- `__tests__/lib/landlordResponseTime.test.js` (new) — 12 tests.

Dashboard-only — no public listing badge.

lint ✅ · test ✅ (186 passed) · build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)