### PR TITLE
fix(i18n): tidy verification-page badge copy

### DIFF
--- a/src/app/[locale]/property/[city]/landlord/verification/page.js
+++ b/src/app/[locale]/property/[city]/landlord/verification/page.js
@@ -87,10 +87,6 @@ export default function LandlordVerificationPage() {
   return (
     <LandlordShell eyebrow="Verification" title="Get verified">
       <div className="max-w-lg">
-        <p className="text-night/60 text-sm mb-8">
-          Upload a government-issued ID to receive a free SuperLandlord badge shown on all your listings.
-        </p>
-
         {loading ? (
           <div className="animate-pulse space-y-4">
             <div className="h-8 w-48 bg-parchment rounded-sm" />
@@ -109,7 +105,7 @@ export default function LandlordVerificationPage() {
               <p className="text-sm text-night/70">
                 {verifiedTier && verifiedTier !== 'none'
                   ? 'Your listings display the SuperLandlord badge automatically.'
-                  : 'Subscribe to SuperLandlord to display the SuperLandlord badge on your listings.'}
+                  : 'Subscribe to SuperLandlord to display the badge on your listings.'}
               </p>
             </div>
           </Card>
@@ -180,7 +176,7 @@ function UploadForm({ file, setFile, fileInputRef, submitting, submitError, subm
           <p className="text-sm text-night/70">
             {subscribed
               ? <>We&apos;ll review your ID within 1–2 business days and notify you when your badge is activated.</>
-              : <>We&apos;ll review your ID within 1–2 business days. A SuperLandlord subscription is also required for the SuperLandlord badge to appear publicly on your listings — you can subscribe at any time, before or after your ID is approved.</>}
+              : <>We&apos;ll review your ID within 1–2 business days. A SuperLandlord subscription is also required for the badge to appear publicly on your listings — you can subscribe at any time, before or after your ID is approved.</>}
           </p>
         </div>
       </Card>


### PR DESCRIPTION
## What

Follow-up to #231, on the landlord verification page (`verification/page.js`):

1. **Deleted the intro line** — "Upload a government-issued ID to receive a **free** SuperLandlord badge shown on all your listings." The badge requires a paid subscription, so "free" overpromised. The "Get verified" title now sits directly above the upload form / status cards.
2. **Deduped two sentences** that read "SuperLandlord … SuperLandlord badge":
   - ID-approved, not-subscribed card → "Subscribe to SuperLandlord to display **the badge** on your listings."
   - Document-submitted, not-subscribed card → "A SuperLandlord subscription is also required for **the badge** to appear publicly…"

Each sentence already names SuperLandlord, so "the badge" stays unambiguous and the "you need a subscription" nudge is preserved in both states.

## Untouched

All ID-verification *process* wording — eyebrow "Verification", title "Get verified", "Your ID is approved", "Upload ID", "We'll review your ID within 1–2 business days" — plus the single legit "SuperLandlord badge" mention in the subscribed state ("Your listings display the SuperLandlord badge automatically.").

## Verification
- `npm run test` → 226 passing
- `npm run build` → clean
- Rendered before/after previewed and approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
