### PR TITLE
fix(security): stop exposing landlord contact_info on public listing APIs

### DIFF
--- a/__tests__/lib/transformListing.test.js
+++ b/__tests__/lib/transformListing.test.js
@@ -49,7 +49,7 @@ describe('transformListing', () => {
       floor: 3,
       photos: ['a.jpg', 'b.jpg'],
       min_duration_months: 9,
-      landlord: { name: 'Alice', contact_info: 'a@example.com' },
+      landlord: { name: 'Alice' },
       faculty_distances: [
         {
           faculty_id: 'auth-cs',
@@ -60,6 +60,14 @@ describe('transformListing', () => {
         },
       ],
     });
+  });
+
+  it('never exposes landlord contact_info, even when present on the row', () => {
+    // Regression guard for security audit #1: contact_info is owner-only PII
+    // and must never leak into the public listing API / SSR shape.
+    const out = transformListing(fullRow);
+    expect(out.landlord).toEqual({ name: 'Alice' });
+    expect(out.landlord).not.toHaveProperty('contact_info');
   });
 
   it('defaults title to null when the row lacks one', () => {

--- a/src/app/[locale]/student/account/page.js
+++ b/src/app/[locale]/student/account/page.js
@@ -108,7 +108,7 @@ async function SavedSection({ locale }) {
         rent ( monthly_price, currency, bills_included, deposit ),
         location ( address, neighborhood, lat, lng ),
         property_types ( name ),
-        landlords ( name, contact_info, verified_tier, is_verified ),
+        landlords ( name, verified_tier, is_verified ),
         listing_amenities ( amenities ( amenity_id, name ) ),
         faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
       )

--- a/src/app/api/landlord/profile/route.js
+++ b/src/app/api/landlord/profile/route.js
@@ -16,7 +16,11 @@ export async function GET(request) {
   const user = await getUserFromToken(token);
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const { data: landlord, error } = await getSupabase()
+  // Token-scoped (authenticated) client, not the anon client: this row
+  // carries owner-only PII (email, contact_info). A follow-up migration
+  // revokes anon SELECT on contact_info, so the owner read must run as the
+  // authenticated role. RLS already lets a landlord read their own row.
+  const { data: landlord, error } = await getSupabaseWithToken(token)
     .from('landlords')
     .select('landlord_id, name, email, contact_info, onboarding_completed, preferred_locale')
     .eq('auth_user_id', user.id)

--- a/src/app/api/listings/[id]/route.js
+++ b/src/app/api/listings/[id]/route.js
@@ -25,7 +25,7 @@ export async function GET(request, { params }) {
         rent ( monthly_price, currency, bills_included, deposit ),
         location ( address, neighborhood, lat, lng ),
         property_types ( name ),
-        landlords ( name, contact_info, verified_tier, is_verified ),
+        landlords ( name, verified_tier, is_verified ),
         listing_amenities ( amenities ( amenity_id, name ) ),
         faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
       `
@@ -46,7 +46,7 @@ export async function GET(request, { params }) {
           rent ( monthly_price, currency, bills_included, deposit ),
           location ( address, neighborhood, lat, lng ),
           property_types ( name ),
-          landlords ( name, contact_info ),
+          landlords ( name ),
           listing_amenities ( amenities ( amenity_id, name ) ),
           faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
         `

--- a/src/app/api/listings/route.js
+++ b/src/app/api/listings/route.js
@@ -20,7 +20,7 @@ const LISTING_SELECT = `
   rent!inner ( monthly_price, currency, bills_included, deposit ),
   location!inner ( address, neighborhood, lat, lng ),
   property_types!inner ( name ),
-  landlords!inner ( name, contact_info, verified_tier, is_verified, verified_tier_rank ),
+  landlords!inner ( name, verified_tier, is_verified, verified_tier_rank ),
   listing_amenities ( amenities ( amenity_id, name ) ),
   faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
 `;
@@ -35,7 +35,7 @@ const LISTING_SELECT_FALLBACK = `
   rent!inner ( monthly_price, currency, bills_included, deposit ),
   location!inner ( address, neighborhood, lat, lng ),
   property_types!inner ( name ),
-  landlords!inner ( name, contact_info ),
+  landlords!inner ( name ),
   listing_amenities ( amenities ( amenity_id, name ) ),
   faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
 `;

--- a/src/lib/listingForRender.js
+++ b/src/lib/listingForRender.js
@@ -10,7 +10,7 @@ const LISTING_SELECT = `
   rent ( monthly_price, currency, bills_included, deposit ),
   location ( address, neighborhood, lat, lng ),
   property_types ( name ),
-  landlords ( name, contact_info, verified_tier, is_verified ),
+  landlords ( name, verified_tier, is_verified ),
   listing_amenities ( amenities ( amenity_id, name ) ),
   faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
 `;
@@ -26,7 +26,7 @@ const LISTING_SELECT_FALLBACK = `
   rent ( monthly_price, currency, bills_included, deposit ),
   location ( address, neighborhood, lat, lng ),
   property_types ( name ),
-  landlords ( name, contact_info ),
+  landlords ( name ),
   listing_amenities ( amenities ( amenity_id, name ) ),
   faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
 `;

--- a/src/lib/transformListing.js
+++ b/src/lib/transformListing.js
@@ -23,9 +23,15 @@ export function transformListing(row) {
     floor: row.floor ?? null,
     photos: row.photos ?? [],
     min_duration_months: row.min_duration_months ?? null,
+    // `contact_info` is deliberately NOT exposed here. It is owner-only PII
+    // (the landlord's email / external contact URL) and this shape feeds the
+    // public, unauthenticated /api/listings, /api/listings/[id], and SSR
+    // render paths — returning it leaked every landlord's contact channel to
+    // anonymous callers (security audit #1). The owner reads/edits it via
+    // /api/landlord/profile; students reach landlords through the in-app
+    // inquiry flow keyed on listing_id, never the raw contact string.
     landlord: {
       name: row.landlords?.name ?? null,
-      contact_info: row.landlords?.contact_info ?? null,
     },
     faculty_distances: (row.faculty_distances ?? []).map((fd) => ({
       faculty_id: fd.faculty_id,


### PR DESCRIPTION
Second of four PRs from the pre-launch security audit. Addresses **finding #1 (the headline / Critical)**.

## The leak
`transformListing()` emitted `landlord.contact_info`, and the **unauthenticated** `/api/listings`, `/api/listings/[id]`, and the SSR render path all selected and serialized it. So an anonymous `curl https://studentx.uk/api/listings` returned every landlord's contact channel — including the founder's own email. It defeats the inquiry gate (the core lead-capture funnel) and exposes PII at scrape-scale.

`contact_info` is rendered in **zero** components — it's owner-only data. The student-facing flow contacts landlords through the in-app inquiry composer keyed on `listing_id`, never the raw string.

## Changes (app layer)
- Remove `contact_info` from `transformListing()` output — the shared shape behind the public list/detail/SSR responses.
- Remove it from every anon/SSR `SELECT`: `api/listings` (+ fallback), `api/listings/[id]` (+ fallback), `lib/listingForRender` (+ fallback), and the student-account favorites query. Landlord **name** is retained (non-sensitive, used for display).
- Switch `/api/landlord/profile` **GET** (the one legitimate owner read of `contact_info`) from the anon client to the **token-scoped** client, so it stays correct and survives the follow-up column revoke.
- `transformListing` test now asserts the output **never** carries `contact_info` (regression guard).

## ⚠️ Sequencing — read before merging the DB PR
This closes the leak through **our** API. But the public anon key (shipped in the browser bundle, by design) can still read `landlords.contact_info` directly via Supabase's raw PostgREST endpoint. Closing that requires a **column-level revoke** of anon `SELECT` on `contact_info`, which ships in the **DB-lockdown PR (#3)**.

That migration must be applied to prod **after this PR deploys** — applying it first would 500 the *current* prod code, which still selects the column (the inverse of the usual migrate-first rule). Merge order: **this PR → deploy → then apply the DB-lockdown migration.**

## Verification
`npm run lint` clean · `215 tests` pass (incl. the new assertion) · `npm run build` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)