### PR TITLE
feat(listing): report-this-listing flow (email-only v1)

### DIFF
--- a/src/app/[locale]/property/[city]/listing/[id]/page.js
+++ b/src/app/[locale]/property/[city]/listing/[id]/page.js
@@ -9,6 +9,7 @@ import ListingGallery from '@/components/listing/ListingGallery';
 import ContactRail from '@/components/listing/ContactRail';
 import ContactGate from '@/components/listing/ContactGate';
 import ViewTracker from '@/components/listing/ViewTracker';
+import ReportListingModal from '@/components/listing/ReportListingModal';
 import FavoriteButton from '@/components/FavoriteButton';
 import Pill from '@/components/ui/Pill';
 import Card from '@/components/ui/Card';
@@ -224,6 +225,13 @@ export default async function ListingPage({ params, searchParams }) {
               </tbody>
             </table>
           </section>
+
+          {/* Subtle "report this listing" trigger — opens a client modal that
+              emails the ops inbox (email-only v1, no DB). Rendered here on the
+              page, not inside a shared detail component. */}
+          <div className="mt-4">
+            <ReportListingModal listingId={listing.listing_id} />
+          </div>
         </div>
 
         {/* Right column — sticky inquiry rail (client-side for modal state) */}

--- a/src/app/api/listings/report/route.js
+++ b/src/app/api/listings/report/route.js
@@ -1,0 +1,170 @@
+import { NextResponse } from 'next/server';
+import { getResend } from '@/lib/resend';
+import { normalizeMultiLine, codepointLength } from '@/lib/textNormalize';
+
+const FROM_ADDRESS = 'StudentX <alerts@studentx.uk>';
+
+// Fixed reason set — must mirror the radio options in ReportListingModal.js
+// and the `report.reason*` keys in en.json. Anything outside this set is a
+// 400 (the modal can only emit these, so an off-list value means a tampered
+// or stale client).
+const ALLOWED_REASONS = new Set([
+  'already_rented',
+  'scam_fraud',
+  'inaccurate_info',
+  'inappropriate',
+  'other',
+]);
+
+const MAX_NOTE_LEN = 1000;
+
+// All listing ids are 7-digit (see star schema). Reject anything else before
+// we spend a Resend send on it.
+const LISTING_ID_RE = /^\d{7}$/;
+
+// --- Best-effort per-IP rate limit ----------------------------------------
+// Module-level Map keyed by client IP → array of recent report timestamps.
+// This is BEST-EFFORT ONLY: Cloudflare Workers runs each request in an
+// ephemeral isolate that can be recycled at any time and is not shared
+// across colos, so this Map is neither global nor durable. It throttles the
+// common "mash the button" / single-isolate flood case and nothing more.
+// A hard guarantee would need a durable store (KV / Durable Object / DB).
+const RATE_LIMIT_MAX = 3; // reports
+const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000; // per 10 minutes per IP
+const reportHits = new Map();
+
+/**
+ * Derive the client IP from the standard CF / proxy headers. Mirrors the
+ * header precedence used elsewhere; cf-connecting-ip is the single trusted
+ * client IP on Cloudflare, x-forwarded-for is the proxy chain (first hop is
+ * the client). Falls back to 'unknown' so the limiter still buckets when no
+ * header is present (e.g. local dev).
+ */
+function clientIp(request) {
+  const cf = request.headers.get('cf-connecting-ip');
+  if (cf) return cf.trim();
+  const xff = request.headers.get('x-forwarded-for');
+  if (xff) return xff.split(',')[0].trim();
+  const real = request.headers.get('x-real-ip');
+  if (real) return real.trim();
+  return 'unknown';
+}
+
+/** @returns {boolean} true when this IP is over the window budget. */
+function isRateLimited(ip) {
+  const now = Date.now();
+  const cutoff = now - RATE_LIMIT_WINDOW_MS;
+  const recent = (reportHits.get(ip) || []).filter((ts) => ts > cutoff);
+  if (recent.length >= RATE_LIMIT_MAX) {
+    reportHits.set(ip, recent);
+    return true;
+  }
+  recent.push(now);
+  reportHits.set(ip, recent);
+  return false;
+}
+
+const REASON_LABELS = {
+  already_rented: 'Already rented / no longer available',
+  scam_fraud: 'Scam or fraud',
+  inaccurate_info: 'Inaccurate information',
+  inappropriate: 'Inappropriate content',
+  other: 'Other',
+};
+
+/**
+ * Anonymous listing-report endpoint (email-only v1 — no table/migration).
+ * A visitor flags a listing from the detail page; we email the ops inbox
+ * (SYNTHETIC_ALERT_EMAIL) so a human can review and act. Validation is
+ * strict (7-digit id, enum reason, capped note) and there's a best-effort
+ * per-IP throttle. Email failures mirror inquiryEmail.js: logged, surfaced
+ * to the caller as a 5xx.
+ */
+export async function POST(request) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error_code: 'INVALID_INPUT', error: 'Invalid JSON body' },
+      { status: 400 },
+    );
+  }
+
+  const listingId = typeof body.listingId === 'string' ? body.listingId.trim() : '';
+  if (!LISTING_ID_RE.test(listingId)) {
+    return NextResponse.json(
+      { error_code: 'INVALID_INPUT', error: 'listingId must be a 7-digit id' },
+      { status: 400 },
+    );
+  }
+
+  const reason = typeof body.reason === 'string' ? body.reason.trim() : '';
+  if (!ALLOWED_REASONS.has(reason)) {
+    return NextResponse.json(
+      { error_code: 'INVALID_INPUT', error: 'reason is not one of the allowed values' },
+      { status: 400 },
+    );
+  }
+
+  // note is optional. Normalize, then hard-cap by codepoint length.
+  let note = normalizeMultiLine(body.note) ?? '';
+  if (codepointLength(note) > MAX_NOTE_LEN) {
+    note = [...note].slice(0, MAX_NOTE_LEN).join('');
+  }
+
+  // Throttle after validation so malformed floods are cheap and a 400 never
+  // burns a 429 slot.
+  const ip = clientIp(request);
+  if (isRateLimited(ip)) {
+    return NextResponse.json(
+      { error_code: 'RATE_LIMITED', error: 'Too many reports. Please try again later.' },
+      { status: 429 },
+    );
+  }
+
+  const recipient = process.env.SYNTHETIC_ALERT_EMAIL;
+  if (!recipient) {
+    console.error('Listing report: no SYNTHETIC_ALERT_EMAIL configured; dropping report', {
+      listingId,
+      reason,
+    });
+    return NextResponse.json(
+      { error_code: 'INTERNAL', error: 'Reporting is temporarily unavailable' },
+      { status: 500 },
+    );
+  }
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://studentx.uk';
+  const listingUrl = `${appUrl}/property/thessaloniki/listing/${listingId}`;
+  const reasonLabel = REASON_LABELS[reason] || reason;
+
+  const lines = [
+    'A visitor reported a listing on StudentX.',
+    '',
+    `Listing ID: ${listingId}`,
+    `Listing URL: ${listingUrl}`,
+    `Reason: ${reasonLabel} (${reason})`,
+    `Reporter IP: ${ip}`,
+    '',
+    'Note:',
+    note || '(none)',
+  ];
+
+  try {
+    await getResend().emails.send({
+      from: FROM_ADDRESS,
+      to: recipient,
+      subject: `Listing report — ${listingId} — ${reasonLabel}`,
+      text: lines.join('\n'),
+    });
+  } catch (err) {
+    console.error('Failed to send listing-report email:', err);
+    return NextResponse.json(
+      { error_code: 'INTERNAL', error: 'Failed to submit report' },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ ok: true }, { status: 200 });
+}

--- a/src/components/listing/ReportListingModal.js
+++ b/src/components/listing/ReportListingModal.js
@@ -1,0 +1,206 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import Card from '@/components/ui/Card';
+import Icon from '@/components/ui/Icon';
+import Button from '@/components/ui/Button';
+
+// Fixed reason set — must mirror ALLOWED_REASONS in
+// src/app/api/listings/report/route.js and the report.reason* keys in en.json.
+const REASONS = [
+  'already_rented',
+  'scam_fraud',
+  'inaccurate_info',
+  'inappropriate',
+  'other',
+];
+
+const MAX_NOTE_LEN = 1000;
+
+/**
+ * "Report this listing" — a subtle trigger link + a small modal. Anyone
+ * (signed in or not) can flag a listing; on submit it POSTs to
+ * /api/listings/report and the ops inbox gets an email. Email-only v1, no DB.
+ *
+ * Rendered directly by the listing detail page (not inside a shared detail
+ * component) so the trigger lives alongside the page, not the reusable parts.
+ */
+export default function ReportListingModal({ listingId }) {
+  const t = useTranslations('propylaea.report');
+
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState('');
+  const [note, setNote] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [status, setStatus] = useState('idle'); // 'idle' | 'success' | 'error'
+  const [error, setError] = useState('');
+
+  function close() {
+    if (submitting) return;
+    setOpen(false);
+    // Reset for a clean next open. Safe — runs from an event handler, not
+    // during render.
+    setReason('');
+    setNote('');
+    setStatus('idle');
+    setError('');
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (!reason) {
+      setError(t('errorNoReason'));
+      return;
+    }
+    setError('');
+    setSubmitting(true);
+
+    try {
+      const res = await fetch('/api/listings/report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ listingId, reason, note: note.trim() || undefined }),
+      });
+
+      if (res.status === 429) {
+        setStatus('error');
+        setError(t('errorRateLimited'));
+        return;
+      }
+      if (!res.ok) {
+        setStatus('error');
+        setError(t('errorGeneric'));
+        return;
+      }
+
+      setStatus('success');
+    } catch (err) {
+      console.error('[ReportListingModal] report failed:', err);
+      setStatus('error');
+      setError(t('errorGeneric'));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-1.5 label-caps text-night/40 hover:text-magenta transition-colors"
+      >
+        <Icon name="shield" className="w-3.5 h-3.5" />
+        {t('trigger')}
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label={t('title')}
+        >
+          <div className="absolute inset-0 bg-night/60" onClick={close} />
+          <Card tone="white" className="relative z-10 w-full max-w-lg p-6 md:p-8">
+            <div className="flex items-start justify-between mb-4 gap-3">
+              <div>
+                <p className="font-display text-2xl text-night">{t('title')}</p>
+                <p className="mt-1 text-sm text-night/60">{t('subtitle')}</p>
+              </div>
+              <button
+                type="button"
+                onClick={close}
+                disabled={submitting}
+                className="p-1 text-night/60 hover:text-night disabled:opacity-50"
+                aria-label={t('closeAriaLabel')}
+              >
+                <Icon name="x" className="w-5 h-5" />
+              </button>
+            </div>
+
+            {status === 'success' ? (
+              <div className="py-4">
+                <p className="flex items-center gap-2 font-display text-lg text-night">
+                  <Icon name="check" className="w-5 h-5 text-blue" />
+                  {t('successTitle')}
+                </p>
+                <p className="mt-2 text-sm text-night/60">{t('successBody')}</p>
+                <Button
+                  type="button"
+                  variant="primary"
+                  onClick={close}
+                  className="mt-5 w-full justify-center"
+                >
+                  {t('done')}
+                </Button>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-5">
+                <fieldset className="space-y-2.5">
+                  <legend className="label-caps text-night/70 mb-1">
+                    {t('reasonLegend')}
+                  </legend>
+                  {REASONS.map((r) => (
+                    <label
+                      key={r}
+                      className="flex items-center gap-3 text-sm text-night/80 cursor-pointer"
+                    >
+                      <input
+                        type="radio"
+                        name="report-reason"
+                        value={r}
+                        checked={reason === r}
+                        onChange={() => setReason(r)}
+                        className="h-4 w-4 accent-blue"
+                      />
+                      {t(`reason_${r}`)}
+                    </label>
+                  ))}
+                </fieldset>
+
+                <div>
+                  <label
+                    htmlFor="report-note"
+                    className="label-caps text-night/70 block mb-1.5"
+                  >
+                    {t('noteLabel')}
+                  </label>
+                  <textarea
+                    id="report-note"
+                    rows={3}
+                    value={note}
+                    onChange={(e) => setNote(e.target.value)}
+                    placeholder={t('notePlaceholder')}
+                    maxLength={MAX_NOTE_LEN}
+                    className="w-full rounded-sm border border-night/15 bg-stone/40 px-3.5 py-3 text-sm text-night focus:outline-none focus:ring-2 focus:ring-blue/20 focus:border-blue resize-none"
+                  />
+                </div>
+
+                {error && (
+                  <p
+                    role="alert"
+                    className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-sm px-3 py-2"
+                  >
+                    {error}
+                  </p>
+                )}
+
+                <Button
+                  type="submit"
+                  variant="primary"
+                  disabled={submitting}
+                  className="w-full justify-center"
+                >
+                  {submitting ? t('submitting') : t('submit')}
+                </Button>
+              </form>
+            )}
+          </Card>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -578,6 +578,28 @@
       "zoomIn": "Zoom in",
       "zoomOut": "Zoom out"
     },
+    "report": {
+      "trigger": "Report this listing",
+      "title": "Report this listing",
+      "subtitle": "Tell us what's wrong and our team will review it.",
+      "reasonLegend": "Reason",
+      "reason_already_rented": "Already rented or no longer available",
+      "reason_scam_fraud": "Scam or fraud",
+      "reason_inaccurate_info": "Inaccurate information",
+      "reason_inappropriate": "Inappropriate content",
+      "reason_other": "Something else",
+      "noteLabel": "Add a note (optional)",
+      "notePlaceholder": "Anything else we should know?",
+      "submit": "Submit report",
+      "submitting": "Submitting…",
+      "successTitle": "Report received",
+      "successBody": "Thanks — our team will take a look. You can close this now.",
+      "done": "Close",
+      "closeAriaLabel": "Close report dialog",
+      "errorNoReason": "Please choose a reason.",
+      "errorRateLimited": "You've sent a few reports already. Please try again later.",
+      "errorGeneric": "Something went wrong. Please try again."
+    },
     "landlord": {
       "nav": {
         "dashboard": "Dashboard",


### PR DESCRIPTION
Adds a "Report this listing" flow to the listing detail page so visitors can flag a listing (already rented, scam, inaccurate info, inappropriate, other) with an optional note. Email-only v1 — no DB table, no migration.

## What's in it
- **UI:** subtle "Report this listing" trigger on the listing detail page that opens a small client modal (`src/components/listing/ReportListingModal.js`). Pick a reason from a fixed set + optional free-text note; POSTs to the API; shows a success/closing state and handles error/429 gracefully. Rendered directly in `listing/[id]/page.js` (the page I own), not inside any shared detail component.
- **API:** `POST /api/listings/report` (`src/app/api/listings/report/route.js`).

## Validation
- `listingId` must match `/^\d{7}$/` (7-digit) — 400 otherwise.
- `reason` must be one of `already_rented | scam_fraud | inaccurate_info | inappropriate | other` — 400 otherwise.
- `note` optional: normalized (`normalizeMultiLine`) and hard-capped at 1000 codepoints.

## Rate limit
- Best-effort per-IP throttle: max **3 reports / 10 min per IP**, returns **429** when exceeded.
- Implemented as a module-level `Map`. Documented in a code comment as **best-effort only** — Cloudflare Workers isolates are ephemeral and not shared across colos, so this is not a hard guarantee (a durable store would be needed for that). IP derived from `cf-connecting-ip` → `x-forwarded-for` (first hop) → `x-real-ip`.

## Recipient
- Reuses **`SYNTHETIC_ALERT_EMAIL`** — the existing ops inbox (already set in `wrangler.jsonc`). No dedicated report/curator env var exists, so this is the most appropriate existing inbox. If a dedicated curator address is wanted later, swap the one `process.env.SYNTHETIC_ALERT_EMAIL` read.

## Email + safety
- Sends from `alerts@studentx.uk` via the existing lazy `getResend()` helper (same pattern as `src/lib/inquiryEmail.js`) — Resend is **not** initialized at module top level, so the route compiles and tests/build pass without `RESEND_API_KEY`.
- Email body includes listing id, reason, optional note, reporter IP, and the listing URL (`NEXT_PUBLIC_APP_URL` + `/property/thessaloniki/listing/<id>`).
- On email failure: logged and returns a 5xx (mirrors `inquiryEmail` error handling). Missing recipient env → 500 with a logged warning.

## i18n
- All strings added under a new `propylaea.report` sub-namespace in `src/messages/en.json` (additive only).

## Checks
- `npm run lint` — 0 errors (1 pre-existing unrelated warning in `cf/worker-entry.mjs`)
- `npm run test` — 174/174 pass
- `npm run build` — compiled successfully; `/api/listings/report` present in route manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)