### PR TITLE
fix(listings): auto-feature new listings during trial, not just active

### DIFF
--- a/src/app/api/landlord/listings/route.js
+++ b/src/app/api/landlord/listings/route.js
@@ -261,14 +261,17 @@ export async function POST(request) {
   }
   const listingId = landlordId + String(nextSeq).padStart(3, '0');
 
-  // Auto-feature listings for landlords with an active subscription
-  const { data: activeSub } = await supabase
+  // Auto-feature listings for landlords with a paying subscription. Must match
+  // the webhook's shouldFeature predicate (handleSubscriptionUpdated treats
+  // 'active' OR 'trialing' as paying) — otherwise a listing added mid-trial is
+  // left un-featured while the landlord's other listings carry the badge.
+  const { data: payingSub } = await supabase
     .from('subscriptions')
     .select('subscription_id')
     .eq('landlord_id', landlordId)
-    .eq('status', 'active')
+    .in('status', ['active', 'trialing'])
     .limit(1);
-  const isFeatured = activeSub && activeSub.length > 0;
+  const isFeatured = payingSub && payingSub.length > 0;
 
   // Insert listing row
   const { data: listing, error: listingError } = await authedSupabase


### PR DESCRIPTION
## What

Minimal fix ("C") for the SuperLandlord badge drift. The create-listing route auto-featured a new listing only when the landlord's subscription `status = 'active'`, but the Stripe webhook (`handleSubscriptionUpdated`) treats `active` **or** `trialing` as paying. A landlord who added a listing during a trial got it created with `is_featured = false` while their other listings carried the badge.

```diff
- .eq('status', 'active')
+ .in('status', ['active', 'trialing'])
```

## Why this suffices for the common case

The normal forward flow now works in both orderings:
- **Subscribe → add listings:** create-route sees active/trialing → features them.
- **Add listings → subscribe:** the checkout webhook features all existing listings.

The residual gap — a genuinely dropped/delayed Stripe webhook leaving `subscriptions.status` stale — is what the deeper fix targets: making "paying" a single **landlord-level** source of truth so the per-listing `is_featured` snapshot can't drift. Tracked as a follow-up.

## Data

The only previously-drifted row (`0106002`) was corrected by hand earlier; the blast-radius query found no other affected landlords, so no backfill migration is included.

## Verification
- `npm run test` → 226 passing
- `npm run build` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
