### PR TITLE
perf(listing): window the photo lightbox to active slide ±1

### DIFF
--- a/src/components/listing/ListingLightbox.js
+++ b/src/components/listing/ListingLightbox.js
@@ -139,22 +139,38 @@ export default function ListingLightbox({ photos, title, startIndex = 0, onClose
             else if (x >= DRAG_BUFFER) go(index - 1);
           }}
         >
-          {photos.map((src, i) => (
-            <div
-              key={src}
-              className="relative shrink-0 w-full h-full"
-              aria-hidden={i === index ? undefined : 'true'}
-            >
-              <ZoomableImage
-                src={variantUrl(src, 'full')}
-                alt={t('photoAlt', { title, number: i + 1 })}
-                active={i === index}
-                scale={i === index ? scale : 1}
-                setScale={setScale}
-                t={t}
-              />
-            </div>
-          ))}
+          {photos.map((src, i) => {
+            // Window the heavy full-res <Image> to the active slide ±1. Opening
+            // the lightbox on a 20–30 photo listing was fetching EVERY photo at
+            // the `full` variant at once (measured: 31 images ≈ 2 MB on a
+            // 31-photo listing) because next/image doesn't defer the
+            // transform-translated off-screen slides. The slide <div>s are all
+            // kept so the track geometry and the `-index * 100%` swipe transform
+            // stay exact; only the off-window image is swapped for a same-size
+            // placeholder. The window follows `index`, so the next/prev slide is
+            // always already mounted before a single-step swipe/arrow lands.
+            const inWindow = Math.abs(i - index) <= 1;
+            return (
+              <div
+                key={src}
+                className="relative shrink-0 w-full h-full"
+                aria-hidden={i === index ? undefined : 'true'}
+              >
+                {inWindow ? (
+                  <ZoomableImage
+                    src={variantUrl(src, 'full')}
+                    alt={t('photoAlt', { title, number: i + 1 })}
+                    active={i === index}
+                    scale={i === index ? scale : 1}
+                    setScale={setScale}
+                    t={t}
+                  />
+                ) : (
+                  <div className="w-full h-full" aria-hidden="true" />
+                )}
+              </div>
+            );
+          })}
         </motion.div>
 
         {/* Prev / next — hidden while zoomed so panning isn't obstructed */}


### PR DESCRIPTION
Fourth PR from the audit — performance finding **P2** (lightbox over-fetch).

## Problem (measured, not theoretical)
Opening the listing lightbox rendered an `<Image>` for **every** photo at the `full` variant in one `.map()`. next/image does **not** defer the transform-translated off-screen slides, so I confirmed live in the browser that a 31-photo listing fetched **all 31 full-res images (~2 MB)** the instant the lightbox opened — on the conversion page, on mobile.

## Fix
Render only the active slide **±1** as real images. Every slide `<div>` is kept so the track geometry and the `-index * 100%` swipe transform stay exact; off-window slides become a same-size placeholder. The window follows the active index, so the next/prev slide is always pre-mounted before a single-step swipe or arrow lands.

## Verified in-browser (listing `0101002`, 31 photos)
| | before | after |
|---|---|---|
| full images fetched on open | **31** (~2 MB) | **2** (~140 KB) |
| `<Image>` mounted | 31 | 2–3 (active ±1) |
| slide `<div>`s (geometry) | 31 | 31 ✅ |

Confirmed the active photo renders, counter reads `1 / 31`, and navigation advances with the window following. Screenshot of the working lightbox attached in the review notes.

`npm run lint` clean · `214 tests` pass · `npm run build` compiles.

## Deferred from this PR (P1)
The `/api/listings` payload trim (cover-photo + nearest-distance projection) + pagination is **not** here. It's a refactor that overlaps PR #223's files and needs a consumer audit of the results grid + map, and at current scale (67 KB / 14 listings) it isn't pinching yet — the win shows up at hundreds of listings. Recommend doing it as its own PR after #223 merges. Details in the session summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)