### PR TITLE
feat(landlord): public verified-landlord profile + profile photo

### DIFF
--- a/__tests__/lib/transformListing.test.js
+++ b/__tests__/lib/transformListing.test.js
@@ -12,7 +12,13 @@ const fullRow = {
   rent: { monthly_price: 450, currency: 'EUR', bills_included: true, deposit: 900 },
   location: { address: '12 Egnatias', neighborhood: 'Center', lat: 40.63, lng: 22.94 },
   property_types: { name: 'Studio' },
-  landlords: { name: 'Alice', contact_info: 'a@example.com', verified_tier: 'gold', is_verified: true },
+  landlords: {
+    name: 'Alice',
+    contact_info: 'a@example.com',
+    verified_tier: 'gold',
+    is_verified: true,
+    profile_photo_url: 'https://cdn.example/landlord-photos/uid/alice.webp',
+  },
   listing_amenities: [
     { amenities: { name: 'wifi' } },
     { amenities: { name: 'heating' } },
@@ -49,7 +55,10 @@ describe('transformListing', () => {
       floor: 3,
       photos: ['a.jpg', 'b.jpg'],
       min_duration_months: 9,
-      landlord: { name: 'Alice' },
+      landlord: {
+        name: 'Alice',
+        profile_photo_url: 'https://cdn.example/landlord-photos/uid/alice.webp',
+      },
       faculty_distances: [
         {
           faculty_id: 'auth-cs',
@@ -66,7 +75,10 @@ describe('transformListing', () => {
     // Regression guard for security audit #1: contact_info is owner-only PII
     // and must never leak into the public listing API / SSR shape.
     const out = transformListing(fullRow);
-    expect(out.landlord).toEqual({ name: 'Alice' });
+    expect(out.landlord).toEqual({
+      name: 'Alice',
+      profile_photo_url: 'https://cdn.example/landlord-photos/uid/alice.webp',
+    });
     expect(out.landlord).not.toHaveProperty('contact_info');
   });
 

--- a/src/app/[locale]/property/[city]/landlord/settings/page.js
+++ b/src/app/[locale]/property/[city]/landlord/settings/page.js
@@ -3,17 +3,16 @@
 import { useTranslations } from 'next-intl';
 
 import LandlordShell from '@/components/landlord/LandlordShell';
-import Card from '@/components/ui/Card';
+import ProfilePhotoSettings from '@/components/landlord/ProfilePhotoSettings';
 
 /*
   Propylaea landlord settings page.
 
   Originally housed the email-language preference (issue #18). With the
   platform collapsed to English-only (issue #158, Step B), the language
-  toggle is gone and there are no other settings yet. Keeping the route
-  alive as a placeholder so navigation links and bookmarks don't 404 —
-  future settings (notifications, display name, billing contact, etc.)
-  can be added as Cards below.
+  toggle is gone. First real setting is the public profile photo; future
+  settings (notifications, display name, billing contact, etc.) can be added
+  as additional Cards below.
 */
 export default function LandlordSettingsPage() {
   const t = useTranslations('propylaea.landlord.settings');
@@ -21,9 +20,7 @@ export default function LandlordSettingsPage() {
   return (
     <LandlordShell eyebrow={t('eyebrow')} title={t('title')}>
       <div className="max-w-xl">
-        <Card tone="parchment" className="px-6 py-6">
-          <p className="text-sm text-night/70">{t('emptyState')}</p>
-        </Card>
+        <ProfilePhotoSettings />
       </div>
     </LandlordShell>
   );

--- a/src/app/[locale]/property/[city]/landlord/signup/page.js
+++ b/src/app/[locale]/property/[city]/landlord/signup/page.js
@@ -10,6 +10,8 @@ import { useLocale, useTranslations } from 'next-intl';
 import AuthShell from '@/components/landlord/AuthShell';
 import FormField from '@/components/landlord/FormField';
 import EncryptButton from '@/components/ui/EncryptButton';
+import Icon from '@/components/ui/Icon';
+import { uploadLandlordPhoto, validateProfilePhoto } from '@/lib/uploadLandlordPhoto';
 
 export default function LandlordSignupPage() {
   const t = useTranslations('landlord.signup');
@@ -21,6 +23,25 @@ export default function LandlordSignupPage() {
   const [error, setError] = useState('');
   const [conflictRole, setConflictRole] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [photoFile, setPhotoFile] = useState(null);
+  const [photoPreview, setPhotoPreview] = useState('');
+  const [photoError, setPhotoError] = useState('');
+
+  function handlePhotoChange(e) {
+    setPhotoError('');
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const errKey = validateProfilePhoto(file);
+    if (errKey) {
+      setPhotoError(t(errKey));
+      return;
+    }
+    setPhotoFile(file);
+    setPhotoPreview((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return URL.createObjectURL(file);
+    });
+  }
 
   async function handleSubmit(e) {
     e.preventDefault();
@@ -52,6 +73,16 @@ export default function LandlordSignupPage() {
 
       const session = authData.session;
       if (session?.access_token) {
+        // Optional avatar — best-effort. A storage hiccup must never block
+        // signup; the landlord can always add/replace the photo in Settings.
+        let profilePhotoUrl;
+        if (photoFile) {
+          try {
+            profilePhotoUrl = await uploadLandlordPhoto(photoFile, session.user.id);
+          } catch (err) {
+            console.error('[signup] profile photo upload failed:', err);
+          }
+        }
         const res = await withTimeout(
           fetch('/api/landlord/profile', {
             method: 'POST',
@@ -59,7 +90,9 @@ export default function LandlordSignupPage() {
               'Content-Type': 'application/json',
               Authorization: `Bearer ${session.access_token}`,
             },
-            body: JSON.stringify({ name }),
+            body: JSON.stringify(
+              profilePhotoUrl ? { name, profile_photo_url: profilePhotoUrl } : { name },
+            ),
           }),
         );
         if (!res.ok) {
@@ -114,6 +147,48 @@ export default function LandlordSignupPage() {
           onChange={setPassword}
           placeholder={t('passwordPlaceholder')}
         />
+
+        {/* Optional profile photo — appears on the landlord's public profile
+            and listing cards once they're verified. Skippable here; editable
+            any time in Settings. */}
+        <div>
+          <span className="block text-sm font-medium text-night/80 mb-2">
+            {t('photoLabel')}
+          </span>
+          <div className="flex items-center gap-4">
+            {photoPreview ? (
+              // eslint-disable-next-line @next/next/no-img-element -- transient blob: preview, not a remote asset
+              <img
+                src={photoPreview}
+                alt=""
+                className="w-14 h-14 rounded-full object-cover border border-night/10"
+              />
+            ) : (
+              <span className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-parchment text-night/30 shrink-0">
+                <Icon name="photo" className="w-6 h-6" />
+              </span>
+            )}
+            <div>
+              <input
+                id="photo"
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                className="hidden"
+                onChange={handlePhotoChange}
+              />
+              <label
+                htmlFor="photo"
+                className="inline-flex items-center gap-2 px-4 py-2 border-2 border-dashed border-gray-200 rounded-lg text-sm text-night/60 hover:border-yellow/60 hover:text-night cursor-pointer transition-colors"
+              >
+                {photoPreview ? t('photoReplace') : t('photoChoose')}
+              </label>
+              <p className="text-xs text-night/40 mt-1.5">{t('photoHelp')}</p>
+            </div>
+          </div>
+          {photoError && (
+            <p className="text-sm text-red-700 mt-2">{photoError}</p>
+          )}
+        </div>
 
         {error && (
           <div className="space-y-2">

--- a/src/app/[locale]/property/[city]/landlords/[landlordId]/page.js
+++ b/src/app/[locale]/property/[city]/landlords/[landlordId]/page.js
@@ -1,0 +1,103 @@
+import { notFound } from 'next/navigation';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { Link } from '@/i18n/navigation';
+
+import { getLandlordProfile } from '@/lib/landlordProfile';
+import ListingCard from '@/components/ListingCard';
+import LandlordAvatar from '@/components/landlord/LandlordAvatar';
+import VerifiedSeal from '@/components/ui/VerifiedSeal';
+import Pill from '@/components/ui/Pill';
+import Icon from '@/components/ui/Icon';
+import OrnamentRule from '@/components/ui/OrnamentRule';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://studentx.uk';
+
+// "Month Year" from a timestamp, e.g. "March 2026". null/invalid → null so the
+// caller can omit the line.
+function formatMemberSince(createdAt) {
+  if (!createdAt) return null;
+  const d = new Date(createdAt);
+  if (Number.isNaN(d.getTime())) return null;
+  return new Intl.DateTimeFormat('en', { month: 'long', year: 'numeric' }).format(d);
+}
+
+export async function generateMetadata({ params }) {
+  const { locale, landlordId } = await params;
+  const data = await getLandlordProfile(landlordId);
+  if (!data) return {};
+  const t = await getTranslations({ locale, namespace: 'propylaea.landlordProfile' });
+  return {
+    title: t('metaTitle', { name: data.landlord.name }),
+    description: t('metaDescription', { name: data.landlord.name }),
+    alternates: {
+      canonical: `${SITE_URL}/property/thessaloniki/landlords/${landlordId}`,
+    },
+  };
+}
+
+export default async function LandlordProfilePage({ params }) {
+  const { locale, landlordId } = await params;
+  setRequestLocale(locale);
+
+  // Verified-only: getLandlordProfile returns null for a missing OR unverified
+  // landlord, so an unverified landlord's URL 404s rather than exposing a page.
+  const data = await getLandlordProfile(landlordId);
+  if (!data) notFound();
+
+  const { landlord, listings } = data;
+  const t = await getTranslations({ locale, namespace: 'propylaea.landlordProfile' });
+
+  const memberSince = formatMemberSince(landlord.created_at);
+  const meta = [
+    memberSince ? t('memberSince', { date: memberSince }) : null,
+    t('propertyCount', { count: listings.length }),
+  ]
+    .filter(Boolean)
+    .join('  ·  ');
+
+  return (
+    <div className="mx-auto max-w-6xl px-5 pt-8 pb-20 md:py-12">
+      {/* Back to the directory */}
+      <Link
+        href="/property/thessaloniki/results"
+        className="inline-flex items-center gap-2 label-caps text-night/60 hover:text-blue transition-colors mb-8"
+      >
+        <Icon name="chevronRight" className="w-3.5 h-3.5 rotate-180" />
+        {t('back')}
+      </Link>
+
+      {/* Header — avatar, verified badge, name, member-since + property count */}
+      <header className="flex flex-col sm:flex-row sm:items-center gap-6 mb-2">
+        <LandlordAvatar
+          name={landlord.name}
+          photoUrl={landlord.profile_photo_url}
+          size={104}
+          className="border-2 border-yellow/60"
+        />
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 mb-3">
+            <VerifiedSeal size={28} />
+            <Pill variant="verified">{t('verified')}</Pill>
+          </div>
+          <h1 className="font-display text-4xl md:text-5xl text-night leading-tight text-balance">
+            {landlord.name}
+          </h1>
+          <p className="label-caps text-night/50 mt-3">{meta}</p>
+        </div>
+      </header>
+
+      <OrnamentRule className="my-8" />
+
+      {/* Their listings — same card as the directory */}
+      {listings.length > 0 ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-5">
+          {listings.map((listing) => (
+            <ListingCard key={listing.listing_id} listing={listing} />
+          ))}
+        </div>
+      ) : (
+        <p className="text-night/60 text-lg font-sans">{t('emptyState')}</p>
+      )}
+    </div>
+  );
+}

--- a/src/app/[locale]/property/[city]/listing/[id]/page.js
+++ b/src/app/[locale]/property/[city]/listing/[id]/page.js
@@ -11,6 +11,7 @@ import ContactGate from '@/components/listing/ContactGate';
 import ViewTracker from '@/components/listing/ViewTracker';
 import ReportListingModal from '@/components/listing/ReportListingModal';
 import FavoriteButton from '@/components/FavoriteButton';
+import LandlordAvatar from '@/components/landlord/LandlordAvatar';
 import Pill from '@/components/ui/Pill';
 import Card from '@/components/ui/Card';
 import Icon from '@/components/ui/Icon';
@@ -118,6 +119,29 @@ export default async function ListingPage({ params, searchParams }) {
               className="md:self-start shrink-0"
             />
           </div>
+
+          {/* Listed by — verified landlords link to their public profile.
+              landlord_id is the first 4 chars of the listing_id (see schema). */}
+          {isVerified && listing.landlord?.name && (
+            <Link
+              href={`/property/thessaloniki/landlords/${listing.listing_id.slice(0, 4)}`}
+              className="group inline-flex items-center gap-3 mb-10 rounded-sm focus-visible:outline-2 focus-visible:outline-yellow focus-visible:outline-offset-2"
+            >
+              <LandlordAvatar
+                name={listing.landlord.name}
+                photoUrl={listing.landlord.profile_photo_url}
+                size={48}
+              />
+              <span className="leading-tight">
+                <span className="label-caps text-night/50 block">
+                  {t('listedBy')}
+                </span>
+                <span className="font-display text-xl text-night group-hover:text-blue transition-colors">
+                  {listing.landlord.name}
+                </span>
+              </span>
+            </Link>
+          )}
 
           {/* Bilingual field grid */}
           <Card tone="parchment" border={false} className="p-6 md:p-8 mb-10">

--- a/src/app/api/landlord/profile/route.js
+++ b/src/app/api/landlord/profile/route.js
@@ -22,7 +22,7 @@ export async function GET(request) {
   // authenticated role. RLS already lets a landlord read their own row.
   const { data: landlord, error } = await getSupabaseWithToken(token)
     .from('landlords')
-    .select('landlord_id, name, email, contact_info, onboarding_completed, preferred_locale')
+    .select('landlord_id, name, email, contact_info, onboarding_completed, preferred_locale, profile_photo_url')
     .eq('auth_user_id', user.id)
     .single();
 
@@ -63,6 +63,17 @@ export async function PATCH(request) {
     updates.preferred_locale = body.preferred_locale;
   }
 
+  // Profile photo: a landlord sets/replaces/clears their public avatar. The
+  // URL must point at our own landlord-photos bucket (the browser uploader's
+  // getPublicUrl output) — see normalizeProfilePhotoUrl. null/'' clears it.
+  if (body.profile_photo_url !== undefined) {
+    const photoRes = normalizeProfilePhotoUrl(body.profile_photo_url);
+    if (!photoRes.ok) {
+      return NextResponse.json({ error: 'Invalid profile_photo_url' }, { status: 400 });
+    }
+    updates.profile_photo_url = photoRes.value;
+  }
+
   if (Object.keys(updates).length === 0) {
     return NextResponse.json({ error: 'No updatable fields supplied' }, { status: 400 });
   }
@@ -74,7 +85,7 @@ export async function PATCH(request) {
     .from('landlords')
     .update(updates)
     .eq('auth_user_id', user.id)
-    .select('landlord_id, name, email, contact_info, onboarding_completed, preferred_locale')
+    .select('landlord_id, name, email, contact_info, onboarding_completed, preferred_locale, profile_photo_url')
     .single();
 
   if (error || !landlord) {
@@ -146,6 +157,14 @@ export async function POST(request) {
   // already trimmed and lowercased upstream.
   const name = normalizeSingleLine(body.name) || user.email.split('@')[0];
 
+  // Optional avatar captured on the signup form. Validate it points at our own
+  // bucket (same rule as PATCH) rather than storing an arbitrary URL; absent is
+  // fine (most signups have no photo — they add one later in Settings).
+  const photoRes = normalizeProfilePhotoUrl(body.profile_photo_url);
+  if (!photoRes.ok) {
+    return NextResponse.json({ error: 'Invalid profile_photo_url' }, { status: 400 });
+  }
+
   const authedSupabase = getSupabaseWithToken(token);
   const { data: landlord, error } = await authedSupabase
     .from('landlords')
@@ -155,6 +174,7 @@ export async function POST(request) {
       contact_info: user.email,
       auth_user_id: user.id,
       email: user.email,
+      profile_photo_url: photoRes.value,
     })
     // founding_rank is set by a BEFORE INSERT trigger (migration 043) — return
     // it here so the welcome-email path can branch on it (rank 1–5 = founding
@@ -190,5 +210,24 @@ export async function POST(request) {
 // (migration 036) — the same email/auth user already has a students row.
 function isRoleConflict(err) {
   return err?.code === '23505' && /already registered as a student/i.test(err?.message || '');
+}
+
+// Validate/normalize a landlord profile photo URL. It must be a public URL on
+// our own Supabase storage `landlord-photos` bucket — exactly what the browser
+// uploader's getPublicUrl() returns. Rejecting arbitrary URLs keeps a landlord
+// from pointing their PUBLIC avatar at an off-site image (tracking/abuse) and
+// keeps stored data consistent with the bucket the uploader writes to.
+// `undefined` / null / '' all mean "no photo" → stored as NULL.
+// Returns { ok: boolean, value?: string|null }.
+function normalizeProfilePhotoUrl(value) {
+  if (value === undefined || value === null || value === '') {
+    return { ok: true, value: null };
+  }
+  if (typeof value !== 'string') return { ok: false };
+  const base = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!base) return { ok: false };
+  const prefix = `${base.replace(/\/+$/, '')}/storage/v1/object/public/landlord-photos/`;
+  if (!value.startsWith(prefix) || value.length > 1024) return { ok: false };
+  return { ok: true, value };
 }
 

--- a/src/app/api/listings/[id]/route.js
+++ b/src/app/api/listings/[id]/route.js
@@ -25,7 +25,7 @@ export async function GET(request, { params }) {
         rent ( monthly_price, currency, bills_included, deposit ),
         location ( address, neighborhood, lat, lng ),
         property_types ( name ),
-        landlords ( name, verified_tier, is_verified ),
+        landlords ( name, verified_tier, is_verified, profile_photo_url ),
         listing_amenities ( amenities ( amenity_id, name ) ),
         faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
       `

--- a/src/app/api/listings/route.js
+++ b/src/app/api/listings/route.js
@@ -20,7 +20,7 @@ const LISTING_SELECT = `
   rent!inner ( monthly_price, currency, bills_included, deposit ),
   location!inner ( address, neighborhood, lat, lng ),
   property_types!inner ( name ),
-  landlords!inner ( name, verified_tier, is_verified, verified_tier_rank ),
+  landlords!inner ( name, verified_tier, is_verified, verified_tier_rank, profile_photo_url ),
   listing_amenities ( amenities ( amenity_id, name ) ),
   faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
 `;

--- a/src/components/ListingCard.js
+++ b/src/components/ListingCard.js
@@ -4,6 +4,7 @@ import { Link } from '@/i18n/navigation';
 import Pill from '@/components/ui/Pill';
 import Icon from '@/components/ui/Icon';
 import FavoriteButton from '@/components/FavoriteButton';
+import LandlordAvatar from '@/components/landlord/LandlordAvatar';
 import { variantUrl } from '@/lib/photoVariants';
 import { formatPropertyType } from '@/lib/propertyType';
 
@@ -11,6 +12,11 @@ import { formatPropertyType } from '@/lib/propertyType';
   Propylaea listing card — matches page 06 of the reference design.
   Parchment frame, photo with gold verified seal overlay, small-caps
   neighborhood, EB Garamond address, type + price row, amenity pills.
+
+  Link structure: the whole card is a "stretched link" to the listing (an
+  absolute overlay, z-0), so the card stays fully clickable while still letting
+  TWO independent links live on top of it without nesting <a>s — the verified
+  landlord chip (→ landlord profile) and the favorite toggle, both z-10.
 */
 
 function isValidPhotoUrl(url) {
@@ -38,81 +44,110 @@ export default function ListingCard({ listing, fromQuery = '', groundFloorDealbr
     ? `/property/thessaloniki/listing/${listing.listing_id}?from=${encodeURIComponent(fromQuery)}`
     : `/property/thessaloniki/listing/${listing.listing_id}`;
 
+  // landlord_id is the first 4 chars of every listing_id (LLLLNNN — see
+  // docs/schema.md), so the profile link needs no extra field. The chip only
+  // renders for verified landlords (profiles are a verified-tier perk).
+  const landlordId = listing.listing_id?.slice(0, 4);
+  const landlordName = listing.landlord?.name;
+  const showLandlord = isVerified && landlordId && landlordName;
+
   return (
-    <div className="relative">
+    <div
+      className={`group relative bg-white rounded-sm overflow-hidden transition-all ${
+        isVerified
+          ? 'border-2 border-yellow/60 shadow-[0_0_12px_-2px_rgba(255,203,87,0.4)] hover:shadow-[0_0_18px_-2px_rgba(255,203,87,0.55)]'
+          : 'border border-night/10 hover:border-blue/40 hover:shadow-[0_2px_18px_-8px_rgba(10,20,54,0.25)]'
+      }`}
+    >
+      {/* Photo */}
+      <div className="relative aspect-[4/3] bg-parchment">
+        {isVerified && (
+          <span className="absolute top-3 right-3 z-10">
+            <Pill variant="verified">{tCard('verified')}</Pill>
+          </span>
+        )}
+        {photo ? (
+          <Image
+            src={variantUrl(photo, 'card')}
+            alt={listing.address}
+            fill
+            className="object-cover"
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+          />
+        ) : (
+          <div className="flex items-center justify-center h-full text-night/20">
+            <Icon name="photo" className="w-10 h-10" />
+          </div>
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="p-5">
+        <p className="label-caps text-night/50">
+          {listing.neighborhood} &middot; Thessaloniki
+        </p>
+        <h3 className="mt-1.5 font-display text-2xl text-night leading-tight line-clamp-2">
+          {listing.title || listing.address}
+        </h3>
+
+        <div className="mt-4 flex items-baseline justify-between gap-3">
+          <span className="label-caps text-night/60">
+            {formatPropertyType(listing.property_type, locale)}
+          </span>
+          <span className="font-display text-xl text-blue">
+            {listing.monthly_price != null ? (
+              <>
+                €{listing.monthly_price}
+                <span className="text-sm text-night/50">
+                  {tCard('perMonth')}
+                </span>
+              </>
+            ) : (
+              <span className="text-sm text-night/50">
+                {tCard('priceOnRequest')}
+              </span>
+            )}
+          </span>
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-1.5">
+          {floorUnspecified && (
+            <Pill variant="info">{t('floorNotSpecified')}</Pill>
+          )}
+          {listing.bills_included && (
+            <Pill variant="amenity">{t('billsIncluded')}</Pill>
+          )}
+        </div>
+
+        {/* Verified landlord chip — its own link (z-10) above the stretched
+            card link, so a tap here opens the landlord profile, not the listing. */}
+        {showLandlord && (
+          <Link
+            href={`/property/thessaloniki/landlords/${landlordId}`}
+            className="relative z-10 mt-4 inline-flex max-w-full items-center gap-2 group/landlord focus-visible:outline-2 focus-visible:outline-yellow focus-visible:outline-offset-2 rounded-sm"
+          >
+            <LandlordAvatar
+              name={landlordName}
+              photoUrl={listing.landlord?.profile_photo_url}
+              size={28}
+            />
+            <span className="label-caps text-night/55 truncate group-hover/landlord:text-blue transition-colors">
+              {tCard('listedBy', { name: landlordName })}
+            </span>
+          </Link>
+        )}
+      </div>
+
+      {/* Primary stretched link → listing detail. Transparent overlay covering
+          the whole card; sits below the chip/favorite (z-0 vs z-10). */}
       <Link
         href={href}
-        className={`group block bg-white rounded-sm overflow-hidden transition-all focus-visible:outline-2 focus-visible:outline-yellow focus-visible:outline-offset-2 ${
-          isVerified
-            ? 'border-2 border-yellow/60 shadow-[0_0_12px_-2px_rgba(255,203,87,0.4)] hover:shadow-[0_0_18px_-2px_rgba(255,203,87,0.55)]'
-            : 'border border-night/10 hover:border-blue/40 hover:shadow-[0_2px_18px_-8px_rgba(10,20,54,0.25)]'
-        }`}
-      >
-        {/* Photo */}
-        <div className="relative aspect-[4/3] bg-parchment">
-          {isVerified && (
-            <span className="absolute top-3 right-3 z-10">
-              <Pill variant="verified">{tCard('verified')}</Pill>
-            </span>
-          )}
-          {photo ? (
-            <Image
-              src={variantUrl(photo, 'card')}
-              alt={listing.address}
-              fill
-              className="object-cover"
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-            />
-          ) : (
-            <div className="flex items-center justify-center h-full text-night/20">
-              <Icon name="photo" className="w-10 h-10" />
-            </div>
-          )}
-        </div>
+        aria-label={listing.title || listing.address}
+        className="absolute inset-0 z-0 rounded-sm focus-visible:outline-2 focus-visible:outline-yellow focus-visible:outline-offset-2"
+      />
 
-        {/* Body */}
-        <div className="p-5">
-          <p className="label-caps text-night/50">
-            {listing.neighborhood} &middot; Thessaloniki
-          </p>
-          <h3 className="mt-1.5 font-display text-2xl text-night leading-tight line-clamp-2">
-            {listing.title || listing.address}
-          </h3>
-
-          <div className="mt-4 flex items-baseline justify-between gap-3">
-            <span className="label-caps text-night/60">
-              {formatPropertyType(listing.property_type, locale)}
-            </span>
-            <span className="font-display text-xl text-blue">
-              {listing.monthly_price != null ? (
-                <>
-                  €{listing.monthly_price}
-                  <span className="text-sm text-night/50">
-                    {tCard('perMonth')}
-                  </span>
-                </>
-              ) : (
-                <span className="text-sm text-night/50">
-                  {tCard('priceOnRequest')}
-                </span>
-              )}
-            </span>
-          </div>
-
-          <div className="mt-4 flex flex-wrap gap-1.5">
-            {floorUnspecified && (
-              <Pill variant="info">{t('floorNotSpecified')}</Pill>
-            )}
-            {listing.bills_included && (
-              <Pill variant="amenity">{t('billsIncluded')}</Pill>
-            )}
-          </div>
-        </div>
-      </Link>
-
-      {/* Save toggle — sibling of the card link (not nested in the
-          anchor), floated over the photo's top-left. Right corner is
-          reserved for the verified seal. */}
+      {/* Save toggle — over the photo's top-left, above the stretched link.
+          Right corner is reserved for the verified seal. */}
       <FavoriteButton
         listingId={listing.listing_id}
         className="absolute top-3 left-3 z-10"

--- a/src/components/landlord/LandlordAvatar.js
+++ b/src/components/landlord/LandlordAvatar.js
@@ -1,0 +1,40 @@
+import Image from 'next/image';
+
+/*
+  Landlord avatar — the profile photo students see on listing cards, the
+  listing detail "Listed by" block, and the landlord profile page header.
+  Falls back to a name-initial monogram when the landlord has no photo (existing
+  accounts, or skipped at signup). Purely presentational, no hooks — safe to
+  render inside a server component.
+
+  The photo is served from our public `landlord-photos` Supabase bucket, whose
+  host is already in next.config.mjs `images.remotePatterns`, so next/image
+  optimizes it without extra config.
+*/
+function initialOf(name) {
+  const c = (name || '').trim().charAt(0);
+  return c ? c.toUpperCase() : '?';
+}
+
+export default function LandlordAvatar({ name, photoUrl, size = 40, className = '' }) {
+  if (photoUrl) {
+    return (
+      <Image
+        src={photoUrl}
+        alt={name || 'Landlord'}
+        width={size}
+        height={size}
+        className={`rounded-full object-cover bg-parchment shrink-0 ${className}`}
+      />
+    );
+  }
+  return (
+    <span
+      aria-hidden="true"
+      className={`inline-flex items-center justify-center shrink-0 rounded-full bg-blue text-white font-display leading-none select-none ${className}`}
+      style={{ width: size, height: size, fontSize: Math.round(size * 0.44) }}
+    >
+      {initialOf(name)}
+    </span>
+  );
+}

--- a/src/components/landlord/ProfilePhotoSettings.js
+++ b/src/components/landlord/ProfilePhotoSettings.js
@@ -1,0 +1,185 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { useAccessToken } from '@/lib/useAccessToken';
+import { uploadLandlordPhoto, validateProfilePhoto } from '@/lib/uploadLandlordPhoto';
+import Card from '@/components/ui/Card';
+import Icon from '@/components/ui/Icon';
+
+/*
+  Landlord Settings → profile photo. Lets a landlord add, replace, or remove the
+  avatar shown on their public profile and listing cards (once verified). This
+  is also how EXISTING landlords — who signed up before the feature — get a
+  photo at all; until then they render as a name-initial monogram.
+
+  Upload is client-side to the landlord-photos bucket (resize + {uid}/ folder),
+  then we PATCH /api/landlord/profile with the resulting public URL.
+*/
+export default function ProfilePhotoSettings() {
+  const t = useTranslations('propylaea.landlord.settings');
+  const token = useAccessToken();
+  const [currentUrl, setCurrentUrl] = useState(null);
+  const [preview, setPreview] = useState(''); // blob: preview of a freshly chosen file
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [status, setStatus] = useState('');
+
+  // Load the current photo once the token resolves. All setState lives inside
+  // the async IIFE so we never call it synchronously in the effect body
+  // (react-hooks/set-state-in-effect).
+  useEffect(() => {
+    if (token === null) return; // still resolving — keep the loading state
+    let cancelled = false;
+    (async () => {
+      // Signed out (shouldn't happen on this authed page): just clear loading.
+      if (!token) {
+        if (!cancelled) setLoading(false);
+        return;
+      }
+      try {
+        const res = await fetch('/api/landlord/profile', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const body = await res.json().catch(() => ({}));
+        if (!cancelled && res.ok) {
+          setCurrentUrl(body.landlord?.profile_photo_url ?? null);
+        }
+      } catch {
+        /* non-fatal — leave the monogram */
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  async function handleChange(e) {
+    setError('');
+    setStatus('');
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const errKey = validateProfilePhoto(file);
+    if (errKey) {
+      setError(t(errKey));
+      return;
+    }
+
+    const localPreview = URL.createObjectURL(file);
+    setPreview(localPreview);
+    setSaving(true);
+    try {
+      const supabase = getSupabaseBrowser();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const url = await uploadLandlordPhoto(file, session?.user?.id);
+      const res = await fetch('/api/landlord/profile', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ profile_photo_url: url }),
+      });
+      if (!res.ok) throw new Error('save failed');
+      setCurrentUrl(url);
+      setStatus(t('photoSaved'));
+    } catch (err) {
+      console.error('[settings] profile photo save failed:', err);
+      setError(t('photoSaveError'));
+    } finally {
+      setSaving(false);
+      URL.revokeObjectURL(localPreview);
+      setPreview('');
+    }
+  }
+
+  async function handleRemove() {
+    setError('');
+    setStatus('');
+    setSaving(true);
+    try {
+      const res = await fetch('/api/landlord/profile', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ profile_photo_url: null }),
+      });
+      if (!res.ok) throw new Error('remove failed');
+      setCurrentUrl(null);
+      setStatus(t('photoRemoved'));
+    } catch (err) {
+      console.error('[settings] profile photo remove failed:', err);
+      setError(t('photoSaveError'));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const shownUrl = preview || currentUrl;
+
+  return (
+    <Card tone="parchment" className="px-6 py-6">
+      <h2 className="font-display text-xl text-night mb-1">{t('photoTitle')}</h2>
+      <p className="text-sm text-night/60 mb-5">{t('photoDescription')}</p>
+
+      <div className="flex items-center gap-5">
+        {shownUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element -- small avatar / transient blob preview; next/image adds no value here
+          <img
+            src={shownUrl}
+            alt=""
+            className="w-20 h-20 rounded-full object-cover border-2 border-yellow/60"
+          />
+        ) : (
+          <span className="inline-flex items-center justify-center w-20 h-20 rounded-full bg-white text-night/25 border border-night/10 shrink-0">
+            <Icon name="photo" className="w-7 h-7" />
+          </span>
+        )}
+
+        <div className="flex flex-col gap-2">
+          <input
+            id="settings-photo"
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            className="hidden"
+            onChange={handleChange}
+            disabled={saving || loading}
+          />
+          <label
+            htmlFor="settings-photo"
+            className={`inline-flex items-center gap-2 px-4 py-2 border-2 border-dashed border-gray-200 rounded-lg text-sm text-night/60 hover:border-yellow/60 hover:text-night cursor-pointer transition-colors ${
+              saving || loading ? 'opacity-50 pointer-events-none' : ''
+            }`}
+          >
+            {saving
+              ? t('photoSaving')
+              : currentUrl
+                ? t('photoReplace')
+                : t('photoChoose')}
+          </label>
+          {currentUrl && !saving && (
+            <button
+              type="button"
+              onClick={handleRemove}
+              className="text-sm text-night/50 hover:text-red-700 transition-colors text-left"
+            >
+              {t('photoRemove')}
+            </button>
+          )}
+          <p className="text-xs text-night/40">{t('photoHelp')}</p>
+        </div>
+      </div>
+
+      {error && <p className="text-sm text-red-700 mt-3">{error}</p>}
+      {status && <p className="text-sm text-green-700 mt-3">{status}</p>}
+    </Card>
+  );
+}

--- a/src/lib/landlordProfile.js
+++ b/src/lib/landlordProfile.js
@@ -1,0 +1,140 @@
+import { cache } from 'react';
+import { getSupabase } from '@/lib/supabase';
+import { transformListing } from '@/lib/transformListing';
+
+// Public-safe landlord columns ONLY. contact_info / email / stripe_customer_id
+// / auth_user_id are owner-only PII (security audit #1 — PRs #223/#224) and must
+// never be selected on this anon/public path. profile_photo_url was granted to
+// anon in migration 057; created_at powers the "member since" line.
+const LANDLORD_SELECT =
+  'landlord_id, name, verified_tier, is_verified, verified_tier_rank, profile_photo_url, created_at';
+
+// Fallback for an environment that hasn't run migration 057 yet (no
+// profile_photo_url column/grant). The verified gate still works — only the
+// avatar is missing and the UI falls back to a monogram.
+const LANDLORD_SELECT_FALLBACK =
+  'landlord_id, name, verified_tier, is_verified, verified_tier_rank, created_at';
+
+// Listings for one landlord — mirrors the public /api/listings shape so the
+// reused <ListingCard> renders identically. Main select carries
+// profile_photo_url (added in #057); fallback drops the newest columns so a
+// half-migrated DB never 500s the profile page.
+const LISTINGS_SELECT = `
+  listing_id,
+  is_featured,
+  title,
+  description,
+  photos,
+  floor,
+  min_duration_months,
+  rent ( monthly_price, currency, bills_included, deposit ),
+  location ( address, neighborhood, lat, lng ),
+  property_types ( name ),
+  landlords ( name, verified_tier, is_verified, verified_tier_rank, profile_photo_url ),
+  listing_amenities ( amenities ( amenity_id, name ) ),
+  faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
+`;
+
+const LISTINGS_SELECT_FALLBACK = `
+  listing_id,
+  title,
+  description,
+  photos,
+  floor,
+  rent ( monthly_price, currency, bills_included, deposit ),
+  location ( address, neighborhood, lat, lng ),
+  property_types ( name ),
+  landlords ( name ),
+  listing_amenities ( amenities ( amenity_id, name ) ),
+  faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
+`;
+
+// A profile is a verified-tier perk. Same predicate the listing detail page and
+// ListingCard use to decide the verified styling, kept in one place here.
+export function isVerifiedLandlord(landlord) {
+  return Boolean(
+    landlord &&
+      landlord.is_verified === true &&
+      landlord.verified_tier &&
+      landlord.verified_tier !== 'none',
+  );
+}
+
+/**
+ * Public landlord-profile fetch for the student-facing
+ * /property/[city]/landlords/[landlordId] page.
+ *
+ * Returns `{ landlord, listings }` for a VERIFIED landlord, or `null` when the
+ * landlord doesn't exist or isn't verified (profiles are verified-only — the
+ * page calls notFound() on null). Reads through the anon client and selects
+ * only public-safe columns. Memoized per-request like getListingForRender so a
+ * layout's metadata pass and the page body share one round-trip.
+ *
+ * @param {string} landlordId 4-digit landlord identifier (the LLLL prefix of a listing_id)
+ */
+export const getLandlordProfile = cache(async (landlordId) => {
+  // landlord_id is the documented 4-digit identifier (see docs/schema.md).
+  if (!landlordId || !/^\d{4}$/.test(landlordId)) return null;
+
+  const supabase = getSupabase();
+  try {
+    // --- Landlord row (public-safe columns + verified gate) ---
+    let { data: landlord, error } = await supabase
+      .from('landlords')
+      .select(LANDLORD_SELECT)
+      .eq('landlord_id', landlordId)
+      .single();
+
+    // PGRST116 = no row; anything else may be a missing column on a
+    // half-migrated DB — retry with the pre-#057 column set.
+    if (error && error.code !== 'PGRST116') {
+      const fb = await supabase
+        .from('landlords')
+        .select(LANDLORD_SELECT_FALLBACK)
+        .eq('landlord_id', landlordId)
+        .single();
+      landlord = fb.data;
+      error = fb.error;
+    }
+
+    if (error || !landlord) return null;
+    if (!isVerifiedLandlord(landlord)) return null;
+
+    // --- Their listings (same shape as the public directory) ---
+    // Single landlord ⇒ verified_tier_rank is constant, so order is just
+    // featured-first then newest (listing_id's per-landlord sequence increases
+    // with recency — see the LLLLNNN format in docs/schema.md).
+    let { data: rows, error: listErr } = await supabase
+      .from('listings')
+      .select(LISTINGS_SELECT)
+      .eq('landlord_id', landlordId)
+      .order('is_featured', { ascending: false })
+      .order('listing_id', { ascending: false });
+
+    if (listErr) {
+      const fb = await supabase
+        .from('listings')
+        .select(LISTINGS_SELECT_FALLBACK)
+        .eq('landlord_id', landlordId)
+        .order('listing_id', { ascending: false });
+      rows = fb.data;
+      listErr = fb.error;
+    }
+
+    const listings = (rows || []).map(transformListing);
+
+    return {
+      landlord: {
+        landlord_id: landlord.landlord_id,
+        name: landlord.name ?? null,
+        verified_tier: landlord.verified_tier ?? 'none',
+        is_verified: landlord.is_verified ?? false,
+        profile_photo_url: landlord.profile_photo_url ?? null,
+        created_at: landlord.created_at ?? null,
+      },
+      listings,
+    };
+  } catch {
+    return null;
+  }
+});

--- a/src/lib/listingForRender.js
+++ b/src/lib/listingForRender.js
@@ -10,7 +10,7 @@ const LISTING_SELECT = `
   rent ( monthly_price, currency, bills_included, deposit ),
   location ( address, neighborhood, lat, lng ),
   property_types ( name ),
-  landlords ( name, verified_tier, is_verified ),
+  landlords ( name, verified_tier, is_verified, profile_photo_url ),
   listing_amenities ( amenities ( amenity_id, name ) ),
   faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
 `;

--- a/src/lib/transformListing.js
+++ b/src/lib/transformListing.js
@@ -32,6 +32,10 @@ export function transformListing(row) {
     // inquiry flow keyed on listing_id, never the raw contact string.
     landlord: {
       name: row.landlords?.name ?? null,
+      // Public-safe: the avatar shown on listing cards and the landlord
+      // profile page. Unlike contact_info (see the note above), this is
+      // intentionally public — it's a photo the landlord uploads for display.
+      profile_photo_url: row.landlords?.profile_photo_url ?? null,
     },
     faculty_distances: (row.faculty_distances ?? []).map((fd) => ({
       faculty_id: fd.faculty_id,

--- a/src/lib/uploadLandlordPhoto.js
+++ b/src/lib/uploadLandlordPhoto.js
@@ -1,0 +1,46 @@
+import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { resizeToVariants } from '@/lib/imageResize';
+
+// Client-side guards before we even resize. The browser resize re-encodes to a
+// small WebP regardless, but reject obviously-wrong/huge inputs up front.
+export const PROFILE_PHOTO_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+export const PROFILE_PHOTO_MAX_BYTES = 8 * 1024 * 1024; // 8 MB
+
+/**
+ * Validate a chosen avatar file. Returns an error key string (for next-intl) or
+ * null when the file is acceptable.
+ */
+export function validateProfilePhoto(file) {
+  if (!PROFILE_PHOTO_TYPES.includes(file.type)) return 'photoInvalidType';
+  if (file.size > PROFILE_PHOTO_MAX_BYTES) return 'photoTooLarge';
+  return null;
+}
+
+/**
+ * Resize a chosen image to a single avatar-sized WebP and upload it to the
+ * caller's own folder in the public `landlord-photos` bucket, returning the
+ * public URL to store on landlords.profile_photo_url.
+ *
+ * MUST be called with an authenticated session present in the browser client —
+ * the storage INSERT policy (migration 057) requires the object path to begin
+ * with the uploader's auth.uid(). The display surfaces crop to a circle with
+ * object-cover, so the stored image needn't be square.
+ *
+ * @param {File} file  user-selected image
+ * @param {string} userId  authenticated auth.uid() (session.user.id)
+ * @returns {Promise<string>} public URL
+ */
+export async function uploadLandlordPhoto(file, userId) {
+  if (!userId) throw new Error('Not signed in');
+  const variants = await resizeToVariants(file);
+  const supabase = getSupabaseBrowser();
+  // {uid}/ prefix satisfies the folder-scoped storage RLS policy.
+  const path = `${userId}/avatar-${Date.now()}-${Math.random().toString(36).slice(2)}.${variants.ext}`;
+  const contentType = variants.ext === 'webp' ? 'image/webp' : 'image/jpeg';
+  const { error } = await supabase.storage
+    .from('landlord-photos')
+    .upload(path, variants.card, { upsert: false, contentType });
+  if (error) throw error;
+  const { data } = supabase.storage.from('landlord-photos').getPublicUrl(path);
+  return data.publicUrl;
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -131,7 +131,8 @@
     "transitMin": "min transit",
     "to": "to",
     "billsIncluded": "Bills included",
-    "billsNotIncluded": "Bills not included"
+    "billsNotIncluded": "Bills not included",
+    "listedBy": "Listed by {name}"
   },
   "about": {
     "metaTitle": "About StudentX",
@@ -197,7 +198,13 @@
       "priceOriginal": "€49",
       "priceDiscounted": "€9.80",
       "pricePeriod": "/ yr",
-      "founderBlurb": "The first five landlords to sign up lock in this price for Year 1. No auto-renewal at full price."
+      "founderBlurb": "The first five landlords to sign up lock in this price for Year 1. No auto-renewal at full price.",
+      "photoLabel": "Profile photo (optional)",
+      "photoChoose": "Choose a photo",
+      "photoReplace": "Choose a different photo",
+      "photoHelp": "Shown on your public profile and listings once you're verified. JPG, PNG or WebP, up to 8 MB.",
+      "photoInvalidType": "Please choose a JPG, PNG or WebP image.",
+      "photoTooLarge": "That image is too large. Please choose one under 8 MB."
     },
     "dashboard": {
       "welcome": "Welcome back, {name}!",
@@ -558,6 +565,7 @@
     "listing": {
       "back": "Back to results",
       "verified": "Verified",
+      "listedBy": "Listed by",
       "streetAddressA11y": "Street address",
       "rentGreek": "Ενοίκιο",
       "rentEnglish": "Rent",
@@ -586,6 +594,15 @@
         "title": "Listing not found",
         "description": "This student housing listing could not be found."
       }
+    },
+    "landlordProfile": {
+      "back": "Back to listings",
+      "verified": "Verified landlord",
+      "memberSince": "Member since {date}",
+      "propertyCount": "{count, plural, =0 {No properties listed} one {# property} other {# properties}}",
+      "emptyState": "This landlord has no listings at the moment.",
+      "metaTitle": "{name} — Verified landlord",
+      "metaDescription": "Browse all student housing listed by {name}, a verified landlord on StudentX Thessaloniki."
     },
     "gallery": {
       "openLightbox": "Open photo gallery",
@@ -636,7 +653,19 @@
       "settings": {
         "eyebrow": "Settings",
         "title": "Account preferences",
-        "emptyState": "No settings to configure yet. Future preferences (notifications, billing contact, display name) will live here."
+        "emptyState": "No settings to configure yet. Future preferences (notifications, billing contact, display name) will live here.",
+        "photoTitle": "Profile photo",
+        "photoDescription": "Shown on your public profile and listing cards once your account is verified.",
+        "photoChoose": "Upload a photo",
+        "photoReplace": "Replace photo",
+        "photoRemove": "Remove photo",
+        "photoHelp": "JPG, PNG or WebP, up to 8 MB.",
+        "photoSaving": "Saving…",
+        "photoSaved": "Profile photo updated.",
+        "photoRemoved": "Profile photo removed.",
+        "photoSaveError": "Couldn't save your photo. Please try again.",
+        "photoInvalidType": "Please choose a JPG, PNG or WebP image.",
+        "photoTooLarge": "That image is too large. Please choose one under 8 MB."
       },
       "dashboard": {
         "welcomeEyebrow": "Landlord dashboard",

--- a/supabase/migrations/057_landlord_profile_photo.sql
+++ b/supabase/migrations/057_landlord_profile_photo.sql
@@ -1,0 +1,70 @@
+-- 057_landlord_profile_photo
+--
+-- Landlord public-profile feature: adds the profile photo students see on a
+-- verified landlord's listing cards and profile page, plus a public storage
+-- bucket to hold the uploaded avatars.
+--
+-- APPLY ORDERING: safe to apply before OR after the consuming code deploys.
+-- The listing SELECTs add profile_photo_url only to their MAIN select (the
+-- FALLBACK select omits it), so pre-migration the code degrades gracefully
+-- (renders a monogram, no 500) rather than breaking. Apply to prod during PR
+-- review per CLAUDE.md's migration-ordering convention so the photo actually
+-- shows on deploy.
+
+-- 1. The column. Nullable: most landlords won't have a photo (existing accounts,
+--    and it's optional at signup), in which case the UI shows a name-initial
+--    monogram instead.
+alter table public.landlords
+  add column if not exists profile_photo_url text;
+
+-- 2. Re-grant anon SELECT on the new column. Migration 056 revoked table-wide
+--    anon SELECT on landlords and re-granted a FIXED column list (every column
+--    that existed at apply time, except contact_info). A column added LATER is
+--    therefore not readable by the anon role until granted explicitly — and the
+--    public listings query (api/listings, anon client) joins landlords, so
+--    without this grant the main SELECT errors and silently falls back to the
+--    no-photo SELECT. contact_info stays revoked.
+grant select (profile_photo_url) on public.landlords to anon;
+
+-- 3. Public storage bucket for landlord avatars, mirroring `listing-photos`.
+--    Public so the stored getPublicUrl renders in <img>/next-image without a
+--    signed URL (public buckets serve reads through the public CDN URL without
+--    an RLS SELECT policy, exactly like listing-photos). The listing-photos
+--    bucket is created out-of-band on prod (prod migration 013, not in the
+--    repo); we create this one in-migration so it's reproducible in the clean
+--    CI `supabase start` stack too.
+insert into storage.buckets (id, name, public)
+values ('landlord-photos', 'landlord-photos', true)
+on conflict (id) do nothing;
+
+-- 4. Write/replace/delete scoped to the caller's own {uid}/ folder — the same
+--    path-scoping #224 (migration 054) applied to listing-photos, so a signed-in
+--    landlord can only touch objects under their own auth.uid() prefix. The
+--    browser uploader writes to `${auth.uid()}/...`, so legitimate uploads pass.
+drop policy if exists "Landlords can upload profile photos" on storage.objects;
+create policy "Landlords can upload profile photos"
+  on storage.objects for insert to authenticated
+  with check (
+    bucket_id = 'landlord-photos'
+    and (auth.uid())::text = (storage.foldername(name))[1]
+  );
+
+drop policy if exists "Landlords can update profile photos" on storage.objects;
+create policy "Landlords can update profile photos"
+  on storage.objects for update to authenticated
+  using (
+    bucket_id = 'landlord-photos'
+    and (auth.uid())::text = (storage.foldername(name))[1]
+  )
+  with check (
+    bucket_id = 'landlord-photos'
+    and (auth.uid())::text = (storage.foldername(name))[1]
+  );
+
+drop policy if exists "Landlords can delete profile photos" on storage.objects;
+create policy "Landlords can delete profile photos"
+  on storage.objects for delete to authenticated
+  using (
+    bucket_id = 'landlord-photos'
+    and (auth.uid())::text = (storage.foldername(name))[1]
+  );


### PR DESCRIPTION
## What & why
Students currently see nothing about who owns a listing. This adds a public profile for **verified** landlords — avatar, name, verified badge, member-since, and all their listings — reachable by clicking the landlord on result cards and on the listing detail page. Landlords add a photo at signup (optional) or in Settings. Unverified landlords have no public profile (the URL 404s). Informational only — contact stays per-listing via the existing inquiry flow.

## Changes
- **Migration `057`** — `landlords.profile_photo_url` + an explicit `anon` SELECT grant (056 revoked table-wide anon SELECT and re-granted a fixed column list, so a new column is invisible to the public listings query until granted) + a public `landlord-photos` storage bucket with `{uid}/`-scoped write policies mirroring `listing-photos` (#224).
- **Exposure** — `profile_photo_url` flows through `transformListing` + the **main** listing SELECTs (`/api/listings`, `/api/listings/[id]`, `lib/listingForRender`); fallback SELECTs left minimal for pre-migration safety. Still exposes **no** `contact_info`/`email` — the audit-#1 boundary (#223) holds.
- **`getLandlordProfile()`** helper with the verified-only gate (returns null → `notFound()` for missing/unverified).
- **`/api/landlord/profile`** POST/PATCH/GET accept a `profile_photo_url` validated to our own `landlord-photos` bucket URL.
- **UI** — `LandlordAvatar` (photo or name-initial monogram); `ListingCard` moved to a stretched-link layout so a landlord chip links to the profile without nesting anchors; "Listed by" block on the listing detail page; new `/property/[city]/landlords/[id]` profile page.
- **Upload** — optional photo field on the signup form + a Settings "Profile photo" card, reusing the existing browser resize (`resizeToVariants`) + storage-upload pattern.
- i18n keys (English).

## Migration ordering
Migration `057` has **already been applied to production** (it's additive and safe for the currently-deployed code, which never selects the new column) — per CLAUDE.md's apply-before-merge convention. Verified on prod: column present, anon SELECT granted, public bucket + 3 storage policies created.

## Verification
- `npm run lint` ✓ · `npm run build` ✓ · **222/222 tests** ✓ (incl. updated `transformListing` snapshot).
- End-to-end on the dev server: profile renders (monogram + photo) at desktop & mobile; verified-only gate (`0100`/`9999` → 404, `0106` → 200); "Listed by" chip on result cards + detail; public `/api/listings` returns `{name, profile_photo_url}` and **no** PII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)