### PR TITLE
fix(i18n): rename remaining landlord badge copy to SuperLandlord

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -244,11 +244,11 @@
     },
     "getVerified": {
       "title": "Get Verified",
-      "description": "Verification is central to the safety of the StudentX community. It lets students know that you are a genuine account holder. The verified badge appears publicly over your property, and also gives you priority search placement.",
+      "description": "Verification is central to the safety of the StudentX community. It lets students know that you are a genuine account holder. The SuperLandlord badge appears publicly over your property, and also gives you priority search placement.",
       "chooseTier": "Choose this plan",
       "stripeNote": "Secure checkout via Stripe. Cancel anytime.",
       "backToDashboard": "Back to dashboard",
-      "tierBadge": "Verified"
+      "tierBadge": "SuperLandlord"
     },
     "listingForm": {
       "locationSection": "Location",
@@ -354,7 +354,7 @@
       "boostListings": "Boost your listings",
       "verifiedDescription": "Verified landlords get a badge, search boost, and more inquiries.",
       "perYear": "/year",
-      "benefitBadge": "Verified badge on all listings",
+      "benefitBadge": "SuperLandlord badge on all listings",
       "benefitSearchBoost": "Higher ranking in search results",
       "benefitPriorityPlacement": "Priority placement in results",
       "benefitAnalytics": "Advanced analytics dashboard",
@@ -692,7 +692,7 @@
         "unverifiedTitle": "Get verified",
         "unverifiedBody": "Show students you're a real landlord — seal, priority, more inquiries.",
         "subscribedAwaitingIdTitle": "Welcome to SuperLandlord",
-        "subscribedAwaitingIdBody": "One last step — upload an ID to activate the Verified badge on your listings.",
+        "subscribedAwaitingIdBody": "One last step — upload an ID to activate the SuperLandlord badge on your listings.",
         "submitIdCta": "Upload ID",
         "idApprovedAwaitingSubscriptionTitle": "Your ID is approved",
         "idApprovedAwaitingSubscriptionBody": "Last step — subscribe to become a publicly verified landlord.",


### PR DESCRIPTION
## What

Follow-up to #227 (which renamed the public badge to **SuperLandlord**). The landlord-facing billing / verification funnel still labelled the badge itself "Verified" in a few `src/messages/en.json` strings. This reconciles **only the explicit badge-label references**:

| Key | Before | After |
|---|---|---|
| `landlord.billing.benefitBadge` | "Verified badge on all listings" | "SuperLandlord badge on all listings" |
| `landlord.getVerified.tierBadge` | "Verified" | "SuperLandlord" |
| `landlord.getVerified.description` | "…the verified badge appears publicly…" | "…the SuperLandlord badge appears publicly…" |
| `propylaea.landlord.dashboard.subscribedAwaitingIdBody` | "…activate the Verified badge…" | "…activate the SuperLandlord badge…" |

`benefitBadge` + `tierBadge` render in `BillingSection.js` and the `/get-verified` pricing cards; `subscribedAwaitingIdBody` is the dashboard "subscribed, awaiting ID" widget state.

## Deliberately left unchanged

The ID-**verification process** vocabulary stays — it describes a real action (uploading/approving an ID), not the badge:
- "Verification pending" / "We're reviewing your documents."
- "Your ID is approved" · "Upload ID" · nav + widget header "Verification"

The status / acquisition-CTA strings were also left as-is (scope = badge labels only), treated as the verification step rather than the public badge:
- `verifiedTitle` "You're verified", `getVerified.title` "Get Verified", `unverifiedTitle`/`quickVerify` "Get verified", `idApprovedAwaitingSubscriptionBody` "…become a publicly verified landlord."

## Verification
- `npm run test` → **226 passing**
- `npm run build` → clean (no missing-message regressions)
- No referenced message key removed, so the `missing-message` synthetic canary is unaffected.

## Noticed but out of scope (not in `en.json`)
- `src/app/[locale]/property/[city]/landlord/get-verified/page.js` has **hardcoded** `{ label: 'Verified badge', value: 'Yes' }` feature rows (~lines 30, 46) — same badge reference, but in JS, not the message catalog.
- Dead keys left untouched: `landlord.billing.verifiedDescription` (unused) and `landlord.dashboard.getVerified`/`getVerifiedDesc` (unused; the latter still says "free Verified badge", which is doubly stale since the badge is paid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
