### PR TITLE
fix(metrics): align admin "Featured" KPI with merged SuperLandlord status

### DIFF
--- a/__tests__/lib/metricsCompute.test.js
+++ b/__tests__/lib/metricsCompute.test.js
@@ -15,7 +15,7 @@ const supabaseBase = {
   freeLandlords: 40,
   byPlan: { basic: 6, pro: 4 },
   totalListings: 120,
-  featuredListings: 8,
+  superLandlordListings: 8,
   inquiriesThisMonth: 60,
   inquiriesLastMonth: 50,
 };
@@ -35,7 +35,7 @@ describe('computeMetrics', () => {
     const out = computeMetrics(stripeBase, supabaseBase);
     expect(out.byPlan).toEqual({ basic: 6, pro: 4 });
     expect(out.totalListings).toBe(120);
-    expect(out.featuredListings).toBe(8);
+    expect(out.superLandlordListings).toBe(8);
     expect(out.trialingCount).toBe(2);
     expect(out.cancelledThisMonth).toBe(1);
     expect(out.cac).toBeNull();

--- a/src/app/[locale]/admin/metrics/page.js
+++ b/src/app/[locale]/admin/metrics/page.js
@@ -110,7 +110,7 @@ export default function AdminMetricsPage() {
           />
           <KpiCard label="Cancelled (mo)" value={metrics.cancelledThisMonth} />
           <KpiCard label="Total Listings" value={metrics.totalListings} />
-          <KpiCard label="Featured" value={metrics.featuredListings} />
+          <KpiCard label="SuperLandlords" value={metrics.superLandlordListings} />
         </div>
       </section>
 

--- a/src/lib/metrics/compute.js
+++ b/src/lib/metrics/compute.js
@@ -3,7 +3,7 @@
  */
 export function computeMetrics(stripeMetrics, supabaseMetrics) {
   const { mrrCents, arrCents, activeSubscriptionCount, trialingCount, cancelledThisMonthCount } = stripeMetrics;
-  const { totalLandlords, paidLandlords, freeLandlords, byPlan, totalListings, featuredListings, inquiriesThisMonth, inquiriesLastMonth } = supabaseMetrics;
+  const { totalLandlords, paidLandlords, freeLandlords, byPlan, totalListings, superLandlordListings, inquiriesThisMonth, inquiriesLastMonth } = supabaseMetrics;
 
   // Free-to-paid conversion rate
   const conversionRate = totalLandlords > 0
@@ -43,7 +43,7 @@ export function computeMetrics(stripeMetrics, supabaseMetrics) {
     cancelledThisMonth: cancelledThisMonthCount,
     byPlan,
     totalListings,
-    featuredListings,
+    superLandlordListings,
     inquiriesThisMonth,
     inquiriesLastMonth,
     inquiryTrend,

--- a/src/lib/metrics/supabase.js
+++ b/src/lib/metrics/supabase.js
@@ -41,11 +41,18 @@ export async function getSupabaseMetrics() {
     .from('listings')
     .select('listing_id', { count: 'exact', head: true });
 
-  // Featured listings
-  const { count: featuredListings } = await supabase
+  // SuperLandlord listings — the single public elevated status (see
+  // transformListing.js: is_superlandlord = is_featured && is_verified &&
+  // verified_tier !== 'none'). A listing counts only when it is paying
+  // (is_featured on the listing) AND its landlord is verified (is_verified +
+  // a paid verified_tier). `landlords!inner` makes the embedded landlord
+  // filters restrict the listing count rather than just nulling the embed.
+  const { count: superLandlordListings } = await supabase
     .from('listings')
-    .select('listing_id', { count: 'exact', head: true })
-    .eq('is_featured', true);
+    .select('listing_id, landlords!inner(verified_tier,is_verified)', { count: 'exact', head: true })
+    .eq('is_featured', true)
+    .eq('landlords.is_verified', true)
+    .neq('landlords.verified_tier', 'none');
 
   // Inquiries this month
   const now = new Date();
@@ -70,7 +77,7 @@ export async function getSupabaseMetrics() {
     freeLandlords: (totalLandlords || 0) - (paidLandlords || 0),
     byPlan,
     totalListings: totalListings || 0,
-    featuredListings: featuredListings || 0,
+    superLandlordListings: superLandlordListings || 0,
     inquiriesThisMonth: inquiriesThisMonth || 0,
     inquiriesLastMonth: inquiriesLastMonth || 0,
   };


### PR DESCRIPTION
## Why

[#227](https://github.com/MichaelChar/StudentX/pull/227) merged the separate "featured" (paying) and "verified" (paid tier + admin ID approval) concepts into one public **SuperLandlord** status, derived in `transformListing.js`:

```
is_superlandlord = is_featured && is_verified && verified_tier !== 'none'
```

The admin metrics dashboard still showed a **"Featured"** KPI that counted only `listings.is_featured = true` (i.e. *paying* landlords), which no longer matches what the public site shows. An admin reading "Featured" would over-count vs. the actual SuperLandlord population (paying landlords who haven't yet passed ID verification are included).

## What

Recompute the count to the full public predicate and relabel the card **"SuperLandlords"** (chose recompute over a plain "Paying" relabel so the admin number tracks the live public status):

- **`src/lib/metrics/supabase.js`** — count listings that are `is_featured = true` **AND** whose landlord has `is_verified = true` **AND** `verified_tier != 'none'`, via a `landlords!inner` join so the embedded filters restrict the listing count rather than just nulling the embed. (Same join shape the deployed `/api/listings` route already uses.) NULL handling mirrors the code predicate: `is_verified` null and `verified_tier` null/`'none'` are both excluded.
- **`src/lib/metrics/compute.js`** — pass through `superLandlordListings` (renamed from `featuredListings`).
- **`src/app/[locale]/admin/metrics/page.js`** — KPI card label `Featured` → `SuperLandlords`.
- **`__tests__/lib/metricsCompute.test.js`** — rename fixture field + assertion.

Counts **listings** (not landlords) to stay parallel with the adjacent **"Total Listings"** card.

## Notes

- No DB migration — the predicate is computed from existing columns (`listings.is_featured`, `landlords.is_verified`, `landlords.verified_tier`), the same ones `transformListing` reads.
- Self-contained follow-up to #227 (already merged to `main`); touches no files #227 touched, so it merges independently.

## Verification

- `npm run test` → 226/226 pass (incl. the renamed metric assertion).
- `npm run lint` → 0 errors (the lone warning is pre-existing in `cf/worker-entry.mjs`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)