### PR TITLE
fix(i18n): rename hardcoded "Verified badge" label in get-verified pricing table

### DIFF
--- a/src/app/[locale]/property/[city]/landlord/get-verified/page.js
+++ b/src/app/[locale]/property/[city]/landlord/get-verified/page.js
@@ -27,7 +27,7 @@ const PAID_TIERS = [
     features: [
       { label: 'Listing cap', value: 'Up to 5' },
       { label: 'Photos per listing', value: 'Unlimited' },
-      { label: 'Verified badge', value: 'Yes' },
+      { label: 'SuperLandlord badge', value: 'Yes' },
       { label: 'Priority placement', value: 'Yes' },
       { label: 'Analytics', value: 'Full' },
       { label: 'Support', value: 'Email' },
@@ -43,7 +43,7 @@ const PAID_TIERS = [
     features: [
       { label: 'Listing cap', value: 'Up to 12 (+€5/mo overage)' },
       { label: 'Photos per listing', value: 'Unlimited' },
-      { label: 'Verified badge', value: 'Yes' },
+      { label: 'SuperLandlord badge', value: 'Yes' },
       { label: 'Priority placement', value: 'Yes' },
       { label: 'Analytics', value: 'Full' },
       { label: 'Support', value: 'Priority' },


### PR DESCRIPTION
## What

Follow-up to #227 / #229 (public badge renamed to **SuperLandlord**). The `/get-verified` pricing comparison table had a hardcoded `{ label: 'Verified badge', value: 'Yes' }` feature row — outside the message catalog — on **both** the SuperLandlord and SuperLandlord Heavy tiers. Renamed to **"SuperLandlord badge"** to match the public badge.

```diff
-      { label: 'Verified badge', value: 'Yes' },
+      { label: 'SuperLandlord badge', value: 'Yes' },
```
(`src/app/[locale]/property/[city]/landlord/get-verified/page.js`, both tiers)

Scope is the badge label only — no ID-verification *process* wording changed.

## ⚠️ Not the only occurrence — rest deliberately deferred

The task assumed this was the lone hardcoded `Verified badge`. It isn't — `grep -rn "Verified badge" src` finds the same public-badge noun in 3 more files. Per the owner's decision, those are **left for a separate change** (this PR stays single-file):

| File | Lines | Context |
|---|---|---|
| `onboarding/page.js` | 21, 39, 57 | pricing comparison table (same pattern) |
| `verification/page.js` | 91, 111, 112, 183 | prose ("display the Verified badge…") |
| `templates/email/subscriptionWelcome.js` | 42 (+ comment 3) | landlord welcome email |

All refer to the public badge, not the ID-verification step (the `"Verification"` eyebrow, `"Get verified"` title, "Upload ID", "Your ID is approved", and review copy on those surfaces stay as-is). A follow-up task has been opened.

`landlord.dashboard.getVerifiedDesc` in `en.json` also still contains "Verified badge", but it's a **dead/unused** key (and predates #229's deliberate decision to leave it).

## Verification
- `npm run test` → **226 passing**
- `npm run build` → clean
- Static string literal in a `const` array; no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
