### PR TITLE
feat(results): filter-aware price histogram (#218)

### DIFF
--- a/__tests__/api/priceDistribution.test.js
+++ b/__tests__/api/priceDistribution.test.js
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock the anon Supabase client the route uses. Each test wires the resolved
-// `.from(...).select(...)` result.
+// Mock the anon Supabase client the route uses.
 const getSupabase = vi.fn();
 vi.mock('@/lib/supabase', () => ({
   getSupabase: (...args) => getSupabase(...args),
@@ -13,13 +12,35 @@ beforeEach(() => {
   getSupabase.mockReset();
 });
 
-// Minimal chainable stub: getSupabase().from(...).select(...) resolves `result`.
-function fakeSupabase(result) {
-  return {
-    from: vi.fn(() => ({
-      select: vi.fn(async () => result),
-    })),
+// A chainable PostgREST query-builder stub. Every filter method records its
+// call (so tests can assert which WHERE clauses the route applied) and returns
+// the builder; the builder is thenable, so `await query` resolves to `result`.
+// `from()` returns a fresh builder per call (main + fallback queries) but they
+// share one `calls` log and resolve to the same `result`.
+function fakeSupabase(result, { rpcResult } = {}) {
+  const calls = [];
+  const makeBuilder = () => {
+    const b = {};
+    const rec = (name) => (...args) => {
+      calls.push([name, ...args]);
+      return b;
+    };
+    for (const m of ['select', 'in', 'eq', 'neq', 'or', 'gte', 'lte', 'order']) {
+      b[m] = rec(m);
+    }
+    b.then = (resolve, reject) => Promise.resolve(result).then(resolve, reject);
+    return b;
   };
+  return {
+    from: vi.fn(() => makeBuilder()),
+    rpc: vi.fn(async () => rpcResult || { data: null, error: null }),
+    _calls: calls,
+  };
+}
+
+// Build a Request-like object for the route's `new URL(request.url)`.
+function req(qs = '') {
+  return { url: `http://localhost/api/listings/price-distribution${qs ? `?${qs}` : ''}` };
 }
 
 describe('GET /api/listings/price-distribution', () => {
@@ -38,37 +59,95 @@ describe('GET /api/listings/price-distribution', () => {
       })
     );
 
-    const res = await GET();
+    const res = await GET(req());
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.prices).toEqual([400, 850, 600]);
-    // Cacheable at the edge — distribution is identical for every visitor.
+    // Cacheable at the edge (per filter-combo).
     expect(res.headers.get('Cache-Control')).toContain('s-maxage=300');
   });
 
-  it('does NOT apply any budget filter (returns prices across the full range)', async () => {
-    getSupabase.mockReturnValue(
-      fakeSupabase({
-        data: [{ rent: { monthly_price: 300 } }, { rent: { monthly_price: 2000 } }],
-        error: null,
-      })
-    );
+  it('does NOT apply any budget filter — budget params are ignored', async () => {
+    const supa = fakeSupabase({
+      data: [{ rent: { monthly_price: 300 } }, { rent: { monthly_price: 2000 } }],
+      error: null,
+    });
+    getSupabase.mockReturnValue(supa);
 
-    const res = await GET();
+    // Pass budget params that would normally constrain the result.
+    const res = await GET(req('max_budget=500&min_budget=400'));
+    expect(res.status).toBe(200);
     const body = await res.json();
-    // Both the cheap and the well-above-typical-budget listing come back.
+    // Both the cheap and the well-above-budget listing come back unfiltered.
     expect(body.prices).toEqual([300, 2000]);
+    // And no monthly_price range clause was ever pushed to the query.
+    const budgetClauses = supa._calls.filter(
+      ([name, col]) => (name === 'gte' || name === 'lte') && col === 'rent.monthly_price'
+    );
+    expect(budgetClauses).toEqual([]);
   });
 
-  it('returns 500 when the query errors', async () => {
+  it('applies a non-budget filter — neighborhoods narrows the query', async () => {
+    // Mock returns the already-narrowed subset the DB would for ?neighborhoods=Kentro.
+    const supa = fakeSupabase({
+      data: [{ rent: { monthly_price: 420 } }, { rent: { monthly_price: 560 } }],
+      error: null,
+    });
+    getSupabase.mockReturnValue(supa);
+
+    const res = await GET(req('neighborhoods=Kentro'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.prices).toEqual([420, 560]);
+
+    // The route translated the param into the matching PostgREST clause.
+    const neighborhoodClause = supa._calls.find(
+      ([name, col]) => name === 'in' && col === 'location.neighborhood'
+    );
+    expect(neighborhoodClause).toBeTruthy();
+    expect(neighborhoodClause[2]).toEqual(['Kentro']);
+  });
+
+  it('applies type + verified filters alongside ignoring budget', async () => {
+    const supa = fakeSupabase({
+      data: [{ rent: { monthly_price: 700 } }],
+      error: null,
+    });
+    getSupabase.mockReturnValue(supa);
+
+    const res = await GET(req('types=Studio,1-Bedroom&verified_only=true&max_budget=600'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.prices).toEqual([700]); // above the 600 budget, still present
+
+    const typeClause = supa._calls.find(
+      ([name, col]) => name === 'in' && col === 'property_types.name'
+    );
+    expect(typeClause[2]).toEqual(['Studio', '1-Bedroom']);
+    // verified_only → both verified clauses applied
+    expect(supa._calls).toContainEqual(['neq', 'landlords.verified_tier', 'none']);
+    expect(supa._calls).toContainEqual(['eq', 'landlords.is_verified', true]);
+    // budget never applied
+    expect(supa._calls.some(([name]) => name === 'gte' || name === 'lte')).toBe(false);
+  });
+
+  it('returns 400 on an invalid non-budget filter (shared validation)', async () => {
+    getSupabase.mockReturnValue(fakeSupabase({ data: [], error: null }));
+    const res = await GET(req('min_duration=7'));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/min_duration/);
+  });
+
+  it('returns 500 when the query (and fallback) error', async () => {
     getSupabase.mockReturnValue(fakeSupabase({ data: null, error: { message: 'boom' } }));
-    const res = await GET();
+    const res = await GET(req());
     expect(res.status).toBe(500);
   });
 
   it('returns an empty array when there are no listings', async () => {
     getSupabase.mockReturnValue(fakeSupabase({ data: [], error: null }));
-    const res = await GET();
+    const res = await GET(req());
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.prices).toEqual([]);

--- a/__tests__/lib/listingFilters.test.js
+++ b/__tests__/lib/listingFilters.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseListingFilters,
+  applyListingFilters,
+  hasGroundFloorTag,
+  hasAllRequiredAmenities,
+} from '@/lib/listingFilters';
+
+// Thin URLSearchParams wrapper so tests read like query strings.
+const sp = (qs) => new URLSearchParams(qs);
+
+// A query-builder recorder: every method logs [name, ...args] and chains.
+function recorder() {
+  const calls = [];
+  const b = {};
+  const rec = (name) => (...args) => {
+    calls.push([name, ...args]);
+    return b;
+  };
+  for (const m of ['select', 'in', 'eq', 'neq', 'or', 'gte', 'lte', 'order']) {
+    b[m] = rec(m);
+  }
+  b._calls = calls;
+  return b;
+}
+
+describe('parseListingFilters', () => {
+  it('parses a normal filter combo with defaults', () => {
+    const f = parseListingFilters(
+      sp('types=Studio&neighborhoods=Kentro&verified_only=true&min_duration=5&available_from=2026-09-01')
+    );
+    expect(f.error).toBeUndefined();
+    expect(f).toMatchObject({
+      types: 'Studio',
+      neighborhoods: 'Kentro',
+      verifiedOnly: true,
+      minDurationN: 5,
+      availableFromDate: '2026-09-01',
+      sortBy: 'price',
+      sortOrder: 'asc',
+    });
+  });
+
+  it('does not read budget params (budget is the route-local divergence)', () => {
+    const f = parseListingFilters(sp('max_budget=abc&min_budget=-5'));
+    // Malformed budget never surfaces as an error here — it is simply ignored.
+    expect(f.error).toBeUndefined();
+    expect(f).not.toHaveProperty('maxBudget');
+    expect(f).not.toHaveProperty('minBudget');
+  });
+
+  it('rejects invalid min_duration', () => {
+    expect(parseListingFilters(sp('min_duration=7')).error).toMatch(/min_duration/);
+  });
+
+  it('rejects impossible available_from dates', () => {
+    expect(parseListingFilters(sp('available_from=2026-02-31')).error).toMatch(/available_from/);
+    expect(parseListingFilters(sp('available_from=nope')).error).toMatch(/available_from/);
+  });
+
+  it('rejects bad sort + the sort-needs-faculty rule + bad faculty id', () => {
+    expect(parseListingFilters(sp('sort_by=banana')).error).toMatch(/sort_by/);
+    expect(parseListingFilters(sp('sort_order=sideways')).error).toMatch(/sort_order/);
+    expect(parseListingFilters(sp('sort_by=walk_minutes')).error).toMatch(/requires a faculty/);
+    expect(parseListingFilters(sp('faculty=Not Valid')).error).toMatch(/faculty/);
+  });
+
+  it('rejects empty types / exclude_amenities', () => {
+    expect(parseListingFilters(sp('types=')).error).toMatch(/types/);
+    expect(parseListingFilters(sp('exclude_amenities=')).error).toMatch(/exclude_amenities/);
+  });
+});
+
+describe('applyListingFilters', () => {
+  it('applies every non-budget clause on the main path', () => {
+    const f = parseListingFilters(
+      sp('neighborhoods=Kentro,Toumba&types=Studio&faculty=auth-main&min_duration=5&verified_only=true&require_bills_included=true&exclude_ground_floor=true&available_from=2026-09-01')
+    );
+    const b = recorder();
+    applyListingFilters(b, f, { amenityListingIds: ['a', 'b'] });
+
+    expect(b._calls).toContainEqual(['in', 'listing_id', ['a', 'b']]);
+    expect(b._calls).toContainEqual(['in', 'location.neighborhood', ['Kentro', 'Toumba']]);
+    expect(b._calls).toContainEqual(['in', 'property_types.name', ['Studio']]);
+    expect(b._calls).toContainEqual(['eq', 'faculty_distances.faculty_id', 'auth-main']);
+    expect(b._calls).toContainEqual(['lte', 'min_duration_months', 5]);
+    expect(b._calls).toContainEqual(['neq', 'landlords.verified_tier', 'none']);
+    expect(b._calls).toContainEqual(['eq', 'landlords.is_verified', true]);
+    expect(b._calls).toContainEqual(['eq', 'rent.bills_included', true]);
+    expect(b._calls).toContainEqual(['or', 'floor.is.null,floor.neq.0']);
+    expect(b._calls).toContainEqual(['or', 'available_from.is.null,available_from.lte.2026-09-01']);
+    // never touches the budget column (min_duration's lte is on min_duration_months)
+    expect(
+      b._calls.some(([name, col]) => (name === 'gte' || name === 'lte') && col === 'rent.monthly_price')
+    ).toBe(false);
+  });
+
+  it('skips verified_only and min_duration on the fallback path', () => {
+    const f = parseListingFilters(sp('verified_only=true&min_duration=5&types=Studio'));
+    const b = recorder();
+    applyListingFilters(b, f, { fallback: true });
+
+    // types still applied...
+    expect(b._calls).toContainEqual(['in', 'property_types.name', ['Studio']]);
+    // ...but the two fallback-incompatible clauses are skipped.
+    expect(b._calls.some(([name, col]) => name === 'neq' && col === 'landlords.verified_tier')).toBe(false);
+    expect(b._calls.some(([name, col]) => name === 'lte' && col === 'min_duration_months')).toBe(false);
+  });
+});
+
+describe('amenity residual predicates', () => {
+  it('hasGroundFloorTag is case-insensitive and null-safe', () => {
+    expect(hasGroundFloorTag(['WiFi', 'Ground Floor'])).toBe(true);
+    expect(hasGroundFloorTag(['ground floor'])).toBe(true);
+    expect(hasGroundFloorTag(['WiFi'])).toBe(false);
+    expect(hasGroundFloorTag(null)).toBe(false);
+  });
+
+  it('hasAllRequiredAmenities requires every item, case-insensitive', () => {
+    expect(hasAllRequiredAmenities(['Furnished', 'AC'], ['furnished', 'ac'])).toBe(true);
+    expect(hasAllRequiredAmenities(['Furnished'], ['Furnished', 'AC'])).toBe(false);
+    expect(hasAllRequiredAmenities(['Furnished'], [])).toBe(true);
+  });
+});

--- a/src/app/[locale]/property/[city]/results/page.js
+++ b/src/app/[locale]/property/[city]/results/page.js
@@ -141,16 +141,60 @@ function ResultsContent() {
       .catch(() => {});
   }, []);
 
-  // Full city price distribution for the budget histogram — fetched once and
-  // independent of the budget filter (cheap: prices only, no listing payload),
-  // so the chart shows how much supply sits ABOVE the student's budget rather
-  // than collapsing to the in-budget slice already visible in the list.
+  // Price distribution for the budget histogram — reflects the student's
+  // current search EXCEPT budget (issue #218). Budget stays a purely
+  // client-side marker overlay (see aboveBudgetCount + the histogram below),
+  // so this refetches only when a NON-budget filter changes, never when the
+  // budget slider moves. Prices-only + cached per filter-combo at the edge, so
+  // re-fetching on each narrow is cheap, and the chart shows how much supply
+  // sits ABOVE the student's budget within their current search.
+  const fetchDistribution = useCallback(async () => {
+    try {
+      const params = new URLSearchParams();
+      if (filters.selectedTypes.length > 0)
+        params.set('types', filters.selectedTypes.join(','));
+      if (filters.selectedNeighborhoods.length > 0)
+        params.set('neighborhoods', filters.selectedNeighborhoods.join(','));
+      if (filters.verifiedOnly) params.set('verified_only', 'true');
+      if (filters.minDuration) params.set('min_duration', String(filters.minDuration));
+      if (filters.dealbreakers.length > 0) {
+        const requiredAmenities = [];
+        if (filters.dealbreakers.includes('unfurnished')) requiredAmenities.push('Furnished');
+        if (filters.dealbreakers.includes('no_ac')) requiredAmenities.push('AC');
+        if (requiredAmenities.length > 0)
+          params.set('exclude_amenities', requiredAmenities.join(','));
+        if (filters.dealbreakers.includes('ground_floor'))
+          params.set('exclude_ground_floor', 'true');
+        if (filters.dealbreakers.includes('bills_not_included'))
+          params.set('require_bills_included', 'true');
+      }
+      if (filters.availableFrom) params.set('available_from', filters.availableFrom);
+      // Budget (max_budget/min_budget) is deliberately omitted — the histogram
+      // must keep above-budget supply visible behind the marker.
+      const qs = params.toString();
+      const res = await fetch(`/api/listings/price-distribution${qs ? `?${qs}` : ''}`);
+      if (!res.ok) return; // keep the last good distribution on error
+      const d = await res.json();
+      setPriceDistribution(Array.isArray(d.prices) ? d.prices : []);
+    } catch {
+      // Network error — keep the last good distribution.
+    }
+  }, [
+    filters.selectedTypes,
+    filters.selectedNeighborhoods,
+    filters.verifiedOnly,
+    filters.minDuration,
+    filters.dealbreakers,
+    filters.availableFrom,
+  ]);
+
+  // Debounced refetch when the non-budget filters change (coalesces rapid
+  // multi-toggles), mirroring the listings fetch. fetchDistribution's identity
+  // is stable across budget-only changes, so dragging the slider never fires.
   useEffect(() => {
-    fetch('/api/listings/price-distribution')
-      .then((r) => r.json())
-      .then((d) => setPriceDistribution(Array.isArray(d.prices) ? d.prices : []))
-      .catch(() => {});
-  }, []);
+    const id = setTimeout(fetchDistribution, 300);
+    return () => clearTimeout(id);
+  }, [fetchDistribution]);
 
   // Sync filter/sort/view state INTO the URL so refresh + share + back
   // preserve what the user picked. The initial state is seeded from the
@@ -247,11 +291,12 @@ function ResultsContent() {
 
   const loaderVisible = showLoader && loading;
 
-  // Derived (pure) — bucket the FULL city price distribution (every listing,
-  // independent of the budget filter) so the chart shows how much supply sits
-  // ABOVE the student's budget, not just the in-budget slice already in the
-  // list below. Falls back to the fetched (budget-filtered) listings only while
-  // the distribution endpoint hasn't answered yet / if it failed.
+  // Derived (pure) — bucket the price distribution for the current search
+  // (all non-budget filters applied, budget ignored) so the chart shows how
+  // much supply sits ABOVE the student's budget within what they're browsing,
+  // not just the in-budget slice already in the list below. Falls back to the
+  // fetched (budget-filtered) listings only while the distribution endpoint
+  // hasn't answered yet / if it failed.
   const histogramSource = priceDistribution.length > 0
     ? priceDistribution.map((p) => ({ monthly_price: p }))
     : listings;
@@ -260,8 +305,9 @@ function ResultsContent() {
     max: BUDGET_MAX,
     buckets: HISTOGRAM_BUCKETS,
   });
-  // How many listings across the city cost more than the current budget —
-  // surfaced as an explicit line under the chart so the tradeoff is legible.
+  // How many listings in the current search cost more than the budget —
+  // recomputed client-side against the (filtered) distribution as the slider
+  // moves, surfaced as an explicit line under the chart so the tradeoff is legible.
   const aboveBudgetCount = priceDistribution.filter((p) => p > filters.maxBudget).length;
 
   return (
@@ -522,11 +568,12 @@ const DEALBREAKER_LABEL_KEYS = {
 
 /*
   Compact price-distribution histogram shown above the budget slider. Bars are
-  bucketed client-side from the FULL city price distribution — every listing,
-  not just the in-budget result set (see src/lib/priceHistogram.js). Bars within
-  budget render in blue; bars above the chosen budget are greyed, and a vertical
-  marker shows where the budget cut lands, so above-budget supply is visible.
-  Pure presentation — all bucketing happens in the helper.
+  bucketed client-side from the current search's price distribution — all
+  non-budget filters applied, budget ignored, not just the in-budget result set
+  (see src/lib/priceHistogram.js). Bars within budget render in blue; bars above
+  the chosen budget are greyed, and a vertical marker shows where the budget cut
+  lands, so above-budget supply is visible. Pure presentation — all bucketing
+  happens in the helper.
 */
 function PriceHistogram({ t, histogram, budget, aboveCount }) {
   const buckets = histogram || [];

--- a/src/app/api/listings/price-distribution/route.js
+++ b/src/app/api/listings/price-distribution/route.js
@@ -1,52 +1,149 @@
 import { NextResponse } from "next/server";
 import { getSupabase } from "@/lib/supabase";
+import {
+  parseListingFilters,
+  resolveRequiredAmenityIds,
+  applyListingFilters,
+  hasGroundFloorTag,
+  hasAllRequiredAmenities,
+} from "@/lib/listingFilters";
 
 /**
- * Lightweight price-distribution source for the results-page budget histogram.
+ * Filter-aware price-distribution source for the results-page budget histogram.
  *
- * Returns ONLY the monthly rent of every listing — no budget filter, and none
- * of the heavy joins (`location`, `property_types`, `landlords`,
- * `listing_amenities`, `faculty_distances`) or per-listing payload the main
- * `/api/listings` route carries. The results page buckets these client-side so
- * a student sees the FULL market spread, including listings priced ABOVE their
- * current budget, and can judge whether nudging the slider up is worth it.
+ * Returns ONLY the monthly rent of each listing in the student's current
+ * search — same filter set as /api/listings (faculty, types, neighborhoods,
+ * exclude_amenities, verified_only, min_duration, exclude_ground_floor,
+ * require_bills_included, available_from), reusing the shared filter logic so
+ * the two routes can't drift — with ONE deliberate exception: budget
+ * (min_budget / max_budget) is ignored. The histogram needs above-budget
+ * listings to stay visible behind the budget marker, so the distribution must
+ * NOT collapse to the in-budget slice the result list already shows.
  *
- * Budget-independent on purpose: the distribution must not collapse to the
- * in-budget slice (that's just the result list they already see below). Other
- * active filters (neighborhood, type, …) are intentionally NOT applied in v1 —
- * keeping the response identical for every visitor makes it trivially cacheable
- * at the edge. (Per-filter distributions are a possible v2.)
+ * v1 (#216) ignored ALL filters so one cached response served every visitor.
+ * v2 (#218) trades that blanket edge-cacheability for accuracy: the response
+ * now varies per filter combo, so each distinct query string caches separately
+ * (s-maxage=300). The accepted trade-off — a student narrowing by neighborhood
+ * sees that neighborhood's price spread, not the whole city's.
+ *
+ * The response stays prices-only — no per-listing payload. The SELECT carries
+ * only the lean joins the filters need (no photos / description / address /
+ * contact / faculty-distance detail), so it's far lighter than /api/listings.
  */
-export async function GET() {
-  try {
-    const { data, error } = await getSupabase()
-      .from("listings")
-      .select("rent!inner ( monthly_price )");
 
-    if (error) {
-      console.error("price-distribution query error:", error);
-      return NextResponse.json(
-        { error: "Failed to fetch price distribution" },
-        { status: 500 }
-      );
+// Lean SELECT: monthly_price + only the columns/joins the shared filters touch.
+const PRICE_SELECT = `
+  rent!inner ( monthly_price, bills_included ),
+  location!inner ( neighborhood ),
+  property_types!inner ( name ),
+  landlords!inner ( verified_tier, is_verified ),
+  faculty_distances ( faculty_id ),
+  listing_amenities ( amenities ( name ) )
+`;
+
+// Fallback SELECT without verified_tier/is_verified for pre-migration compat
+// (mirrors /api/listings' fallback — verified_only is skipped on this path).
+const PRICE_SELECT_FALLBACK = `
+  rent!inner ( monthly_price, bills_included ),
+  location!inner ( neighborhood ),
+  property_types!inner ( name ),
+  landlords!inner ( name ),
+  faculty_distances ( faculty_id ),
+  listing_amenities ( amenities ( name ) )
+`;
+
+function priceOf(row) {
+  // `rent` is a to-one embed (object), but guard against a PostgREST array shape.
+  const rent = Array.isArray(row.rent) ? row.rent[0] : row.rent;
+  return rent?.monthly_price;
+}
+
+function amenityNamesOf(row) {
+  return (row.listing_amenities || [])
+    .map((la) => {
+      const a = Array.isArray(la.amenities) ? la.amenities[0] : la.amenities;
+      return a?.name;
+    })
+    .filter(Boolean);
+}
+
+function pricesResponse(prices) {
+  const response = NextResponse.json({ prices });
+  // Cacheable per filter-combo at the edge — one cached response per distinct
+  // query string (the #218 trade-off vs v1's one-for-everyone cache).
+  response.headers.set(
+    "Cache-Control",
+    "public, s-maxage=300, stale-while-revalidate=600"
+  );
+  return response;
+}
+
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+
+    // Same non-budget filter parsing/validation as /api/listings. Budget params
+    // are simply never read here, so they're ignored (not validated, not applied).
+    const f = parseListingFilters(searchParams);
+    if (f.error) {
+      return NextResponse.json({ error: f.error }, { status: 400 });
     }
 
-    // `rent` is a to-one embed (object), but guard against a PostgREST array
-    // shape just in case. Drop nulls / non-numbers so the client can bucket
-    // cleanly.
-    const prices = (data || [])
-      .map((row) => {
-        const rent = Array.isArray(row.rent) ? row.rent[0] : row.rent;
-        return rent?.monthly_price;
-      })
+    const supabase = getSupabase();
+
+    // Amenity AND-filter: resolve qualifying listing_ids via SQL RPC
+    const {
+      listingIds: amenityListingIds,
+      failed: amenityRpcFailed,
+      empty: amenityEmpty,
+    } = await resolveRequiredAmenityIds(supabase, f.excludeAmenities);
+
+    if (amenityEmpty) {
+      return pricesResponse([]);
+    }
+
+    // Build query — identical filters to /api/listings, MINUS the two budget
+    // clauses (the only divergence).
+    let query = supabase.from("listings").select(PRICE_SELECT);
+    query = applyListingFilters(query, f, { amenityListingIds });
+
+    let { data, error } = await query;
+
+    // Retry without verified columns if they aren't migrated yet (mirrors
+    // /api/listings — verified_only is dropped on the fallback path).
+    if (error) {
+      console.warn("price-distribution query failed, retrying without verified_tier:", error.message);
+      let fallbackQuery = supabase.from("listings").select(PRICE_SELECT_FALLBACK);
+      fallbackQuery = applyListingFilters(fallbackQuery, f, { fallback: true, amenityListingIds });
+      const fallbackResult = await fallbackQuery;
+      if (fallbackResult.error) {
+        console.error("price-distribution fallback query error:", fallbackResult.error);
+        return NextResponse.json(
+          { error: "Failed to fetch price distribution" },
+          { status: 500 }
+        );
+      }
+      data = fallbackResult.data;
+    }
+
+    let rows = data || [];
+
+    // Residual JS filters, mirroring /api/listings, so the price set matches the
+    // listings set exactly (minus budget).
+    if (f.excludeGroundFloor) {
+      rows = rows.filter((row) => !hasGroundFloorTag(amenityNamesOf(row)));
+    }
+    if (f.excludeAmenities && amenityRpcFailed) {
+      const required = f.excludeAmenities.split(",").map((a) => a.trim());
+      rows = rows.filter((row) => hasAllRequiredAmenities(amenityNamesOf(row), required));
+    }
+
+    // Drop nulls / non-numbers so the client can bucket cleanly.
+    const prices = rows
+      .map(priceOf)
       .filter((p) => typeof p === "number" && Number.isFinite(p));
 
-    const response = NextResponse.json({ prices });
-    response.headers.set(
-      "Cache-Control",
-      "public, s-maxage=300, stale-while-revalidate=600"
-    );
-    return response;
+    return pricesResponse(prices);
   } catch (err) {
     console.error("Unexpected error in GET /api/listings/price-distribution:", err);
     return NextResponse.json(

--- a/src/app/api/listings/route.js
+++ b/src/app/api/listings/route.js
@@ -1,6 +1,13 @@
 import { NextResponse } from "next/server";
 import { getSupabase } from "@/lib/supabase";
 import { transformListing } from "@/lib/transformListing";
+import {
+  parseListingFilters,
+  resolveRequiredAmenityIds,
+  applyListingFilters,
+  hasGroundFloorTag,
+  hasAllRequiredAmenities,
+} from "@/lib/listingFilters";
 
 const LISTING_SELECT = `
   listing_id,
@@ -37,132 +44,38 @@ export async function GET(request) {
   try {
     const { searchParams } = new URL(request.url);
 
-    const faculty = searchParams.get("faculty");
-    const maxBudget = searchParams.get("max_budget");
+    // Shared (non-budget) filter parsing + validation. Budget is handled inline
+    // below — it's the one filter the price-distribution route drops (issue #218).
+    const f = parseListingFilters(searchParams);
+    if (f.error) {
+      return NextResponse.json({ error: f.error }, { status: 400 });
+    }
+
     const minBudget = searchParams.get("min_budget");
-    const types = searchParams.get("types");
-    const neighborhoods = searchParams.get("neighborhoods");
-    const amenities = searchParams.get("amenities");
-    const excludeAmenities = searchParams.get("exclude_amenities");
-    const sortBy = searchParams.get("sort_by") || "price";
-    const sortOrder = searchParams.get("sort_order") || "asc";
-    const verifiedOnly = searchParams.get("verified_only") === "true";
-    const minDuration = searchParams.get("min_duration");
-    const excludeGroundFloor = searchParams.get("exclude_ground_floor") === "true";
-    const requireBillsIncluded = searchParams.get("require_bills_included") === "true";
-    const availableFrom = searchParams.get("available_from");
+    const maxBudget = searchParams.get("max_budget");
 
-    // Validate min_duration: must be 1, 5, or 9 (or absent)
-    const ALLOWED_MIN_DURATIONS = [1, 5, 9];
-    let minDurationN = null;
-    if (minDuration) {
-      const n = Number(minDuration);
-      if (!ALLOWED_MIN_DURATIONS.includes(n)) {
-        return NextResponse.json(
-          { error: "min_duration must be 1, 5, or 9" },
-          { status: 400 }
-        );
-      }
-      minDurationN = n;
-    }
-
-    // Validate available_from: must be a real YYYY-MM-DD date (or absent).
-    // Mirrors the budget validators — a malformed value is a client error (400).
-    let availableFromDate = null;
-    if (availableFrom) {
-      const isShape = /^\d{4}-\d{2}-\d{2}$/.test(availableFrom);
-      const parsed = isShape ? new Date(`${availableFrom}T00:00:00Z`) : new Date("invalid");
-      // Reject both bad shapes and impossible dates (e.g. 2026-02-31, which JS
-      // would otherwise roll over to March).
-      const roundTrips = !Number.isNaN(parsed.getTime()) &&
-        parsed.toISOString().slice(0, 10) === availableFrom;
-      if (!isShape || !roundTrips) {
-        return NextResponse.json(
-          { error: "available_from must be a valid date in YYYY-MM-DD format" },
-          { status: 400 }
-        );
-      }
-      availableFromDate = availableFrom;
-    }
-
-    // Validate sort params
-    const validSortBy = ["price", "walk_minutes", "transit_minutes"];
-    if (!validSortBy.includes(sortBy)) {
-      return NextResponse.json(
-        { error: `sort_by must be one of: ${validSortBy.join(", ")}` },
-        { status: 400 }
-      );
-    }
-    if (sortOrder !== "asc" && sortOrder !== "desc") {
-      return NextResponse.json(
-        { error: "sort_order must be 'asc' or 'desc'" },
-        { status: 400 }
-      );
-    }
-
-    // Validate: sorting by walk/transit requires a faculty param
-    if ((sortBy === "walk_minutes" || sortBy === "transit_minutes") && !faculty) {
-      return NextResponse.json(
-        { error: `sort_by '${sortBy}' requires a faculty param` },
-        { status: 400 }
-      );
-    }
-
-    // Validate: faculty ID format (lowercase alphanumeric with dashes)
-    if (faculty && !/^[a-z0-9-]+$/.test(faculty)) {
-      return NextResponse.json(
-        { error: "faculty must be a valid faculty ID (e.g. 'auth-main')" },
-        { status: 400 }
-      );
-    }
-
-    // Validate: types — non-empty items
-    if (types !== null && types.trim() === "") {
-      return NextResponse.json(
-        { error: "types must be a non-empty comma-separated list of property type names" },
-        { status: 400 }
-      );
-    }
-
-    // Validate: exclude_amenities — non-empty items
-    if (excludeAmenities !== null && excludeAmenities.trim() === "") {
-      return NextResponse.json(
-        { error: "exclude_amenities must be a non-empty comma-separated list" },
-        { status: 400 }
-      );
-    }
+    const supabase = getSupabase();
 
     // Amenity AND-filter: resolve qualifying listing_ids via SQL RPC
-    let amenityListingIds = null;
-    let amenityRpcFailed = false;
+    const {
+      listingIds: amenityListingIds,
+      failed: amenityRpcFailed,
+      empty: amenityEmpty,
+    } = await resolveRequiredAmenityIds(supabase, f.excludeAmenities);
 
-    if (excludeAmenities) {
-      const required = excludeAmenities.split(",").map((a) => a.trim());
-      const { data: rows, error: rpcErr } = await getSupabase()
-        .rpc("listings_with_all_amenities", { p_amenity_names: required });
-
-      if (rpcErr) {
-        console.warn("listings_with_all_amenities RPC unavailable, falling back to JS:", rpcErr.message);
-        amenityRpcFailed = true;
-      } else if (!rows || rows.length === 0) {
-        const response = NextResponse.json({ listings: [] });
-        response.headers.set(
-          "Cache-Control",
-          "public, s-maxage=300, stale-while-revalidate=600"
-        );
-        return response;
-      } else {
-        amenityListingIds = rows.map((r) => r.listing_id);
-      }
+    if (amenityEmpty) {
+      const response = NextResponse.json({ listings: [] });
+      response.headers.set(
+        "Cache-Control",
+        "public, s-maxage=300, stale-while-revalidate=600"
+      );
+      return response;
     }
 
     // Build query
     let usedFallback = false;
-    let query = getSupabase().from("listings").select(LISTING_SELECT);
-
-    if (amenityListingIds) {
-      query = query.in("listing_id", amenityListingIds);
-    }
+    let query = supabase.from("listings").select(LISTING_SELECT);
+    query = applyListingFilters(query, f, { amenityListingIds });
 
     // Filter: min budget
     if (minBudget) {
@@ -188,72 +101,14 @@ export async function GET(request) {
       query = query.lte("rent.monthly_price", budget);
     }
 
-    // Filter: neighborhoods (comma-separated)
-    if (neighborhoods) {
-      const neighborhoodList = neighborhoods.split(",").map((n) => n.trim()).filter(Boolean);
-      if (neighborhoodList.length > 0) {
-        query = query.in("location.neighborhood", neighborhoodList);
-      }
-    }
-
-    // Filter: property types (comma-separated)
-    if (types) {
-      const typeList = types.split(",").map((t) => t.trim());
-      query = query.in("property_types.name", typeList);
-    }
-
-    // Filter: faculty distances to selected faculty only
-    if (faculty) {
-      query = query.eq("faculty_distances.faculty_id", faculty);
-    }
-
-    // Filter: minimum-duration commitment. A student picking N months sees
-    // listings whose min_duration_months <= N (i.e. they accept that
-    // commitment level or shorter). Listings with NULL min_duration_months
-    // are excluded when a filter is active.
-    if (minDurationN !== null) {
-      query = query.lte("min_duration_months", minDurationN);
-    }
-
-    // Filter: verified only — requires both a paid tier AND admin-approved ID
-    if (verifiedOnly) {
-      query = query
-        .neq("landlords.verified_tier", "none")
-        .eq("landlords.is_verified", true);
-    }
-
-    // Filter: bills included. Pushed to SQL so Supabase only returns
-    // matching rows instead of the route filtering them in JS post-fetch.
-    if (requireBillsIncluded) {
-      query = query.eq("rent.bills_included", true);
-    }
-
-    // Filter: exclude ground-floor units. The `floor === 0` half is
-    // handled in SQL here. The complementary "ground floor" amenity-tag
-    // check stays in JS below because amenities live behind a join we
-    // can't AND-filter cleanly via PostgREST. NULL floors are kept (not
-    // every listing has a recorded floor) — `WHERE floor != 0` would
-    // drop them since NULL <> 0 is NULL, not TRUE.
-    if (excludeGroundFloor) {
-      query = query.or("floor.is.null,floor.neq.0");
-    }
-
-    // Filter: available on or before the chosen move-in date. A listing matches
-    // when available_from IS NULL (always available) OR available_from <= date.
-    // Pushed to SQL via PostgREST .or() — `available_from` lives on the base
-    // listings table so the top-level filter applies cleanly.
-    if (availableFromDate) {
-      query = query.or(`available_from.is.null,available_from.lte.${availableFromDate}`);
-    }
-
     // SQL-level sort: tier rank → featured → user-chosen metric
     query = query
       .order('landlords(verified_tier_rank)', { ascending: true })
       .order('is_featured', { ascending: false });
 
-    if (sortBy === 'price') {
+    if (f.sortBy === 'price') {
       query = query.order('rent(monthly_price)', {
-        ascending: sortOrder === 'asc',
+        ascending: f.sortOrder === 'asc',
         nullsFirst: false,
       });
     }
@@ -264,20 +119,10 @@ export async function GET(request) {
     if (error) {
       console.warn("Listings query failed, retrying without verified_tier:", error.message);
       usedFallback = true;
-      let fallbackQuery = getSupabase().from("listings").select(LISTING_SELECT_FALLBACK);
-
-      if (amenityListingIds) fallbackQuery = fallbackQuery.in("listing_id", amenityListingIds);
+      let fallbackQuery = supabase.from("listings").select(LISTING_SELECT_FALLBACK);
+      fallbackQuery = applyListingFilters(fallbackQuery, f, { fallback: true, amenityListingIds });
       if (minBudget) fallbackQuery = fallbackQuery.gte("rent.monthly_price", Number(minBudget));
       if (maxBudget) fallbackQuery = fallbackQuery.lte("rent.monthly_price", Number(maxBudget));
-      if (neighborhoods) {
-        const neighborhoodList = neighborhoods.split(",").map((n) => n.trim()).filter(Boolean);
-        if (neighborhoodList.length > 0) fallbackQuery = fallbackQuery.in("location.neighborhood", neighborhoodList);
-      }
-      if (types) fallbackQuery = fallbackQuery.in("property_types.name", types.split(",").map((t) => t.trim()));
-      if (faculty) fallbackQuery = fallbackQuery.eq("faculty_distances.faculty_id", faculty);
-      if (requireBillsIncluded) fallbackQuery = fallbackQuery.eq("rent.bills_included", true);
-      if (excludeGroundFloor) fallbackQuery = fallbackQuery.or("floor.is.null,floor.neq.0");
-      if (availableFromDate) fallbackQuery = fallbackQuery.or(`available_from.is.null,available_from.lte.${availableFromDate}`);
 
       const fallbackResult = await fallbackQuery;
       if (fallbackResult.error) {
@@ -296,28 +141,20 @@ export async function GET(request) {
     // Residual amenity-tag check for excludeGroundFloor — the `floor != 0`
     // half is now in SQL above, so this only catches listings whose floor
     // is unset/non-zero but carry the "ground floor" amenity tag anyway.
-    if (excludeGroundFloor) {
-      results = results.filter((listing) => {
-        const tagged = (listing.amenities || []).some(
-          (a) => a.toLowerCase() === "ground floor"
-        );
-        return !tagged;
-      });
+    if (f.excludeGroundFloor) {
+      results = results.filter((listing) => !hasGroundFloorTag(listing.amenities));
     }
 
     // Amenity AND-filter fallback: only needed when the SQL RPC was unavailable
-    if (excludeAmenities && amenityRpcFailed) {
-      const required = excludeAmenities.split(",").map((a) => a.trim().toLowerCase());
-      results = results.filter((listing) => {
-        const has = listing.amenities.map((a) => a.toLowerCase());
-        return required.every((r) => has.includes(r));
-      });
+    if (f.excludeAmenities && amenityRpcFailed) {
+      const required = f.excludeAmenities.split(",").map((a) => a.trim());
+      results = results.filter((listing) => hasAllRequiredAmenities(listing.amenities, required));
     }
 
     // Sort: SQL handles tier rank → featured → price for sortBy=price.
     // Walk/transit need JS because faculty_distances is a to-many join.
     // Fallback path always needs JS (no .order() was applied).
-    if (usedFallback || sortBy !== "price") {
+    if (usedFallback || f.sortBy !== "price") {
       const tierRank = { verified_pro: 0, verified: 1, none: 2 };
       results.sort((a, b) => {
         const rankA = tierRank[a.verified_tier] ?? 2;
@@ -329,13 +166,13 @@ export async function GET(request) {
 
         let valA, valB;
 
-        if (sortBy === "price") {
+        if (f.sortBy === "price") {
           valA = a.monthly_price;
           valB = b.monthly_price;
-        } else if (sortBy === "walk_minutes") {
+        } else if (f.sortBy === "walk_minutes") {
           valA = a.faculty_distances[0]?.walk_minutes ?? null;
           valB = b.faculty_distances[0]?.walk_minutes ?? null;
-        } else if (sortBy === "transit_minutes") {
+        } else if (f.sortBy === "transit_minutes") {
           valA = a.faculty_distances[0]?.transit_minutes ?? null;
           valB = b.faculty_distances[0]?.transit_minutes ?? null;
         }
@@ -344,7 +181,7 @@ export async function GET(request) {
         if (valA == null) return 1;
         if (valB == null) return -1;
 
-        return sortOrder === "desc" ? valB - valA : valA - valB;
+        return f.sortOrder === "desc" ? valB - valA : valA - valB;
       });
     }
 

--- a/src/lib/listingFilters.js
+++ b/src/lib/listingFilters.js
@@ -1,0 +1,214 @@
+/**
+ * Shared listing-filter logic for /api/listings and
+ * /api/listings/price-distribution.
+ *
+ * Both routes honour an identical filter set (faculty, types, neighborhoods,
+ * exclude_amenities, verified_only, min_duration, exclude_ground_floor,
+ * require_bills_included, available_from). The ONE intentional divergence is
+ * budget: /api/listings applies its min_budget/max_budget clauses inline (they
+ * live in that route, not here), while the price-distribution route drops them
+ * so the histogram keeps above-budget supply visible behind the budget marker
+ * (issue #218).
+ *
+ * Keeping the parse/validate/RPC/where-clause logic here means the two routes
+ * can never drift on what a filter means — the distribution reflects exactly
+ * the subset /api/listings would return for the same non-budget filters.
+ */
+
+const ALLOWED_MIN_DURATIONS = [1, 5, 9];
+
+/**
+ * Parse + validate every shared (non-budget) filter param from a
+ * URLSearchParams. Returns `{ error: string }` on the first validation failure
+ * (the caller turns that into a 400), otherwise a normalized filter object.
+ *
+ * Budget is intentionally NOT handled here — /api/listings reads and validates
+ * min_budget/max_budget itself, and the distribution route ignores them.
+ */
+export function parseListingFilters(searchParams) {
+  const faculty = searchParams.get("faculty");
+  const types = searchParams.get("types");
+  const neighborhoods = searchParams.get("neighborhoods");
+  const excludeAmenities = searchParams.get("exclude_amenities");
+  const sortBy = searchParams.get("sort_by") || "price";
+  const sortOrder = searchParams.get("sort_order") || "asc";
+  const verifiedOnly = searchParams.get("verified_only") === "true";
+  const minDuration = searchParams.get("min_duration");
+  const excludeGroundFloor = searchParams.get("exclude_ground_floor") === "true";
+  const requireBillsIncluded = searchParams.get("require_bills_included") === "true";
+  const availableFrom = searchParams.get("available_from");
+
+  // Validate min_duration: must be 1, 5, or 9 (or absent)
+  let minDurationN = null;
+  if (minDuration) {
+    const n = Number(minDuration);
+    if (!ALLOWED_MIN_DURATIONS.includes(n)) {
+      return { error: "min_duration must be 1, 5, or 9" };
+    }
+    minDurationN = n;
+  }
+
+  // Validate available_from: must be a real YYYY-MM-DD date (or absent).
+  // Rejects bad shapes and impossible dates (e.g. 2026-02-31, which JS would
+  // otherwise roll over to March).
+  let availableFromDate = null;
+  if (availableFrom) {
+    const isShape = /^\d{4}-\d{2}-\d{2}$/.test(availableFrom);
+    const parsed = isShape ? new Date(`${availableFrom}T00:00:00Z`) : new Date("invalid");
+    const roundTrips = !Number.isNaN(parsed.getTime()) &&
+      parsed.toISOString().slice(0, 10) === availableFrom;
+    if (!isShape || !roundTrips) {
+      return { error: "available_from must be a valid date in YYYY-MM-DD format" };
+    }
+    availableFromDate = availableFrom;
+  }
+
+  // Validate sort params
+  const validSortBy = ["price", "walk_minutes", "transit_minutes"];
+  if (!validSortBy.includes(sortBy)) {
+    return { error: `sort_by must be one of: ${validSortBy.join(", ")}` };
+  }
+  if (sortOrder !== "asc" && sortOrder !== "desc") {
+    return { error: "sort_order must be 'asc' or 'desc'" };
+  }
+  if ((sortBy === "walk_minutes" || sortBy === "transit_minutes") && !faculty) {
+    return { error: `sort_by '${sortBy}' requires a faculty param` };
+  }
+  if (faculty && !/^[a-z0-9-]+$/.test(faculty)) {
+    return { error: "faculty must be a valid faculty ID (e.g. 'auth-main')" };
+  }
+  if (types !== null && types.trim() === "") {
+    return { error: "types must be a non-empty comma-separated list of property type names" };
+  }
+  if (excludeAmenities !== null && excludeAmenities.trim() === "") {
+    return { error: "exclude_amenities must be a non-empty comma-separated list" };
+  }
+
+  return {
+    faculty,
+    types,
+    neighborhoods,
+    excludeAmenities,
+    sortBy,
+    sortOrder,
+    verifiedOnly,
+    minDurationN,
+    excludeGroundFloor,
+    requireBillsIncluded,
+    availableFromDate,
+  };
+}
+
+/**
+ * Resolve the exclude_amenities AND-filter to a set of qualifying listing ids
+ * via the `listings_with_all_amenities` SQL RPC.
+ *
+ * @returns {Promise<{ listingIds: string[]|null, failed: boolean, empty: boolean }>}
+ *   - `listingIds` — ids to constrain the query to (null = no constraint).
+ *   - `failed` — RPC unavailable; caller should fall back to a JS amenity check.
+ *   - `empty` — RPC succeeded but matched zero listings; caller should
+ *     short-circuit to an empty response.
+ */
+export async function resolveRequiredAmenityIds(supabase, excludeAmenities) {
+  if (!excludeAmenities) {
+    return { listingIds: null, failed: false, empty: false };
+  }
+  const required = excludeAmenities.split(",").map((a) => a.trim());
+  const { data: rows, error } = await supabase
+    .rpc("listings_with_all_amenities", { p_amenity_names: required });
+
+  if (error) {
+    console.warn("listings_with_all_amenities RPC unavailable, falling back to JS:", error.message);
+    return { listingIds: null, failed: true, empty: false };
+  }
+  if (!rows || rows.length === 0) {
+    return { listingIds: null, failed: false, empty: true };
+  }
+  return { listingIds: rows.map((r) => r.listing_id), failed: false, empty: false };
+}
+
+/**
+ * Apply the shared WHERE clauses to a Supabase query builder and return it.
+ * Budget is NOT applied here (see module docstring).
+ *
+ * @param query   a Supabase PostgREST query builder
+ * @param f       a normalized filter object from {@link parseListingFilters}
+ * @param opts
+ * @param opts.fallback           when true, skip the clauses the fallback
+ *   SELECT can't support — verified_only (no verified_tier columns) and
+ *   min_duration — mirroring the original /api/listings fallback path exactly.
+ * @param opts.amenityListingIds  ids from {@link resolveRequiredAmenityIds}.
+ */
+export function applyListingFilters(query, f, { fallback = false, amenityListingIds = null } = {}) {
+  if (amenityListingIds) {
+    query = query.in("listing_id", amenityListingIds);
+  }
+
+  // Neighborhoods (comma-separated)
+  if (f.neighborhoods) {
+    const neighborhoodList = f.neighborhoods.split(",").map((n) => n.trim()).filter(Boolean);
+    if (neighborhoodList.length > 0) {
+      query = query.in("location.neighborhood", neighborhoodList);
+    }
+  }
+
+  // Property types (comma-separated)
+  if (f.types) {
+    query = query.in("property_types.name", f.types.split(",").map((t) => t.trim()));
+  }
+
+  // Faculty distances scoped to the selected faculty only
+  if (f.faculty) {
+    query = query.eq("faculty_distances.faculty_id", f.faculty);
+  }
+
+  // Minimum-duration commitment: listings whose min_duration_months <= N.
+  // Skipped on the fallback path (mirrors the original route).
+  if (!fallback && f.minDurationN !== null) {
+    query = query.lte("min_duration_months", f.minDurationN);
+  }
+
+  // Verified only — requires both a paid tier AND admin-approved ID. Skipped on
+  // the fallback path (the verified columns are what triggered the fallback).
+  if (!fallback && f.verifiedOnly) {
+    query = query
+      .neq("landlords.verified_tier", "none")
+      .eq("landlords.is_verified", true);
+  }
+
+  // Bills included
+  if (f.requireBillsIncluded) {
+    query = query.eq("rent.bills_included", true);
+  }
+
+  // Exclude ground-floor units (SQL half — the `floor != 0` check). The
+  // complementary "ground floor" amenity-tag check stays in JS post-fetch.
+  // NULL floors are kept (`WHERE floor != 0` would drop them).
+  if (f.excludeGroundFloor) {
+    query = query.or("floor.is.null,floor.neq.0");
+  }
+
+  // Available on or before the chosen move-in date (NULL = always available).
+  if (f.availableFromDate) {
+    query = query.or(`available_from.is.null,available_from.lte.${f.availableFromDate}`);
+  }
+
+  return query;
+}
+
+/**
+ * Whether a listing carries the "ground floor" amenity tag — the JS residual
+ * for the exclude_ground_floor filter (the `floor != 0` half is pushed to SQL).
+ */
+export function hasGroundFloorTag(amenityNames) {
+  return (amenityNames || []).some((a) => String(a).toLowerCase() === "ground floor");
+}
+
+/**
+ * Whether a listing has ALL required amenities — the JS fallback for
+ * exclude_amenities when the SQL RPC is unavailable. Case-insensitive.
+ */
+export function hasAllRequiredAmenities(amenityNames, required) {
+  const have = (amenityNames || []).map((a) => String(a).toLowerCase());
+  return (required || []).every((r) => have.includes(String(r).toLowerCase()));
+}

--- a/src/lib/priceHistogram.js
+++ b/src/lib/priceHistogram.js
@@ -3,11 +3,12 @@
  *
  * Given a set of price-bearing rows ({ monthly_price }), these functions bucket
  * the monthly prices into a fixed set of bars so a compact chart can show where
- * the current budget cut lands. The results page feeds them the FULL city price
- * distribution (see /api/listings/price-distribution) — NOT just the in-budget
- * result set — so bars to the right of the budget marker represent supply
- * priced above the student's max. Kept dependency-free and side-effect-free so
- * it's trivially unit-testable.
+ * the current budget cut lands. The results page feeds them the current
+ * search's price distribution (see /api/listings/price-distribution) — every
+ * non-budget filter applied, budget ignored, NOT just the in-budget result set
+ * — so bars to the right of the budget marker represent supply priced above the
+ * student's max. Kept dependency-free and side-effect-free so it's trivially
+ * unit-testable.
  */
 
 /**

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -528,7 +528,7 @@
       "maxPrice": "Max price",
       "upTo": "up to",
       "priceDistribution": "Price distribution",
-      "priceHistogramCaption": "All listings by price — the line marks your budget. Bars to its right cost more than your max.",
+      "priceHistogramCaption": "Matching listings by price — the line marks your budget. Bars to its right cost more than your max.",
       "priceHistogramEmpty": "No price data to chart",
       "priceHistogramBarLabel": "{count, plural, =0 {No listings} one {# listing} other {# listings}} between €{from} and €{to}",
       "priceHistogramAboveBudget": "{count, plural, one {# listing above your budget} other {# listings above your budget}}",


### PR DESCRIPTION
Closes #218.

## What
The results-page price histogram (shipped in #216, fed by `/api/listings/price-distribution`) showed the **whole-city** price spread no matter how the student narrowed their search. Now the distribution tracks every **non-budget** filter, so narrowing by neighbourhood / type reshapes the chart to that subset — while still **ignoring budget** so above-budget supply stays visible behind the budget marker.

## How
- **Extract shared filter logic** → `src/lib/listingFilters.js`: `parseListingFilters` (validate), `resolveRequiredAmenityIds` (the `listings_with_all_amenities` RPC), `applyListingFilters` (the WHERE-clause builder), and the `hasGroundFloorTag` / `hasAllRequiredAmenities` residual predicates. Single source of truth so the two routes can't drift on what a filter means.
- **`/api/listings` refactored onto it with no behaviour change.** Budget validation + the two `.gte/.lte` clauses stay inline in that route — the one thing the distribution drops. The fallback path still skips `verified_only` **and** `min_duration` exactly as before (preserved via the `fallback` flag), so this untested route's behaviour is byte-for-byte preserved. Net: 364 → 201 lines.
- **`/api/listings/price-distribution` is now filter-aware**, reusing the shared logic minus the budget clauses, over a **lean prices-only SELECT** (only the joins the filters touch — no photos/description/address/contact). Response stays `{ prices: [...] }`.
- **Results page** refetches the distribution (debounced 300 ms) when a **non-budget** filter changes, and **never** when the budget slider moves (the fetch's deps exclude `maxBudget`). The "N listings above your budget" count + marker recompute purely client-side against the filtered distribution.

## Trade-off (per #218)
The endpoint loses blanket edge-cacheability — it now caches **per filter-combo** instead of one-for-everyone. `s-maxage=300` is retained, so each distinct query string still caches at the edge for 5 min. Accepted in the issue.

## Tests — `lint` / `test` / `build` all green
- Rewrote `__tests__/api/priceDistribution.test.js` for the chainable, filter-aware query: a non-budget filter (`neighborhoods`, `types`+`verified_only`) is translated into the matching PostgREST clause; **budget params are ignored** (no `rent.monthly_price` clause; above-budget prices retained); invalid filters still 400; 500 only when both main + fallback error.
- Added `__tests__/lib/listingFilters.test.js` covering `parseListingFilters` (valid + each validation error + budget-is-ignored), `applyListingFilters` (every clause on the main path; `verified_only`/`min_duration` skipped on the fallback path), and the residual predicates. (Insurance: `/api/listings` had no unit test before.)
- Full suite: **214 passed**.

## Verified at runtime (`npm run dev`, real Supabase data)
Server access log for `/property/thessaloniki/results`:
- Initial load → one `GET /api/listings/price-distribution` (no params).
- Toggle **Kentro** → `GET /api/listings/price-distribution?neighborhoods=Kentro` fires (distribution refetches with the filter); listings also refetch.
- Drag budget €900 → €500 → only `GET /api/listings?max_budget=500&neighborhoods=Kentro…` fires; **no new `price-distribution` request** — the slider does not refetch the distribution.
- `curl` of `…/price-distribution?neighborhoods=Kentro` returns a narrower set than the unfiltered call, and adding `&max_budget=500&min_budget=400` returns the **identical** set (budget ignored).

## Notes
- No migration (per the task / issue).
- Unrelated working-tree changes (`.claude/settings.local.json`, `docs/ux-plan.md`, `public/*.png`) were intentionally left unstaged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)