### PR TITLE
feat(listings): merge featured + verified into one "SuperLandlord" status

### DIFF
--- a/__tests__/lib/listingFilters.test.js
+++ b/__tests__/lib/listingFilters.test.js
@@ -86,6 +86,8 @@ describe('applyListingFilters', () => {
     expect(b._calls).toContainEqual(['lte', 'min_duration_months', 5]);
     expect(b._calls).toContainEqual(['neq', 'landlords.verified_tier', 'none']);
     expect(b._calls).toContainEqual(['eq', 'landlords.is_verified', true]);
+    // SuperLandlord = verified half (above) + paying half (is_featured).
+    expect(b._calls).toContainEqual(['eq', 'is_featured', true]);
     expect(b._calls).toContainEqual(['eq', 'rent.bills_included', true]);
     expect(b._calls).toContainEqual(['or', 'floor.is.null,floor.neq.0']);
     expect(b._calls).toContainEqual(['or', 'available_from.is.null,available_from.lte.2026-09-01']);
@@ -104,6 +106,7 @@ describe('applyListingFilters', () => {
     expect(b._calls).toContainEqual(['in', 'property_types.name', ['Studio']]);
     // ...but the two fallback-incompatible clauses are skipped.
     expect(b._calls.some(([name, col]) => name === 'neq' && col === 'landlords.verified_tier')).toBe(false);
+    expect(b._calls.some(([name, col]) => name === 'eq' && col === 'is_featured')).toBe(false);
     expect(b._calls.some(([name, col]) => name === 'lte' && col === 'min_duration_months')).toBe(false);
   });
 });

--- a/__tests__/lib/transformListing.test.js
+++ b/__tests__/lib/transformListing.test.js
@@ -40,6 +40,7 @@ describe('transformListing', () => {
       is_featured: true,
       verified_tier: 'gold',
       is_verified: true,
+      is_superlandlord: true,
       title: 'Sunny studio near Medical School',
       address: '12 Egnatias',
       neighborhood: 'Center',
@@ -127,5 +128,26 @@ describe('transformListing', () => {
     const row = { ...fullRow };
     delete row.is_featured;
     expect(transformListing(row).is_featured).toBe(false);
+  });
+
+  describe('is_superlandlord (paying AND verified)', () => {
+    it('is true when the landlord is paying and fully verified', () => {
+      // fullRow: is_featured + verified_tier 'gold' + is_verified true
+      expect(transformListing(fullRow).is_superlandlord).toBe(true);
+    });
+
+    it('is false when verified but not paying (is_featured false)', () => {
+      expect(transformListing({ ...fullRow, is_featured: false }).is_superlandlord).toBe(false);
+    });
+
+    it('is false when paying but ID not approved (is_verified false)', () => {
+      const row = { ...fullRow, landlords: { ...fullRow.landlords, is_verified: false } };
+      expect(transformListing(row).is_superlandlord).toBe(false);
+    });
+
+    it('is false when paying and ID-approved but verified_tier is "none"', () => {
+      const row = { ...fullRow, landlords: { ...fullRow.landlords, verified_tier: 'none' } };
+      expect(transformListing(row).is_superlandlord).toBe(false);
+    });
   });
 });

--- a/src/app/[locale]/property/[city]/landlord/dashboard/page.js
+++ b/src/app/[locale]/property/[city]/landlord/dashboard/page.js
@@ -212,7 +212,10 @@ export default function LandlordDashboardPage() {
               <ul className="divide-y divide-night/10">
                 {listings.slice(0, 5).map((listing) => (
                   <li key={listing.listing_id} className="py-4 first:pt-0 last:pb-0">
-                    <ListingRow listing={listing} />
+                    <ListingRow
+                      listing={listing}
+                      isSuper={isVerified && verifiedTier !== 'none'}
+                    />
                   </li>
                 ))}
               </ul>
@@ -298,12 +301,14 @@ function StatTile({ label, value, loading, accent, caption }) {
   );
 }
 
-function ListingRow({ listing }) {
+function ListingRow({ listing, isSuper }) {
   const photo = listing.photos?.find((url) => typeof url === 'string' && url.startsWith('http'));
   const address = listing.location?.address || 'Untitled listing';
   const neighborhood = listing.location?.neighborhood;
   const price = listing.rent?.monthly_price;
-  const status = listing.is_featured ? 'Featured' : null;
+  // is_featured (paying) alone is not enough — a subscribed-but-unverified
+  // landlord isn't a SuperLandlord and gets no halo/ranking, so don't imply it.
+  const status = isSuper && listing.is_featured ? 'SuperLandlord' : null;
 
   return (
     <div className="flex items-center gap-4">

--- a/src/app/[locale]/property/[city]/landlord/listings/page.js
+++ b/src/app/[locale]/property/[city]/landlord/listings/page.js
@@ -29,6 +29,9 @@ export default function LandlordListingsPage() {
   const [deleting, setDeleting] = useState(null);
   // The listing pending delete-confirmation, or null when the dialog is closed.
   const [confirmTarget, setConfirmTarget] = useState(null);
+  // SuperLandlord status (the verified half — is_featured per listing supplies
+  // the paying half). Gates the per-listing "SuperLandlord" badge.
+  const [isSuper, setIsSuper] = useState(false);
   useEffect(() => {
     (async () => {
       const supabase = getSupabaseBrowser();
@@ -44,6 +47,20 @@ export default function LandlordListingsPage() {
         } else {
           setError('Failed to load listings');
         }
+
+        // SuperLandlord status (verified half). Non-fatal: if this read fails
+        // the badge just stays hidden — it must never dark the listings table.
+        try {
+          const subRes = await fetch('/api/landlord/billing/subscription', {
+            headers: { Authorization: `Bearer ${session.access_token}` },
+          });
+          if (subRes.ok) {
+            const sub = await subRes.json();
+            setIsSuper(
+              sub.isVerified === true && sub.verifiedTier && sub.verifiedTier !== 'none'
+            );
+          }
+        } catch { /* non-fatal */ }
       } catch {
         setError('Failed to load listings');
       } finally {
@@ -123,6 +140,7 @@ export default function LandlordListingsPage() {
                   listing={listing}
                   deleting={deleting === listing.listing_id}
                   onDelete={() => setConfirmTarget(listing)}
+                  isSuper={isSuper}
                   t={t}
                 />
               </li>
@@ -151,7 +169,7 @@ export default function LandlordListingsPage() {
   );
 }
 
-function ListingRow({ listing, deleting, onDelete, t }) {
+function ListingRow({ listing, deleting, onDelete, isSuper, t }) {
   const photo = listing.photos?.find((url) => typeof url === 'string' && url.startsWith('http'));
   const address = listing.location?.address || t('noAddress');
   const heading = listing.title || address;
@@ -181,7 +199,9 @@ function ListingRow({ listing, deleting, onDelete, t }) {
           <p className="font-display text-xl text-night truncate">
             {heading}
           </p>
-          {listing.is_featured && <Pill variant="verified">{t('featured')}</Pill>}
+          {isSuper && listing.is_featured && (
+            <Pill variant="verified">{t('superLandlord')}</Pill>
+          )}
         </div>
         {/* Address always rendered on this internal surface — landlords
             identify their own listings by street most reliably. For

--- a/src/app/[locale]/property/[city]/listing/[id]/page.js
+++ b/src/app/[locale]/property/[city]/listing/[id]/page.js
@@ -46,10 +46,10 @@ export default async function ListingPage({ params, searchParams }) {
   const photos = (listing.photos || []).filter(
     (url) => typeof url === 'string' && url.startsWith('http'),
   );
-  const isVerified =
-    listing.verified_tier &&
-    listing.verified_tier !== 'none' &&
-    listing.is_verified === true;
+  // SuperLandlord = the single elevated status (paying AND verified), computed
+  // once in transformListing. Drives the seal, the badge, and the "listed by"
+  // profile link below.
+  const isSuper = listing.is_superlandlord;
 
   const distances = deriveDestinations(listing.faculty_distances || [], t);
 
@@ -88,9 +88,9 @@ export default async function ListingPage({ params, searchParams }) {
         <div>
           {/* Hero stripe — verified seal + address */}
           <div className="flex flex-col md:flex-row md:items-start gap-5 mb-8">
-            {isVerified && <VerifiedSeal size={52} />}
+            {isSuper && <VerifiedSeal size={52} />}
             <div className="flex-1">
-              {isVerified && (
+              {isSuper && (
                 <div className="flex flex-wrap items-center gap-2 mb-3">
                   <Pill variant="verified">{t('verified')}</Pill>
                 </div>
@@ -120,9 +120,9 @@ export default async function ListingPage({ params, searchParams }) {
             />
           </div>
 
-          {/* Listed by — verified landlords link to their public profile.
+          {/* Listed by — SuperLandlords link to their public profile.
               landlord_id is the first 4 chars of the listing_id (see schema). */}
-          {isVerified && listing.landlord?.name && (
+          {isSuper && listing.landlord?.name && (
             <Link
               href={`/property/thessaloniki/landlords/${listing.listing_id.slice(0, 4)}`}
               className="group inline-flex items-center gap-3 mb-10 rounded-sm focus-visible:outline-2 focus-visible:outline-yellow focus-visible:outline-offset-2"

--- a/src/app/api/listings/[id]/route.js
+++ b/src/app/api/listings/[id]/route.js
@@ -19,6 +19,7 @@ export async function GET(request, { params }) {
       .select(
         `
         listing_id,
+        is_featured,
         title,
         description,
         photos,

--- a/src/app/api/listings/route.js
+++ b/src/app/api/listings/route.js
@@ -20,7 +20,7 @@ const LISTING_SELECT = `
   rent!inner ( monthly_price, currency, bills_included, deposit ),
   location!inner ( address, neighborhood, lat, lng ),
   property_types!inner ( name ),
-  landlords!inner ( name, verified_tier, is_verified, verified_tier_rank, profile_photo_url ),
+  landlords!inner ( name, verified_tier, is_verified, profile_photo_url ),
   listing_amenities ( amenities ( amenity_id, name ) ),
   faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
 `;
@@ -73,7 +73,6 @@ export async function GET(request) {
     }
 
     // Build query
-    let usedFallback = false;
     let query = supabase.from("listings").select(LISTING_SELECT);
     query = applyListingFilters(query, f, { amenityListingIds });
 
@@ -101,24 +100,15 @@ export async function GET(request) {
       query = query.lte("rent.monthly_price", budget);
     }
 
-    // SQL-level sort: tier rank → featured → user-chosen metric
-    query = query
-      .order('landlords(verified_tier_rank)', { ascending: true })
-      .order('is_featured', { ascending: false });
-
-    if (f.sortBy === 'price') {
-      query = query.order('rent(monthly_price)', {
-        ascending: f.sortOrder === 'asc',
-        nullsFirst: false,
-      });
-    }
-
+    // No DB-level ordering: ranking is computed in JS after transform (see the
+    // sort below). The SuperLandlord predicate spans listing + joined landlord
+    // columns, which a single .order() can't express cleanly.
     let { data, error } = await query;
 
-    // If query fails (e.g. verified_tier_rank column not yet migrated), retry without it
+    // If query fails (e.g. the verified columns aren't migrated yet), retry
+    // with the reduced SELECT that omits them.
     if (error) {
-      console.warn("Listings query failed, retrying without verified_tier:", error.message);
-      usedFallback = true;
+      console.warn("Listings query failed, retrying without verified columns:", error.message);
       let fallbackQuery = supabase.from("listings").select(LISTING_SELECT_FALLBACK);
       fallbackQuery = applyListingFilters(fallbackQuery, f, { fallback: true, amenityListingIds });
       if (minBudget) fallbackQuery = fallbackQuery.gte("rent.monthly_price", Number(minBudget));
@@ -151,39 +141,36 @@ export async function GET(request) {
       results = results.filter((listing) => hasAllRequiredAmenities(listing.amenities, required));
     }
 
-    // Sort: SQL handles tier rank → featured → price for sortBy=price.
-    // Walk/transit need JS because faculty_distances is a to-many join.
-    // Fallback path always needs JS (no .order() was applied).
-    if (usedFallback || f.sortBy !== "price") {
-      const tierRank = { verified_pro: 0, verified: 1, none: 2 };
-      results.sort((a, b) => {
-        const rankA = tierRank[a.verified_tier] ?? 2;
-        const rankB = tierRank[b.verified_tier] ?? 2;
-        if (rankA !== rankB) return rankA - rankB;
+    // Ranking: SuperLandlords (the single elevated status — paying AND
+    // verified) float to the top, then the student's chosen metric within each
+    // group, then newest-first as a deterministic tiebreaker. Done in JS for
+    // every sort mode because the SuperLandlord predicate spans listing +
+    // joined landlord columns and faculty_distances is a to-many join — neither
+    // expressible as a single .order(). (The old verified_tier_rank → featured
+    // gradient collapsed to this binary predicate in the SuperLandlord merge,
+    // so verified_pro no longer outranks verified.)
+    const metricValue = (listing) => {
+      if (f.sortBy === "price") return listing.monthly_price;
+      if (f.sortBy === "walk_minutes") return listing.faculty_distances[0]?.walk_minutes ?? null;
+      if (f.sortBy === "transit_minutes") return listing.faculty_distances[0]?.transit_minutes ?? null;
+      return null; // 'match'/default: SuperLandlord-first, then newest
+    };
 
-        if (a.is_featured && !b.is_featured) return -1;
-        if (!a.is_featured && b.is_featured) return 1;
+    results.sort((a, b) => {
+      if (a.is_superlandlord !== b.is_superlandlord) return a.is_superlandlord ? -1 : 1;
 
-        let valA, valB;
-
-        if (f.sortBy === "price") {
-          valA = a.monthly_price;
-          valB = b.monthly_price;
-        } else if (f.sortBy === "walk_minutes") {
-          valA = a.faculty_distances[0]?.walk_minutes ?? null;
-          valB = b.faculty_distances[0]?.walk_minutes ?? null;
-        } else if (f.sortBy === "transit_minutes") {
-          valA = a.faculty_distances[0]?.transit_minutes ?? null;
-          valB = b.faculty_distances[0]?.transit_minutes ?? null;
-        }
-
-        if (valA == null && valB == null) return 0;
+      const valA = metricValue(a);
+      const valB = metricValue(b);
+      if (valA != null || valB != null) {
         if (valA == null) return 1;
         if (valB == null) return -1;
+        if (valA !== valB) return f.sortOrder === "desc" ? valB - valA : valA - valB;
+      }
 
-        return f.sortOrder === "desc" ? valB - valA : valA - valB;
-      });
-    }
+      // Deterministic tiebreaker: newest first (listing_id grows with recency).
+      if (a.listing_id === b.listing_id) return 0;
+      return a.listing_id < b.listing_id ? 1 : -1;
+    });
 
     const response = NextResponse.json({ listings: results });
     response.headers.set(

--- a/src/components/ListingCard.js
+++ b/src/components/ListingCard.js
@@ -32,10 +32,10 @@ export default function ListingCard({ listing, fromQuery = '', groundFloorDealbr
   // floor, flag it so they ask before viewing rather than discovering on the
   // day (NULL floors are kept in results, not filtered out — see #100).
   const floorUnspecified = groundFloorDealbreaker && listing.floor == null;
-  const isVerified =
-    listing.verified_tier &&
-    listing.verified_tier !== 'none' &&
-    listing.is_verified === true;
+  // SuperLandlord = the single elevated status (paying AND verified), computed
+  // once in transformListing. Drives the golden frame, the badge, and the
+  // landlord chip below.
+  const isSuper = listing.is_superlandlord;
 
   // Thread current results search-state into the listing URL so the
   // detail page's back link returns to the same filtered view. Caller
@@ -46,22 +46,22 @@ export default function ListingCard({ listing, fromQuery = '', groundFloorDealbr
 
   // landlord_id is the first 4 chars of every listing_id (LLLLNNN — see
   // docs/schema.md), so the profile link needs no extra field. The chip only
-  // renders for verified landlords (profiles are a verified-tier perk).
+  // renders for SuperLandlords (public profiles are a SuperLandlord perk).
   const landlordId = listing.listing_id?.slice(0, 4);
   const landlordName = listing.landlord?.name;
-  const showLandlord = isVerified && landlordId && landlordName;
+  const showLandlord = isSuper && landlordId && landlordName;
 
   return (
     <div
       className={`group relative bg-white rounded-sm overflow-hidden transition-all ${
-        isVerified
+        isSuper
           ? 'border-2 border-yellow/60 shadow-[0_0_12px_-2px_rgba(255,203,87,0.4)] hover:shadow-[0_0_18px_-2px_rgba(255,203,87,0.55)]'
           : 'border border-night/10 hover:border-blue/40 hover:shadow-[0_2px_18px_-8px_rgba(10,20,54,0.25)]'
       }`}
     >
       {/* Photo */}
       <div className="relative aspect-[4/3] bg-parchment">
-        {isVerified && (
+        {isSuper && (
           <span className="absolute top-3 right-3 z-10">
             <Pill variant="verified">{tCard('verified')}</Pill>
           </span>

--- a/src/components/property/DirectoryCarousel.js
+++ b/src/components/property/DirectoryCarousel.js
@@ -48,9 +48,9 @@ export default function DirectoryCarousel() {
 
   const dragX = useMotionValue(0);
 
-  // Fetch the featured slice. /api/listings already returns verified-tier
-  // → featured → price-ordered rows, so the head of the list is the
-  // "featured" set we want to surface.
+  // Fetch the head of the directory. /api/listings already returns
+  // SuperLandlords first (the single elevated status), so the head of the
+  // list is the elevated set we want to surface in the carousel.
   useEffect(() => {
     let cancelled = false;
     fetch('/api/listings')

--- a/src/lib/landlordProfile.js
+++ b/src/lib/landlordProfile.js
@@ -49,8 +49,11 @@ const LISTINGS_SELECT_FALLBACK = `
   faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
 `;
 
-// A profile is a verified-tier perk. Same predicate the listing detail page and
-// ListingCard use to decide the verified styling, kept in one place here.
+// The "verified half" of SuperLandlord status: a paid verified tier + admin ID
+// approval. getLandlordProfile combines this with the "paying half" (an active
+// subscription, read from is_featured on the landlord's listings) to gate the
+// public profile, which is a SuperLandlord perk. Kept here so the verified
+// predicate lives in one place.
 export function isVerifiedLandlord(landlord) {
   return Boolean(
     landlord &&
@@ -64,11 +67,12 @@ export function isVerifiedLandlord(landlord) {
  * Public landlord-profile fetch for the student-facing
  * /property/[city]/landlords/[landlordId] page.
  *
- * Returns `{ landlord, listings }` for a VERIFIED landlord, or `null` when the
- * landlord doesn't exist or isn't verified (profiles are verified-only — the
- * page calls notFound() on null). Reads through the anon client and selects
- * only public-safe columns. Memoized per-request like getListingForRender so a
- * layout's metadata pass and the page body share one round-trip.
+ * Returns `{ landlord, listings }` for a SuperLandlord (paying AND verified),
+ * or `null` when the landlord doesn't exist or isn't a SuperLandlord (public
+ * profiles are a SuperLandlord perk — the page calls notFound() on null).
+ * Reads through the anon client and selects only public-safe columns. Memoized
+ * per-request like getListingForRender so a layout's metadata pass and the
+ * page body share one round-trip.
  *
  * @param {string} landlordId 4-digit landlord identifier (the LLLL prefix of a listing_id)
  */
@@ -104,6 +108,7 @@ export const getLandlordProfile = cache(async (landlordId) => {
     // Single landlord ⇒ verified_tier_rank is constant, so order is just
     // featured-first then newest (listing_id's per-landlord sequence increases
     // with recency — see the LLLLNNN format in docs/schema.md).
+    let listingsUsedFallback = false;
     let { data: rows, error: listErr } = await supabase
       .from('listings')
       .select(LISTINGS_SELECT)
@@ -112,6 +117,7 @@ export const getLandlordProfile = cache(async (landlordId) => {
       .order('listing_id', { ascending: false });
 
     if (listErr) {
+      listingsUsedFallback = true;
       const fb = await supabase
         .from('listings')
         .select(LISTINGS_SELECT_FALLBACK)
@@ -120,6 +126,17 @@ export const getLandlordProfile = cache(async (landlordId) => {
       rows = fb.data;
       listErr = fb.error;
     }
+
+    // SuperLandlord = verified (gated above) AND currently paying. is_featured
+    // mirrors paying status across all of a landlord's listings (the Stripe
+    // webhook keeps them in lockstep), so any featured listing ⇒ the landlord
+    // is paying. A lapsed landlord (or one with no listings to prove payment)
+    // 404s — the "drop immediately" rule. On the column-less fallback path we
+    // can't read is_featured, so we degrade to the verified-only gate rather
+    // than 404 every profile during a migration window.
+    const isPaying =
+      listingsUsedFallback || (rows || []).some((r) => r.is_featured === true);
+    if (!isPaying) return null;
 
     const listings = (rows || []).map(transformListing);
 

--- a/src/lib/listingFilters.js
+++ b/src/lib/listingFilters.js
@@ -168,12 +168,15 @@ export function applyListingFilters(query, f, { fallback = false, amenityListing
     query = query.lte("min_duration_months", f.minDurationN);
   }
 
-  // Verified only — requires both a paid tier AND admin-approved ID. Skipped on
-  // the fallback path (the verified columns are what triggered the fallback).
+  // SuperLandlords only — requires the verified half (a paid verified tier AND
+  // admin-approved ID) PLUS the paying half (`is_featured` — an active/trialing
+  // subscription). Skipped on the fallback path (the verified columns are what
+  // triggered the fallback).
   if (!fallback && f.verifiedOnly) {
     query = query
       .neq("landlords.verified_tier", "none")
-      .eq("landlords.is_verified", true);
+      .eq("landlords.is_verified", true)
+      .eq("is_featured", true);
   }
 
   // Bills included

--- a/src/lib/listingForRender.js
+++ b/src/lib/listingForRender.js
@@ -4,6 +4,7 @@ import { transformListing } from '@/lib/transformListing';
 
 const LISTING_SELECT = `
   listing_id,
+  is_featured,
   title,
   description,
   photos,

--- a/src/lib/transformListing.js
+++ b/src/lib/transformListing.js
@@ -3,11 +3,23 @@
  * into the flat API response shape defined in docs/api-contracts.md.
  */
 export function transformListing(row) {
+  // The three inputs to SuperLandlord status. SuperLandlord is the single
+  // elevated tier: a landlord who is BOTH currently paying (`is_featured` —
+  // an active/trialing subscription, kept in sync by the Stripe webhook) AND
+  // verified (a paid verified tier + admin ID approval). `is_superlandlord`
+  // is the one flag every public surface keys off — the golden halo, priority
+  // ranking, the "SuperLandlord" pill, and the public landlord profile.
+  const is_featured = row.is_featured ?? false;
+  const verified_tier = row.landlords?.verified_tier ?? 'none';
+  const is_verified = row.landlords?.is_verified ?? false;
+  const is_superlandlord = is_featured && is_verified && verified_tier !== 'none';
+
   return {
     listing_id: row.listing_id,
-    is_featured: row.is_featured ?? false,
-    verified_tier: row.landlords?.verified_tier ?? 'none',
-    is_verified: row.landlords?.is_verified ?? false,
+    is_featured,
+    verified_tier,
+    is_verified,
+    is_superlandlord,
     title: row.title ?? null,
     address: row.location?.address ?? null,
     neighborhood: row.location?.neighborhood ?? null,

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -64,7 +64,7 @@
     "noResultsHint": "Try adjusting your filters.",
     "loadingMap": "Loading map…",
     "to": "to",
-    "verifiedOnly": "Verified only"
+    "verifiedOnly": "SuperLandlords only"
   },
   "listing": {
     "backToResults": "Back to results",
@@ -88,8 +88,8 @@
     "listingNotFound": "Listing not found",
     "listingNotFoundDesc": "The listing you're looking for may have been removed or doesn't exist.",
     "backToSearchBtn": "Back to search",
-    "verified": "Verified",
-    "verifiedPro": "Verified",
+    "verified": "SuperLandlord",
+    "verifiedPro": "SuperLandlord",
     "minutes": "{n} min",
     "somethingWentWrong": "Something went wrong",
     "failedToLoad": "Failed to load listing"
@@ -122,8 +122,8 @@
   },
   "listingCard": {
     "featured": "Featured",
-    "verified": "Verified",
-    "verifiedPro": "Verified",
+    "verified": "SuperLandlord",
+    "verifiedPro": "SuperLandlord",
     "priceOnRequest": "Price on request",
     "perMonth": "/mo",
     "estimated": "est ",
@@ -215,6 +215,7 @@
       "delete": "Delete",
       "deleting": "Deleting…",
       "featured": "Featured",
+      "superLandlord": "SuperLandlord",
       "unfeatured": "Set as featured",
       "noListings": "No listings yet.",
       "addFirst": "Add your first listing",
@@ -552,8 +553,8 @@
       "minDurationSemesterMonths": "5 mo",
       "minDurationAcademicName": "Academic year",
       "minDurationAcademicMonths": "9 mo",
-      "verified": "Verified",
-      "verifiedLandlordsOnly": "Verified landlords only",
+      "verified": "SuperLandlord",
+      "verifiedLandlordsOnly": "SuperLandlords only",
       "billsIncluded": "Bills included",
       "floorNotSpecified": "Floor not specified",
       "dealbreakers": "Your dealbreakers",
@@ -564,7 +565,7 @@
     },
     "listing": {
       "back": "Back to results",
-      "verified": "Verified",
+      "verified": "SuperLandlord",
       "listedBy": "Listed by",
       "streetAddressA11y": "Street address",
       "rentGreek": "Ενοίκιο",
@@ -597,12 +598,12 @@
     },
     "landlordProfile": {
       "back": "Back to listings",
-      "verified": "Verified landlord",
+      "verified": "SuperLandlord",
       "memberSince": "Member since {date}",
       "propertyCount": "{count, plural, =0 {No properties listed} one {# property} other {# properties}}",
       "emptyState": "This landlord has no listings at the moment.",
-      "metaTitle": "{name} — Verified landlord",
-      "metaDescription": "Browse all student housing listed by {name}, a verified landlord on StudentX Thessaloniki."
+      "metaTitle": "{name} — SuperLandlord",
+      "metaDescription": "Browse all student housing listed by {name}, a SuperLandlord on StudentX Thessaloniki."
     },
     "gallery": {
       "openLightbox": "Open photo gallery",


### PR DESCRIPTION
## What

Merges the two previously-separate concepts — **featured** (paying; ranking-only) and **verified** (paid verified tier + admin ID approval; badge-only) — into a single elevated status: **SuperLandlord**.

A landlord is a **SuperLandlord** iff they fulfil **all** criteria of both:

```
is_superlandlord = is_featured            // active/trialing subscription (paying)
                && is_verified            // admin approved their ID
                && verified_tier !== 'none' // bought a verified tier
```

SuperLandlords get: the **golden halo** on all their listings, **priority ranking**, and a **"SuperLandlord"** badge on the property pill + their public landlord profile.

> Heads-up for context: the public halo/badge/profile were *already* driven by `verified` (not `featured`) — `featured` only fed ranking + internal pills. So this mostly **adds the "currently paying" requirement** to that badge, renames it, and unifies ranking. Net effect: the badge is slightly *more* exclusive than before.

## Decisions (confirmed with product)

- **Ranking → SuperLandlords only.** Paying-but-unverified landlords (and lapsed-verified ones) no longer get any ranking boost. The old `verified_pro > verified` gradient is gone — ranking is binary now.
- **Lapsed payment → drop immediately.** SuperLandlord requires an active/trialing sub. On `past_due` the paying flag already flips off, so the status drops at once; the public profile 404s until they resubscribe.

## Changes

| Area | File | Change |
|---|---|---|
| Predicate | `lib/transformListing.js` | exposes `is_superlandlord` (one source of truth) |
| Ranking | `api/listings/route.js` | SuperLandlord-first → metric → newest (JS sort; dropped `verified_tier_rank`/`is_featured` DB ordering) |
| Card | `components/ListingCard.js` | halo + badge + landlord chip gate on `is_superlandlord` |
| Detail | `…/listing/[id]/page.js` | seal + badge + "listed by" gate on `is_superlandlord` |
| Profile | `lib/landlordProfile.js` | gate now also requires paying (derived from listings' `is_featured`) |
| Filter | `lib/listingFilters.js` | "Verified only" → "SuperLandlords only" (adds `is_featured`) |
| Selects | `lib/listingForRender.js`, `api/listings/[id]/route.js` | add `is_featured` (predicate needs it) |
| Internal pills | landlord `dashboard` + `listings` pages | gate on full predicate so a subscribed-but-unapproved landlord isn't shown a premium badge they don't have publicly |
| Copy | `messages/en.json` | public "Verified"/"Verified only" strings → "SuperLandlord"/"SuperLandlords only" |
| Tests | `__tests__/lib/{transformListing,listingFilters}.test.js` | cover the predicate + the tightened filter |

**No DB migration** — `is_superlandlord` is derived in code from existing columns.

## Verification

- `npm run lint` ✓ (only the pre-existing `cf/worker-entry.mjs` warning) · `npm run test` ✓ 226/226 · `npm run build` ✓
- Browser (dev server, real data): results page renders, the one paying+verified landlord shows the **SUPERLANDLORD** pill + golden halo + profile chip and is **ranked first**; all other cards are plain. No console errors.

## Deliberately out of scope (follow-ups)

1. **Admin "Featured" KPI** (`lib/metrics/*`, admin metrics page) still counts `is_featured` — a valid "paying landlords" metric, but it should probably be renamed/recomputed to count actual SuperLandlords.
2. **Landlord billing/verification marketing copy** still says "Verified" in places (e.g. `billing.benefitBadge` "Verified badge on all listings", `getVerified.tierBadge`, dashboard `verifiedTitle`) — a pre-existing partial rename (the tier is already sold as "SuperLandlord"). Worth reconciling for full consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)