### PR TITLE
feat(pending-listings): consent-gated pre-population pipeline

### DIFF
--- a/__tests__/lib/pendingIngest.test.js
+++ b/__tests__/lib/pendingIngest.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isBlockedResponse,
+  preprocessHtml,
+  fetchListingHtml,
+  extractListingFields,
+  buildPendingListing,
+} from '@/lib/pendingIngest';
+
+const LONG_BODY = '<p>Sunny studio in Ano Poli near AUTH campus. </p>'.repeat(120); // > 2KB
+
+function fakeImageResponse() {
+  return { ok: true, headers: { get: () => 'image/jpeg' }, arrayBuffer: async () => new ArrayBuffer(16) };
+}
+
+// One mock standing in for fetch(): image URLs return bytes, everything else
+// returns the given html with the given status.
+function makeFetch({ html = LONG_BODY, status = 200 } = {}) {
+  return vi.fn(async (u) => {
+    if (/\.(jpe?g|png|webp)/i.test(u) || u.includes('/photo')) return fakeImageResponse();
+    return { ok: status < 400, status, url: u, text: async () => html };
+  });
+}
+
+const fakeSupabase = {
+  storage: {
+    from: () => ({
+      upload: async () => ({ error: null }),
+      getPublicUrl: (p) => ({ data: { publicUrl: `https://cdn.test/${p}` } }),
+    }),
+  },
+};
+
+describe('isBlockedResponse', () => {
+  it('blocks on error statuses and short/challenge bodies', () => {
+    expect(isBlockedResponse(403, LONG_BODY)).toBe(true);
+    expect(isBlockedResponse(429, LONG_BODY)).toBe(true);
+    expect(isBlockedResponse(503, LONG_BODY)).toBe(true);
+    expect(isBlockedResponse(200, 'tiny')).toBe(true);
+    expect(isBlockedResponse(200, 'Just a moment...'.padEnd(3000, ' '))).toBe(true);
+  });
+  it('passes a normal long body', () => {
+    expect(isBlockedResponse(200, LONG_BODY)).toBe(false);
+  });
+});
+
+describe('preprocessHtml', () => {
+  it('strips script/style and keeps visible text, truncating to budget', () => {
+    const out = preprocessHtml('<script>var secret=1</script><style>.x{}</style><p>visible text</p>');
+    expect(out).toContain('visible text');
+    expect(out).not.toContain('secret');
+    expect(out).not.toContain('.x{}');
+  });
+  it('does not strip <head> when removing <header>', () => {
+    const out = preprocessHtml('<head><meta content="keepme"></head><header>chrome</header><p>body</p>');
+    expect(out).toContain('keepme');
+    expect(out).not.toContain('chrome');
+  });
+});
+
+describe('fetchListingHtml', () => {
+  it('returns ok for a healthy page', async () => {
+    const r = await fetchListingHtml('https://x.gr/listing/1', makeFetch());
+    expect(r.ok).toBe(true);
+    expect(r.html).toContain('Ano Poli');
+  });
+  it('marks 403 as blocked', async () => {
+    const r = await fetchListingHtml('https://x.gr/listing/1', makeFetch({ status: 403 }));
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('blocked');
+  });
+  it('never throws on network failure', async () => {
+    const r = await fetchListingHtml('https://x.gr/1', vi.fn(async () => { throw new Error('boom'); }));
+    expect(r).toEqual({ ok: false, reason: 'fetch_failed' });
+  });
+});
+
+describe('extractListingFields', () => {
+  it('parses the model response', async () => {
+    const ai = { run: vi.fn(async () => ({ response: '{"address":"Egnatia 1","property_type":"studio"}' })) };
+    const out = await extractListingFields(ai, 'html');
+    expect(out).toEqual({ address: 'Egnatia 1', property_type: 'studio' });
+    expect(ai.run).toHaveBeenCalledOnce();
+  });
+});
+
+describe('buildPendingListing', () => {
+  const goodAi = {
+    run: vi.fn(async () => ({
+      response: JSON.stringify({
+        address: 'Egnatia 100',
+        neighborhood: 'Kentro',
+        beds: 1,
+        baths: 1,
+        sqm: 45,
+        price_eur_month: 480,
+        property_type: '1-bed',
+        description: 'Nice flat',
+        photo_urls: ['/photos/a.jpg', 'https://cdn/b.png'],
+        contact_phone: '+30 690',
+        contact_email: null,
+      }),
+    })),
+  };
+
+  it('returns a populated pending row + uploaded photos on success', async () => {
+    const row = await buildPendingListing({
+      url: 'https://x.gr/listing/1',
+      ai: goodAi,
+      supabase: fakeSupabase,
+      id: 'pli_1',
+      fetchImpl: makeFetch(),
+    });
+    expect(row.status).toBe('pending');
+    expect(row.price_eur_month).toBe(480);
+    expect(row.property_type).toBe('1-bed');
+    expect(row.photos_json).toHaveLength(2);
+    expect(row.photos_json[0].url).toContain('https://cdn.test/pending/pli_1/');
+  });
+
+  it('marks needs_manual_entry when the page is blocked', async () => {
+    const row = await buildPendingListing({
+      url: 'https://x.gr/1',
+      ai: goodAi,
+      supabase: fakeSupabase,
+      id: 'pli_2',
+      fetchImpl: makeFetch({ status: 403 }),
+    });
+    expect(row.status).toBe('needs_manual_entry');
+    expect(row.photos_json).toEqual([]);
+  });
+
+  it('marks needs_manual_entry when the model returns junk', async () => {
+    const badAi = { run: vi.fn(async () => ({ response: 'I could not find anything useful.' })) };
+    const row = await buildPendingListing({
+      url: 'https://x.gr/listing/1',
+      ai: badAi,
+      supabase: fakeSupabase,
+      id: 'pli_3',
+      fetchImpl: makeFetch(),
+    });
+    expect(row.status).toBe('needs_manual_entry');
+  });
+
+  it('marks error when the AI binding throws', async () => {
+    const throwingAi = { run: vi.fn(async () => { throw new Error('AI unavailable'); }) };
+    const row = await buildPendingListing({
+      url: 'https://x.gr/listing/1',
+      ai: throwingAi,
+      supabase: fakeSupabase,
+      id: 'pli_4',
+      fetchImpl: makeFetch(),
+    });
+    expect(row.status).toBe('error');
+  });
+});

--- a/__tests__/lib/pendingMappers.test.js
+++ b/__tests__/lib/pendingMappers.test.js
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import {
+  propertyEnumToTypeName,
+  typeNameToEnum,
+  bedsFromTypeName,
+  nextLandlordId,
+  nextListingId,
+  parseExtractionJson,
+  resolvePhotoUrl,
+  photoExtFromUrl,
+  sourceTagFromUrl,
+  toIntOrNull,
+} from '@/lib/pendingMappers';
+
+describe('property type mapping', () => {
+  it('maps enum -> existing public type name, degrading 3-bed and other', () => {
+    expect(propertyEnumToTypeName('studio')).toBe('Studio');
+    expect(propertyEnumToTypeName('1-bed')).toBe('1-Bedroom');
+    expect(propertyEnumToTypeName('2-bed')).toBe('2-Bedroom');
+    expect(propertyEnumToTypeName('3-bed')).toBe('2-Bedroom'); // no 3-bedroom type exists
+    expect(propertyEnumToTypeName('room')).toBe('Room in shared apartment');
+    expect(propertyEnumToTypeName('other')).toBe('Studio'); // fallback
+    expect(propertyEnumToTypeName('garbage')).toBe('Studio');
+  });
+
+  it('maps public type name -> enum, including the (x2) variant', () => {
+    expect(typeNameToEnum('Studio')).toBe('studio');
+    expect(typeNameToEnum('2-Bedroom (x2)')).toBe('2-bed');
+    expect(typeNameToEnum('Room in shared apartment')).toBe('room');
+    expect(typeNameToEnum('Something else')).toBe('other');
+  });
+
+  it('derives a best-effort bed count from a type name', () => {
+    expect(bedsFromTypeName('Studio')).toBe(0);
+    expect(bedsFromTypeName('2-Bedroom (x2)')).toBe(2);
+    expect(bedsFromTypeName('mystery')).toBeNull();
+  });
+});
+
+describe('id minting', () => {
+  it('mints the next 4-digit landlord id', () => {
+    expect(nextLandlordId('0106')).toBe('0107');
+    expect(nextLandlordId(null)).toBe('0100');
+    expect(() => nextLandlordId('9999')).toThrow();
+  });
+
+  it('mints the 7-digit listing id with the landlord prefix', () => {
+    expect(nextListingId('0107', null)).toBe('0107001');
+    expect(nextListingId('0107', '0107001')).toBe('0107002');
+    expect(() => nextListingId('0107', '0107999')).toThrow();
+  });
+});
+
+describe('parseExtractionJson', () => {
+  it('parses bare JSON', () => {
+    expect(parseExtractionJson('{"address":"A","beds":2}')).toEqual({ address: 'A', beds: 2 });
+  });
+  it('strips ```json fences', () => {
+    expect(parseExtractionJson('```json\n{"a":1}\n```')).toEqual({ a: 1 });
+  });
+  it('recovers JSON wrapped in prose', () => {
+    expect(parseExtractionJson('Here you go: {"a":1} hope that helps')).toEqual({ a: 1 });
+  });
+  it('returns null on unparseable input', () => {
+    expect(parseExtractionJson('not json at all')).toBeNull();
+    expect(parseExtractionJson(null)).toBeNull();
+  });
+});
+
+describe('photo helpers', () => {
+  it('resolves relative urls and rejects junk', () => {
+    expect(resolvePhotoUrl('/img/a.jpg', 'https://x.gr/listing/1')).toBe('https://x.gr/img/a.jpg');
+    expect(resolvePhotoUrl('https://cdn/x.png', 'https://x.gr')).toBe('https://cdn/x.png');
+    expect(resolvePhotoUrl('data:image/png;base64,xx', 'https://x.gr')).toBeNull();
+    expect(resolvePhotoUrl('', 'https://x.gr')).toBeNull();
+  });
+  it('extracts a normalised extension', () => {
+    expect(photoExtFromUrl('https://x/a.JPG')).toBe('jpg');
+    expect(photoExtFromUrl('https://x/a.jpeg')).toBe('jpg');
+    expect(photoExtFromUrl('https://x/a.webp')).toBe('webp');
+    expect(photoExtFromUrl('https://x/image?id=3')).toBe('jpg');
+  });
+});
+
+describe('misc coercion', () => {
+  it('derives a source tag from the hostname', () => {
+    expect(sourceTagFromUrl('https://www.spitogatos.gr/x/1')).toBe('spitogatos.gr');
+    expect(sourceTagFromUrl('not a url')).toBe('scraped');
+  });
+  it('coerces number-ish values to a non-negative int or null', () => {
+    expect(toIntOrNull('€480')).toBe(480);
+    expect(toIntOrNull(30)).toBe(30);
+    expect(toIntOrNull('')).toBeNull();
+    expect(toIntOrNull(-5)).toBeNull();
+  });
+});

--- a/__tests__/lib/requireAdmin.test.js
+++ b/__tests__/lib/requireAdmin.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// next/headers is imported at module top in requireAdmin.js (for requireAdmin's
+// cookie read). Mock it so importing the SUT in node is clean; these tests
+// exercise the header-token path (requireAdminApi) which does not touch cookies.
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => ({ get: () => undefined })),
+}));
+
+vi.mock('@/lib/authCookies', () => ({ SB_ACCESS_TOKEN_COOKIE: 'sb-access-token' }));
+
+vi.mock('@/lib/supabaseServer', () => ({
+  extractToken: vi.fn(() => null),
+  getUserFromToken: vi.fn(async () => null),
+  getSupabaseWithToken: vi.fn(),
+}));
+
+const { isAdminEmail, requireAdminApi } = await import('@/lib/requireAdmin');
+const supabaseServer = await import('@/lib/supabaseServer');
+
+beforeEach(() => {
+  process.env.ADMIN_EMAILS = 'michaelcharlesg@icloud.com, Ops@StudentX.uk';
+  vi.mocked(supabaseServer.extractToken).mockReset();
+  vi.mocked(supabaseServer.getUserFromToken).mockReset();
+});
+
+describe('isAdminEmail', () => {
+  it('matches allowlisted emails case-insensitively', () => {
+    expect(isAdminEmail('michaelcharlesg@icloud.com')).toBe(true);
+    expect(isAdminEmail('OPS@studentx.uk')).toBe(true);
+  });
+  it('rejects non-allowlisted, empty, and nullish emails', () => {
+    expect(isAdminEmail('someone@else.com')).toBe(false);
+    expect(isAdminEmail('')).toBe(false);
+    expect(isAdminEmail(null)).toBe(false);
+  });
+  it('rejects everyone when ADMIN_EMAILS is unset (the current prod state)', () => {
+    delete process.env.ADMIN_EMAILS;
+    expect(isAdminEmail('michaelcharlesg@icloud.com')).toBe(false);
+  });
+});
+
+describe('requireAdminApi', () => {
+  it('401s when no bearer token is present', async () => {
+    vi.mocked(supabaseServer.extractToken).mockReturnValue(null);
+    const r = await requireAdminApi(new Request('https://x/admin'));
+    expect(r).toMatchObject({ ok: false, status: 401 });
+  });
+
+  it('401s when the token does not resolve to a user', async () => {
+    vi.mocked(supabaseServer.extractToken).mockReturnValue('tok');
+    vi.mocked(supabaseServer.getUserFromToken).mockResolvedValue(null);
+    const r = await requireAdminApi(new Request('https://x/admin'));
+    expect(r).toMatchObject({ ok: false, status: 401 });
+  });
+
+  it('403s when the user is signed in but not allowlisted', async () => {
+    vi.mocked(supabaseServer.extractToken).mockReturnValue('tok');
+    vi.mocked(supabaseServer.getUserFromToken).mockResolvedValue({ email: 'nope@x.com' });
+    const r = await requireAdminApi(new Request('https://x/admin'));
+    expect(r).toMatchObject({ ok: false, status: 403 });
+  });
+
+  it('passes an allowlisted admin through', async () => {
+    vi.mocked(supabaseServer.extractToken).mockReturnValue('tok');
+    vi.mocked(supabaseServer.getUserFromToken).mockResolvedValue({ email: 'michaelcharlesg@icloud.com' });
+    const r = await requireAdminApi(new Request('https://x/admin'));
+    expect(r).toMatchObject({ ok: true, token: 'tok' });
+    expect(r.user.email).toBe('michaelcharlesg@icloud.com');
+  });
+});

--- a/docs/runbooks/pending-listings-pipeline.md
+++ b/docs/runbooks/pending-listings-pipeline.md
@@ -1,0 +1,88 @@
+# Pending-listings pipeline (consent-gated pre-population)
+
+Ingest housing listings from arbitrary external sites, stage them as **pending
+listings** under **pending landlords**, then send each landlord a magic claim
+link to publish to the public directory. Also used to migrate the existing fake
+seed listings into the same claim flow.
+
+Free to operate: bare `fetch()` + **Cloudflare Workers AI**
+(`@cf/meta/llama-3.1-8b-instruct`) for extraction — no external API keys, no paid
+scraping service. Storage is the existing **Supabase Postgres + Storage** stack
+(not D1/R2 — see migration `059` header for why).
+
+## One-time setup (REQUIRED after merge)
+
+1. **Apply the migration** to prod during PR review (per the CLAUDE.md migration
+   ordering convention), e.g. `mcp__supabase__apply_migration` or `supabase db push`.
+   Adds `pending_landlords`, `pending_listings` (RLS-locked, service-role only)
+   and the public `pending-photos` Storage bucket.
+
+2. **Set the admin allowlist.** Admin access reuses the existing `ADMIN_EMAILS`
+   model — and `ADMIN_EMAILS` is currently **not set anywhere** (not in
+   `.env*`, `wrangler.jsonc`, or as a Worker secret), so today *every* admin
+   route (existing `/admin/metrics`, `/admin/verifications`, and the new ones)
+   returns 403/redirect for everyone. Fix it once:
+
+   ```bash
+   wrangler secret put ADMIN_EMAILS --name studentx
+   # paste: michaelcharlesg@icloud.com
+   ```
+
+3. `SUPABASE_SERVICE_ROLE_KEY` must be set as a Worker secret (it already is in
+   prod; the pipeline uses it for all pending_* reads/writes). No new secret
+   beyond `ADMIN_EMAILS`.
+
+The Workers AI binding (`AI`) is declared in `wrangler.jsonc`; nothing to set.
+
+## Admin surface (`/admin/*`, gated by ADMIN_EMAILS + Supabase session)
+
+- **`/admin/dashboard`** — ingest a single URL or a batch, create pending
+  landlords, assign unassigned listings, edit landlord details, and generate a
+  claim link.
+- **`/admin/migrate-fake-listings`** — the one-time, idempotent fake-listings
+  wizard (below).
+
+Ingest marks a listing `needs_manual_entry` when the page is a bot-challenge /
+403 / 429 / 5xx / suspiciously short, or when the model returns unparseable
+JSON. It never crashes the worker.
+
+> **Workers AI runs only on the Worker.** `getCloudflareContext().env.AI` is
+> unavailable in `next dev` (the ingest routes return 503 there). Verify ingest
+> on `npm run preview` or after deploy.
+
+## Claim flow (`/claim/:token`, public, token-gated)
+
+The landlord opens the link, reviews/edits their listings, and clicks **Publish
+my listings**. Publish moves data into the public star schema: a new `landlords`
+row, and per listing a `rent` + `location` + `listings` row (7-digit id minted
+with the landlord prefix), copying photos into the public `listing-photos`
+bucket. Idempotent — re-clicking is safe. Tokens expire after 30 days.
+
+## Fake-listings migration wizard
+
+`/admin/migrate-fake-listings`:
+
+1. Create up to two pending landlords (or use existing ones).
+2. For each fake listing, choose a pending landlord or **Skip / delete**.
+3. Click **Migrate**. Assigned listings are staged into `pending_listings`
+   (`source_type='migrated_fake'`) and the public listing is hard-deleted;
+   skipped listings are just deleted. Summary: `X migrated, Y skipped, Z errors`.
+
+**Protected owners are never shown and never deletable** — resolved server-side
+by email/name (michaelcharlesg, plus any landlord literally named
+"Superlandlord"). Idempotent via `pending_listings.migrated_from_listing_id`
+(UNIQUE): re-running drops already-migrated rows from the grid.
+
+## Notes / limitations
+
+- `pending-photos` is a **public** bucket (like `listing-photos`); object keys
+  use unguessable pending ids. The sensitive data (addresses/prices/links) lives
+  in the RLS-locked tables, never in object storage. Switch to a private bucket +
+  signed URLs if stricter photo privacy is wanted.
+- Published listings have **no lat/lng** (we do not geocode at publish), so they
+  carry no `faculty_distances` until coordinates are added. They will not appear
+  in commute-time-filtered results until then.
+- The public `property_types` table has no "3-Bedroom" — pending `3-bed`
+  publishes as `2-Bedroom`; `other` publishes as `Studio`.
+- Batch ingest processes in the background via `ctx.waitUntil` (capped at 25
+  URLs/request); refresh the dashboard to see rows resolve.

--- a/src/app/[locale]/admin/NotAuthorized.js
+++ b/src/app/[locale]/admin/NotAuthorized.js
@@ -1,0 +1,19 @@
+// Server component shown when a signed-in user is NOT on the ADMIN_EMAILS
+// allowlist. Distinct from the guest case (which redirects to login) so we never
+// bounce an already-signed-in user into a login loop, and never flash admin
+// chrome before the check.
+export default function NotAuthorized({ email }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-6">
+      <div className="max-w-md text-center">
+        <h1 className="font-display text-2xl font-bold text-night mb-2">Not authorised</h1>
+        <p className="text-night/60">
+          {email ? <strong>{email}</strong> : 'This account'} is signed in but is not on the admin allowlist.
+        </p>
+        <p className="text-night/40 text-sm mt-3">
+          Add the address to the ADMIN_EMAILS Worker secret to grant access.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/dashboard/DashboardClient.js
+++ b/src/app/[locale]/admin/dashboard/DashboardClient.js
@@ -1,0 +1,303 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+
+// All admin mutations re-check the ADMIN_EMAILS allowlist server-side; here we
+// just attach the Supabase session token, exactly like the existing admin pages.
+async function authedFetch(path, options = {}) {
+  const supabase = getSupabaseBrowser();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const headers = { 'Content-Type': 'application/json', ...(options.headers || {}) };
+  if (session?.access_token) headers.Authorization = `Bearer ${session.access_token}`;
+  return fetch(path, { ...options, headers });
+}
+
+const money = (v) => (v == null ? '—' : `€${v}/mo`);
+
+const STATUS_STYLES = {
+  pending: 'bg-gray-100 text-night/60',
+  assigned: 'bg-blue/10 text-blue',
+  needs_manual_entry: 'bg-yellow/30 text-night/70',
+  error: 'bg-red-50 text-red-600',
+  published: 'bg-green-50 text-green-700',
+  claim_sent: 'bg-blue/10 text-blue',
+  claimed: 'bg-green-50 text-green-700',
+  archived: 'bg-gray-100 text-night/40',
+};
+
+function Badge({ status }) {
+  return (
+    <span className={`text-[11px] rounded-full px-2 py-0.5 ${STATUS_STYLES[status] || 'bg-gray-100 text-night/60'}`}>
+      {status}
+    </span>
+  );
+}
+
+function ListingRow({ listing, landlords, onAssign }) {
+  const cover = Array.isArray(listing.photos_json) && listing.photos_json[0]?.url;
+  return (
+    <div className="flex items-center gap-3 py-2 border-t border-gray-100">
+      {cover ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={cover} alt="" className="w-12 h-12 rounded object-cover bg-gray-100" />
+      ) : (
+        <div className="w-12 h-12 rounded bg-gray-100 grid place-items-center text-[10px] text-night/30">no photo</div>
+      )}
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-night truncate">{listing.address || listing.source_url || listing.id}</p>
+        <p className="text-xs text-night/50">
+          {[listing.neighborhood, listing.property_type, money(listing.price_eur_month)].filter(Boolean).join(' · ')}
+        </p>
+      </div>
+      <Badge status={listing.status} />
+      {onAssign && (
+        <select
+          className="text-xs border border-gray-200 rounded px-2 py-1"
+          defaultValue=""
+          onChange={(e) => e.target.value && onAssign(listing.id, e.target.value)}
+        >
+          <option value="">Assign to…</option>
+          {landlords.map((l) => (
+            <option key={l.id} value={l.id}>
+              {l.display_name || l.id}
+            </option>
+          ))}
+        </select>
+      )}
+    </div>
+  );
+}
+
+function LandlordCard({ landlord, listings, onChanged, setMsg }) {
+  const [edit, setEdit] = useState({
+    display_name: landlord.display_name || '',
+    phone: landlord.phone || '',
+    email: landlord.email || '',
+    notes: landlord.notes || '',
+  });
+  const [claimUrl, setClaimUrl] = useState('');
+
+  const save = async () => {
+    const res = await authedFetch(`/api/admin/pending-landlords/${landlord.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(edit),
+    });
+    setMsg(res.ok ? 'Saved.' : 'Save failed.');
+    if (res.ok) onChanged();
+  };
+
+  const generate = async () => {
+    const res = await authedFetch(`/api/admin/pending-landlords/${landlord.id}/generate-claim-link`, { method: 'POST' });
+    const d = await res.json();
+    if (res.ok) {
+      setClaimUrl(d.url);
+      onChanged();
+    } else {
+      setMsg(d.error || 'Could not generate link.');
+    }
+  };
+
+  return (
+    <div className="border border-gray-200 rounded-lg p-4 mb-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="font-display font-semibold text-night">{landlord.display_name || landlord.id}</h3>
+        <Badge status={landlord.status} />
+      </div>
+      <div className="grid grid-cols-2 gap-2 mb-3">
+        {['display_name', 'phone', 'email', 'notes'].map((f) => (
+          <input
+            key={f}
+            className="text-sm border border-gray-200 rounded px-2 py-1"
+            placeholder={f.replace('_', ' ')}
+            value={edit[f]}
+            onChange={(e) => setEdit((s) => ({ ...s, [f]: e.target.value }))}
+          />
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-2 mb-2">
+        <button onClick={save} className="text-xs bg-night text-white rounded px-3 py-1.5">
+          Save
+        </button>
+        <button onClick={generate} className="text-xs bg-blue text-white rounded px-3 py-1.5">
+          Generate claim link
+        </button>
+        {landlord.published_landlord_id && (
+          <span className="text-xs text-green-700 self-center">published as {landlord.published_landlord_id}</span>
+        )}
+      </div>
+      {claimUrl && (
+        <div className="flex items-center gap-2 mb-2">
+          <input readOnly value={claimUrl} className="flex-1 text-xs border border-gray-200 rounded px-2 py-1 bg-gray-50" />
+          <button
+            onClick={() => navigator.clipboard?.writeText(claimUrl)}
+            className="text-xs border border-gray-200 rounded px-2 py-1"
+          >
+            Copy
+          </button>
+        </div>
+      )}
+      <div>
+        {listings.length === 0 ? (
+          <p className="text-xs text-night/40 py-2 border-t border-gray-100">No listings assigned yet.</p>
+        ) : (
+          listings.map((l) => <ListingRow key={l.id} listing={l} landlords={[]} />)
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function DashboardClient({ initialLandlords, initialListings }) {
+  const [landlords, setLandlords] = useState(initialLandlords);
+  const [listings, setListings] = useState(initialListings);
+  const [msg, setMsg] = useState('');
+  const [url, setUrl] = useState('');
+  const [batch, setBatch] = useState('');
+  const [form, setForm] = useState({ display_name: '', phone: '', email: '', notes: '' });
+
+  const refresh = useCallback(async () => {
+    const res = await authedFetch('/api/admin/pending-landlords');
+    if (res.ok) {
+      const d = await res.json();
+      setLandlords(d.landlords);
+      setListings(d.listings);
+    }
+  }, []);
+
+  const byLandlord = useMemo(() => {
+    const map = {};
+    for (const l of listings) {
+      const k = l.pending_landlord_id || '__unassigned__';
+      (map[k] = map[k] || []).push(l);
+    }
+    return map;
+  }, [listings]);
+
+  const ingestSingle = async () => {
+    if (!url.trim()) return;
+    setMsg('Ingesting…');
+    const res = await authedFetch('/api/admin/ingest-listing', { method: 'POST', body: JSON.stringify({ url: url.trim() }) });
+    const d = await res.json();
+    setMsg(res.ok ? `Ingest: ${d.status} (${d.preview?.photos ?? 0} photos)` : `Error: ${d.error}`);
+    setUrl('');
+    refresh();
+  };
+
+  const ingestBatch = async () => {
+    const urls = batch.split(/\s+/).map((s) => s.trim()).filter(Boolean);
+    if (!urls.length) return;
+    setMsg(`Queuing ${urls.length}…`);
+    const res = await authedFetch('/api/admin/ingest-listings-batch', { method: 'POST', body: JSON.stringify({ urls }) });
+    const d = await res.json();
+    setMsg(res.ok ? `Queued ${d.results.length}. Refresh in a moment.` : `Error: ${d.error}`);
+    setBatch('');
+    refresh();
+  };
+
+  const createLandlord = async () => {
+    const res = await authedFetch('/api/admin/pending-landlords', { method: 'POST', body: JSON.stringify(form) });
+    if (res.ok) {
+      setForm({ display_name: '', phone: '', email: '', notes: '' });
+      refresh();
+    } else {
+      setMsg('Could not create landlord.');
+    }
+  };
+
+  const assign = async (listingId, landlordId) => {
+    const res = await authedFetch(`/api/admin/pending-listings/${listingId}/assign`, {
+      method: 'POST',
+      body: JSON.stringify({ pending_landlord_id: landlordId }),
+    });
+    if (res.ok) refresh();
+    else setMsg('Assign failed.');
+  };
+
+  const unassigned = byLandlord.__unassigned__ || [];
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-10">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="font-display text-2xl font-bold text-night">Pending listings</h1>
+        <div className="flex items-center gap-3">
+          <Link href="/admin/migrate-fake-listings" className="text-sm text-blue underline">
+            Migrate fake listings →
+          </Link>
+          <button onClick={refresh} className="text-sm border border-gray-200 rounded px-3 py-1.5">
+            Refresh
+          </button>
+        </div>
+      </div>
+      {msg && <p className="text-sm text-night/70 bg-parchment rounded px-3 py-2 mb-4">{msg}</p>}
+
+      <section className="border border-gray-200 rounded-lg p-4 mb-6">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-night/40 mb-3">Ingest from a URL</h2>
+        <div className="flex gap-2 mb-3">
+          <input
+            className="flex-1 text-sm border border-gray-200 rounded px-3 py-2"
+            placeholder="https://www.spitogatos.gr/…"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+          />
+          <button onClick={ingestSingle} className="text-sm bg-blue text-white rounded px-4 py-2">
+            Ingest
+          </button>
+        </div>
+        <textarea
+          className="w-full text-sm border border-gray-200 rounded px-3 py-2 mb-2"
+          rows={3}
+          placeholder="Batch: one URL per line"
+          value={batch}
+          onChange={(e) => setBatch(e.target.value)}
+        />
+        <button onClick={ingestBatch} className="text-sm border border-gray-200 rounded px-4 py-2">
+          Queue batch
+        </button>
+      </section>
+
+      <section className="border border-gray-200 rounded-lg p-4 mb-6">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-night/40 mb-3">New pending landlord</h2>
+        <div className="grid grid-cols-2 gap-2 mb-3">
+          {['display_name', 'phone', 'email', 'notes'].map((f) => (
+            <input
+              key={f}
+              className="text-sm border border-gray-200 rounded px-2 py-1"
+              placeholder={f.replace('_', ' ')}
+              value={form[f]}
+              onChange={(e) => setForm((s) => ({ ...s, [f]: e.target.value }))}
+            />
+          ))}
+        </div>
+        <button onClick={createLandlord} className="text-sm bg-night text-white rounded px-4 py-2">
+          Create landlord
+        </button>
+      </section>
+
+      {unassigned.length > 0 && (
+        <section className="border border-gray-200 rounded-lg p-4 mb-6">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-night/40 mb-1">Unassigned listings</h2>
+          {unassigned.map((l) => (
+            <ListingRow key={l.id} listing={l} landlords={landlords} onAssign={assign} />
+          ))}
+        </section>
+      )}
+
+      <h2 className="text-xs font-semibold uppercase tracking-wide text-night/40 mb-3">
+        Landlords ({landlords.length})
+      </h2>
+      {landlords.map((l) => (
+        <LandlordCard
+          key={l.id}
+          landlord={l}
+          listings={byLandlord[l.id] || []}
+          onChanged={refresh}
+          setMsg={setMsg}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/dashboard/page.js
+++ b/src/app/[locale]/admin/dashboard/page.js
@@ -1,0 +1,32 @@
+import { redirect } from 'next/navigation';
+import { setRequestLocale } from 'next-intl/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { getSupabaseAsService } from '@/lib/supabaseServer';
+import NotAuthorized from '../NotAuthorized';
+import DashboardClient from './DashboardClient';
+
+export const dynamic = 'force-dynamic';
+
+// GET /admin/dashboard — pending-landlords + pending-listings control surface.
+// Server-gated by requireAdmin(): guests redirect to login; signed-in
+// non-allowlisted users get NotAuthorized (no admin chrome flashes).
+export default async function PendingDashboardPage({ params }) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const admin = await requireAdmin();
+  if (!admin) {
+    redirect(`/property/thessaloniki/landlord/login?next=${encodeURIComponent('/admin/dashboard')}`);
+  }
+  if (admin.kind === 'not-admin') {
+    return <NotAuthorized email={admin.email} />;
+  }
+
+  const supabase = getSupabaseAsService();
+  const [{ data: landlords }, { data: listings }] = await Promise.all([
+    supabase.from('pending_landlords').select('*').order('created_at', { ascending: false }),
+    supabase.from('pending_listings').select('*').order('created_at', { ascending: false }),
+  ]);
+
+  return <DashboardClient initialLandlords={landlords || []} initialListings={listings || []} />;
+}

--- a/src/app/[locale]/admin/migrate-fake-listings/MigrateWizard.js
+++ b/src/app/[locale]/admin/migrate-fake-listings/MigrateWizard.js
@@ -1,0 +1,190 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import Link from 'next/link';
+import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+
+async function authedFetch(path, options = {}) {
+  const supabase = getSupabaseBrowser();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const headers = { 'Content-Type': 'application/json', ...(options.headers || {}) };
+  if (session?.access_token) headers.Authorization = `Bearer ${session.access_token}`;
+  return fetch(path, { ...options, headers });
+}
+
+const money = (v) => (v == null ? '—' : `€${v}/mo`);
+
+// Data is loaded server-side (page.js) and passed in, so there is no
+// fetch-on-mount effect. load() is a manual refresh used only after mutations.
+export default function MigrateWizard({ initialCandidates = [], initialPendingLandlords = [] }) {
+  const [candidates, setCandidates] = useState(initialCandidates);
+  const [pendingLandlords, setPendingLandlords] = useState(initialPendingLandlords);
+  const [selections, setSelections] = useState(() => {
+    const m = {};
+    for (const c of initialCandidates) m[c.listing_id] = ''; // '' = leave untouched (safe default)
+    return m;
+  });
+  const [names, setNames] = useState({ a: '', b: '' });
+  const [summary, setSummary] = useState(null);
+  const [msg, setMsg] = useState('');
+  const [running, setRunning] = useState(false);
+
+  const load = useCallback(async () => {
+    const res = await authedFetch('/api/admin/migrate-fake-listings');
+    if (!res.ok) {
+      setMsg('Could not reload.');
+      return;
+    }
+    const d = await res.json();
+    setCandidates(d.candidates || []);
+    setPendingLandlords(d.pendingLandlords || []);
+    setSelections((prev) => {
+      const next = { ...prev };
+      for (const c of d.candidates || []) if (!(c.listing_id in next)) next[c.listing_id] = '';
+      return next;
+    });
+  }, []);
+
+  const createLandlord = async (slot) => {
+    const display_name = names[slot].trim();
+    if (!display_name) return;
+    const res = await authedFetch('/api/admin/pending-landlords', { method: 'POST', body: JSON.stringify({ display_name }) });
+    if (res.ok) {
+      setNames((s) => ({ ...s, [slot]: '' }));
+      load();
+    } else {
+      setMsg('Could not create landlord.');
+    }
+  };
+
+  const runMigration = async () => {
+    // Only act on listings the operator explicitly chose. Blank rows are left
+    // untouched (NOT skip/delete) so an accidental click never destroys fakes.
+    const assignments = {};
+    for (const c of candidates) {
+      const sel = selections[c.listing_id];
+      if (sel) assignments[c.listing_id] = sel;
+    }
+    if (Object.keys(assignments).length === 0) {
+      setMsg('Choose an action (a landlord, or Skip / delete) for at least one listing first.');
+      return;
+    }
+    setRunning(true);
+    setMsg('Migrating…');
+    const res = await authedFetch('/api/admin/migrate-fake-listings', { method: 'POST', body: JSON.stringify({ assignments }) });
+    const d = await res.json();
+    setRunning(false);
+    if (res.ok) {
+      setSummary(d);
+      setMsg('');
+      load(); // migrated+deleted rows drop out of the candidate set, so re-running is safe
+    } else {
+      setMsg(d.error || 'Migration failed.');
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-10">
+      <div className="flex items-center justify-between mb-2">
+        <h1 className="font-display text-2xl font-bold text-night">Migrate fake listings</h1>
+        <Link href="/admin/dashboard" className="text-sm text-blue underline">
+          ← Dashboard
+        </Link>
+      </div>
+      <p className="text-sm text-night/50 mb-6">
+        Move seed/fake listings into the pending pipeline and remove them from the public directory. Protected owners
+        (michaelcharlesg) are never shown here and can never be deleted. Safe to re-run.
+      </p>
+
+      <section className="border border-gray-200 rounded-lg p-4 mb-6">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-night/40 mb-3">Create pending landlords</h2>
+        <div className="grid sm:grid-cols-2 gap-3">
+          {['a', 'b'].map((slot) => (
+            <div key={slot} className="flex gap-2">
+              <input
+                className="flex-1 text-sm border border-gray-200 rounded px-3 py-2"
+                placeholder={`Pending landlord ${slot === 'a' ? '1' : '2'} name`}
+                value={names[slot]}
+                onChange={(e) => setNames((s) => ({ ...s, [slot]: e.target.value }))}
+              />
+              <button onClick={() => createLandlord(slot)} className="text-sm bg-night text-white rounded px-3 py-2">
+                Create
+              </button>
+            </div>
+          ))}
+        </div>
+        <p className="text-xs text-night/40 mt-2">{pendingLandlords.length} pending landlord(s) available to assign.</p>
+      </section>
+
+      {summary && (
+        <div className="text-sm rounded px-3 py-2 mb-4 bg-green-50 text-green-800">
+          {summary.migrated} migrated, {summary.skipped} skipped, {summary.errors} errors.
+          {summary.errorDetail?.length > 0 && (
+            <ul className="mt-1 list-disc pl-5 text-red-600">
+              {summary.errorDetail.map((e, i) => (
+                <li key={i}>{e}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+      {msg && <p className="text-sm text-night/70 bg-parchment rounded px-3 py-2 mb-4">{msg}</p>}
+
+      <section className="border border-gray-200 rounded-lg overflow-hidden mb-6">
+        <div className="grid grid-cols-[auto_1fr_auto] gap-3 items-center bg-gray-50 px-4 py-2 text-xs font-semibold text-night/50">
+          <span>Cover</span>
+          <span>Listing</span>
+          <span>Assign to</span>
+        </div>
+        {candidates.length === 0 ? (
+          <p className="px-4 py-6 text-sm text-night/40">No fake listings left to migrate.</p>
+        ) : (
+          candidates.map((c) => (
+            <div key={c.listing_id} className="grid grid-cols-[auto_1fr_auto] gap-3 items-center px-4 py-2 border-t border-gray-100">
+              {c.cover ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={c.cover} alt="" className="w-14 h-14 rounded object-cover bg-gray-100" />
+              ) : (
+                <div className="w-14 h-14 rounded bg-gray-100 grid place-items-center text-[10px] text-night/30">none</div>
+              )}
+              <div className="min-w-0">
+                <p className="text-sm text-night truncate">
+                  {c.title} <span className="text-night/30">({c.listing_id})</span>
+                </p>
+                <p className="text-xs text-night/50">
+                  {[c.neighborhood, c.property_type, money(c.price_eur_month), c.sqm ? `${c.sqm}m²` : null]
+                    .filter(Boolean)
+                    .join(' · ')}
+                </p>
+                {c.already_migrated && <span className="text-[11px] text-green-700">already staged</span>}
+              </div>
+              <select
+                className="text-xs border border-gray-200 rounded px-2 py-1"
+                value={selections[c.listing_id] || ''}
+                onChange={(e) => setSelections((s) => ({ ...s, [c.listing_id]: e.target.value }))}
+              >
+                <option value="">— leave untouched —</option>
+                {pendingLandlords.map((l) => (
+                  <option key={l.id} value={l.id}>
+                    {l.display_name || l.id}
+                  </option>
+                ))}
+                <option value="skip">Skip / delete</option>
+              </select>
+            </div>
+          ))
+        )}
+      </section>
+
+      <button
+        onClick={runMigration}
+        disabled={running || candidates.length === 0}
+        className="text-sm bg-blue text-white rounded px-5 py-2.5 disabled:opacity-40"
+      >
+        {running ? 'Migrating…' : 'Migrate'}
+      </button>
+    </div>
+  );
+}

--- a/src/app/[locale]/admin/migrate-fake-listings/page.js
+++ b/src/app/[locale]/admin/migrate-fake-listings/page.js
@@ -1,0 +1,35 @@
+import { redirect } from 'next/navigation';
+import { setRequestLocale } from 'next-intl/server';
+import { requireAdmin } from '@/lib/requireAdmin';
+import { getSupabaseAsService } from '@/lib/supabaseServer';
+import { loadFakeCandidates } from '@/lib/pendingMigrate';
+import NotAuthorized from '../NotAuthorized';
+import MigrateWizard from './MigrateWizard';
+
+export const dynamic = 'force-dynamic';
+
+// GET /admin/migrate-fake-listings — one-time-use, idempotent wizard to move the
+// fake seed listings into the pending pipeline and out of the public directory.
+// Candidate list is loaded server-side (after the admin gate) so nothing flashes
+// and there is no fetch-on-mount.
+export default async function MigrateFakeListingsPage({ params }) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const admin = await requireAdmin();
+  if (!admin) {
+    redirect(`/property/thessaloniki/landlord/login?next=${encodeURIComponent('/admin/migrate-fake-listings')}`);
+  }
+  if (admin.kind === 'not-admin') {
+    return <NotAuthorized email={admin.email} />;
+  }
+
+  const supabase = getSupabaseAsService();
+  const { candidates } = await loadFakeCandidates(supabase);
+  const { data: pendingLandlords } = await supabase
+    .from('pending_landlords')
+    .select('id, display_name, status')
+    .order('created_at', { ascending: true });
+
+  return <MigrateWizard initialCandidates={candidates} initialPendingLandlords={pendingLandlords || []} />;
+}

--- a/src/app/[locale]/claim/[token]/ClaimClient.js
+++ b/src/app/[locale]/claim/[token]/ClaimClient.js
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState } from 'react';
+import { PROPERTY_TYPE_ENUM } from '@/lib/pendingMappers';
+
+const money = (v) => (v == null ? '' : `€${v}/mo`);
+
+function PhotoStrip({ photos }) {
+  const urls = (Array.isArray(photos) ? photos : []).map((p) => p?.url).filter(Boolean);
+  if (!urls.length) return <div className="h-40 bg-gray-100 rounded-lg grid place-items-center text-night/30 text-sm">No photos</div>;
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-1">
+      {urls.map((u, i) => (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img key={i} src={u} alt="" className="h-40 w-56 object-cover rounded-lg bg-gray-100 flex-shrink-0" />
+      ))}
+    </div>
+  );
+}
+
+export default function ClaimClient({ token, landlord, listings }) {
+  const claimable = listings.filter((l) => l.status !== 'published');
+  const [edits, setEdits] = useState(() => {
+    const map = {};
+    for (const l of listings) {
+      map[l.id] = {
+        address: l.address || '',
+        neighborhood: l.neighborhood || '',
+        price_eur_month: l.price_eur_month ?? '',
+        property_type: l.property_type || 'other',
+        description: l.description || '',
+      };
+    }
+    return map;
+  });
+  const [contact, setContact] = useState({
+    display_name: landlord.display_name || '',
+    phone: landlord.phone || '',
+    email: landlord.email || '',
+  });
+  const [publishing, setPublishing] = useState(false);
+  const [result, setResult] = useState(landlord.published_landlord_id ? { already: true } : null);
+
+  const setListingField = (id, field, value) => setEdits((s) => ({ ...s, [id]: { ...s[id], [field]: value } }));
+
+  const publish = async () => {
+    setPublishing(true);
+    const listingEdits = {};
+    for (const l of claimable) {
+      const e = edits[l.id];
+      listingEdits[l.id] = {
+        address: e.address || null,
+        neighborhood: e.neighborhood || null,
+        price_eur_month: e.price_eur_month === '' ? null : Number(e.price_eur_month),
+        property_type: e.property_type,
+        description: e.description || null,
+      };
+    }
+    const res = await fetch(`/api/claim/${token}/publish`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ edits: { landlord: contact, listings: listingEdits } }),
+    });
+    const d = await res.json();
+    setPublishing(false);
+    if (res.ok) setResult(d);
+    else setResult({ error: d.error || 'Publish failed' });
+  };
+
+  if (result?.already || result?.ok) {
+    return (
+      <div className="min-h-screen grid place-items-center p-6">
+        <div className="max-w-md text-center">
+          <h1 className="font-display text-2xl font-bold text-night mb-2">You are live 🎉</h1>
+          <p className="text-night/60">
+            {result.already
+              ? 'Your listings have already been published to StudentX.'
+              : `Published ${result.published?.length ?? 0} listing(s) to StudentX.`}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-10">
+      <h1 className="font-display text-2xl font-bold text-night mb-1">Claim your StudentX listings</h1>
+      <p className="text-night/60 mb-6">
+        Review the details below and publish them to the StudentX directory. You can edit anything before publishing.
+      </p>
+
+      <section className="border border-gray-200 rounded-lg p-4 mb-6">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-night/40 mb-3">Your contact details</h2>
+        <div className="grid sm:grid-cols-3 gap-2">
+          {['display_name', 'phone', 'email'].map((f) => (
+            <input
+              key={f}
+              className="text-sm border border-gray-200 rounded px-2 py-1.5"
+              placeholder={f.replace('_', ' ')}
+              value={contact[f]}
+              onChange={(e) => setContact((s) => ({ ...s, [f]: e.target.value }))}
+            />
+          ))}
+        </div>
+      </section>
+
+      {result?.error && <p className="text-sm bg-red-50 text-red-600 rounded px-3 py-2 mb-4">{result.error}</p>}
+
+      {claimable.length === 0 ? (
+        <p className="text-night/50">There are no listings waiting to be published.</p>
+      ) : (
+        claimable.map((l) => (
+          <div key={l.id} className="border border-gray-200 rounded-lg p-4 mb-4">
+            <PhotoStrip photos={l.photos_json} />
+            <div className="grid sm:grid-cols-2 gap-2 mt-3">
+              <input
+                className="text-sm border border-gray-200 rounded px-2 py-1.5"
+                placeholder="address"
+                value={edits[l.id].address}
+                onChange={(e) => setListingField(l.id, 'address', e.target.value)}
+              />
+              <input
+                className="text-sm border border-gray-200 rounded px-2 py-1.5"
+                placeholder="neighborhood"
+                value={edits[l.id].neighborhood}
+                onChange={(e) => setListingField(l.id, 'neighborhood', e.target.value)}
+              />
+              <input
+                type="number"
+                className="text-sm border border-gray-200 rounded px-2 py-1.5"
+                placeholder="price € / month"
+                value={edits[l.id].price_eur_month}
+                onChange={(e) => setListingField(l.id, 'price_eur_month', e.target.value)}
+              />
+              <select
+                className="text-sm border border-gray-200 rounded px-2 py-1.5"
+                value={edits[l.id].property_type}
+                onChange={(e) => setListingField(l.id, 'property_type', e.target.value)}
+              >
+                {PROPERTY_TYPE_ENUM.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <textarea
+              className="w-full text-sm border border-gray-200 rounded px-2 py-1.5 mt-2"
+              rows={3}
+              placeholder="description"
+              value={edits[l.id].description}
+              onChange={(e) => setListingField(l.id, 'description', e.target.value)}
+            />
+            {l.price_eur_month != null && <p className="text-xs text-night/40 mt-1">Current: {money(l.price_eur_month)}</p>}
+          </div>
+        ))
+      )}
+
+      <button
+        onClick={publish}
+        disabled={publishing || claimable.length === 0}
+        className="w-full text-base bg-blue text-white rounded-lg px-5 py-3 disabled:opacity-40"
+      >
+        {publishing ? 'Publishing…' : 'Publish my listings'}
+      </button>
+    </div>
+  );
+}

--- a/src/app/[locale]/claim/[token]/page.js
+++ b/src/app/[locale]/claim/[token]/page.js
@@ -1,0 +1,32 @@
+import { setRequestLocale } from 'next-intl/server';
+import { getSupabaseAsService } from '@/lib/supabaseServer';
+import { loadClaimContext } from '@/lib/pendingPublish';
+import ClaimClient from './ClaimClient';
+
+export const dynamic = 'force-dynamic';
+
+// GET /claim/:token — PUBLIC but token-gated. Renders the landlord's pending
+// profile + listings (server-loaded via the service client, since RLS denies
+// anon). An invalid/expired token shows a neutral message and nothing else.
+export default async function ClaimPage({ params }) {
+  const { locale, token } = await params;
+  setRequestLocale(locale);
+
+  const supabase = getSupabaseAsService();
+  const ctx = await loadClaimContext(supabase, token);
+
+  if (!ctx) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-6">
+        <div className="max-w-md text-center">
+          <h1 className="font-display text-2xl font-bold text-night mb-2">Link expired</h1>
+          <p className="text-night/60">
+            This claim link is invalid or has expired. Please ask StudentX for a fresh link.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return <ClaimClient token={token} landlord={ctx.landlord} listings={ctx.listings} />;
+}

--- a/src/app/api/admin/ingest-listing/route.js
+++ b/src/app/api/admin/ingest-listing/route.js
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/requireAdmin';
+import { getSupabaseAsService } from '@/lib/supabaseServer';
+import { getAiBinding } from '@/lib/cloudflareEnv';
+import { buildPendingListing } from '@/lib/pendingIngest';
+import { newPendingListingId } from '@/lib/pendingIds';
+
+// POST /api/admin/ingest-listing  { url, pending_landlord_id? }
+// Fetches the URL, extracts fields via Workers AI, downloads photos to R2-equiv
+// (pending-photos Storage bucket), and writes a pending_listings row.
+export async function POST(request) {
+  const gate = await requireAdminApi(request);
+  if (!gate.ok) return NextResponse.json({ error: gate.error }, { status: gate.status });
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  const url = typeof body?.url === 'string' ? body.url.trim() : '';
+  if (!/^https?:\/\//i.test(url)) {
+    return NextResponse.json({ error: 'A valid http(s) url is required' }, { status: 400 });
+  }
+
+  const ai = getAiBinding();
+  if (!ai) {
+    return NextResponse.json(
+      { error: 'Workers AI binding unavailable. Ingest runs on preview/deploy, not in next dev.' },
+      { status: 503 }
+    );
+  }
+
+  const supabase = getSupabaseAsService();
+  const id = newPendingListingId();
+  const pendingLandlordId = typeof body?.pending_landlord_id === 'string' ? body.pending_landlord_id : null;
+
+  const row = await buildPendingListing({ url, ai, supabase, id });
+  const status = pendingLandlordId && row.status === 'pending' ? 'assigned' : row.status;
+
+  const { error } = await supabase.from('pending_listings').insert({ id, pending_landlord_id: pendingLandlordId, ...row, status });
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  return NextResponse.json({
+    id,
+    status,
+    preview: {
+      address: row.address ?? null,
+      neighborhood: row.neighborhood ?? null,
+      beds: row.beds ?? null,
+      baths: row.baths ?? null,
+      sqm: row.sqm ?? null,
+      price_eur_month: row.price_eur_month ?? null,
+      property_type: row.property_type ?? null,
+      description: row.description ?? null,
+      photos: Array.isArray(row.photos_json) ? row.photos_json.length : 0,
+      contact_phone: row.contact_phone_extracted ?? null,
+      contact_email: row.contact_email_extracted ?? null,
+    },
+  });
+}

--- a/src/app/api/admin/ingest-listings-batch/route.js
+++ b/src/app/api/admin/ingest-listings-batch/route.js
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/requireAdmin';
+import { getSupabaseAsService } from '@/lib/supabaseServer';
+import { getAiBinding, getExecutionCtx } from '@/lib/cloudflareEnv';
+import { buildPendingListing } from '@/lib/pendingIngest';
+import { sourceTagFromUrl } from '@/lib/pendingMappers';
+import { newPendingListingId } from '@/lib/pendingIds';
+
+const MAX_BATCH = 25;
+
+// POST /api/admin/ingest-listings-batch  { urls: [string], pending_landlord_id? }
+// Inserts a placeholder pending_listings row per url immediately, then processes
+// fetch + extraction + photos in the background (ctx.waitUntil on the Worker;
+// inline fallback in dev). Returns one { url, id, status:'queued' } per url.
+export async function POST(request) {
+  const gate = await requireAdminApi(request);
+  if (!gate.ok) return NextResponse.json({ error: gate.error }, { status: gate.status });
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+  const urls = Array.isArray(body?.urls)
+    ? body.urls.filter((u) => typeof u === 'string' && /^https?:\/\//i.test(u.trim())).map((u) => u.trim())
+    : [];
+  if (!urls.length) return NextResponse.json({ error: 'urls must be a non-empty array of http(s) links' }, { status: 400 });
+  if (urls.length > MAX_BATCH) return NextResponse.json({ error: `Batch capped at ${MAX_BATCH} urls` }, { status: 400 });
+
+  const ai = getAiBinding();
+  if (!ai) {
+    return NextResponse.json({ error: 'Workers AI binding unavailable (run on preview/deploy)' }, { status: 503 });
+  }
+
+  const supabase = getSupabaseAsService();
+  const pendingLandlordId = typeof body?.pending_landlord_id === 'string' ? body.pending_landlord_id : null;
+  const items = urls.map((url) => ({ url, id: newPendingListingId() }));
+
+  const { error: insErr } = await supabase.from('pending_listings').insert(
+    items.map((it) => ({
+      id: it.id,
+      pending_landlord_id: pendingLandlordId,
+      source_url: it.url,
+      source_type: sourceTagFromUrl(it.url),
+      status: 'pending',
+      photos_json: [],
+    }))
+  );
+  if (insErr) return NextResponse.json({ error: insErr.message }, { status: 500 });
+
+  const work = (async () => {
+    for (const it of items) {
+      try {
+        const row = await buildPendingListing({ url: it.url, ai, supabase, id: it.id });
+        const status = pendingLandlordId && row.status === 'pending' ? 'assigned' : row.status;
+        await supabase.from('pending_listings').update({ ...row, status }).eq('id', it.id);
+      } catch {
+        await supabase.from('pending_listings').update({ status: 'error' }).eq('id', it.id);
+      }
+    }
+  })();
+
+  const exec = getExecutionCtx();
+  if (exec?.waitUntil) exec.waitUntil(work);
+  else await work; // dev: no execution ctx, process inline before responding
+
+  return NextResponse.json({ results: items.map((it) => ({ url: it.url, id: it.id, status: 'queued' })) });
+}

--- a/src/app/api/admin/migrate-fake-listings/route.js
+++ b/src/app/api/admin/migrate-fake-listings/route.js
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/requireAdmin';
+import { getSupabaseAsService } from '@/lib/supabaseServer';
+import { loadFakeCandidates, migrateOneFake, deletePublicListing } from '@/lib/pendingMigrate';
+
+export const dynamic = 'force-dynamic';
+
+// GET — wizard data: the fake (non-protected) public listings, the protected
+// landlord_ids (never touchable), and the pending landlords to assign into.
+export async function GET(request) {
+  const gate = await requireAdminApi(request);
+  if (!gate.ok) return NextResponse.json({ error: gate.error }, { status: gate.status });
+
+  const supabase = getSupabaseAsService();
+  const { candidates, protectedLandlordIds } = await loadFakeCandidates(supabase);
+  const { data: pendingLandlords } = await supabase
+    .from('pending_landlords')
+    .select('id, display_name, status')
+    .order('created_at', { ascending: true });
+
+  return NextResponse.json({ candidates, protectedLandlordIds, pendingLandlords: pendingLandlords || [] });
+}
+
+// POST  { assignments: { <listing_id>: <pending_landlord_id> | 'skip' } }
+// For each: a pending landlord => stage into pending_listings (idempotent) then
+// delete the public listing; 'skip'/'delete' => just delete the public listing.
+// Protected/unknown listing_ids are refused server-side regardless of input.
+export async function POST(request) {
+  const gate = await requireAdminApi(request);
+  if (!gate.ok) return NextResponse.json({ error: gate.error }, { status: gate.status });
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+  const assignments = body?.assignments && typeof body.assignments === 'object' ? body.assignments : null;
+  if (!assignments) return NextResponse.json({ error: 'assignments object is required' }, { status: 400 });
+
+  const supabase = getSupabaseAsService();
+
+  // Safety net: only listing_ids that are genuinely fake (non-protected) and
+  // still present may be acted on. Anything else is refused or treated as an
+  // idempotent no-op — a protected listing can never be deleted here.
+  const { candidates } = await loadFakeCandidates(supabase);
+  const allowed = new Set(candidates.map((c) => c.listing_id));
+  const { data: mig } = await supabase
+    .from('pending_listings')
+    .select('migrated_from_listing_id')
+    .not('migrated_from_listing_id', 'is', null);
+  const migratedSet = new Set((mig || []).map((m) => m.migrated_from_listing_id));
+
+  let migrated = 0;
+  let skipped = 0;
+  const errors = [];
+
+  for (const [listingId, target] of Object.entries(assignments)) {
+    if (!allowed.has(listingId)) {
+      // already migrated+deleted on a previous run => benign idempotent skip
+      if (migratedSet.has(listingId)) skipped++;
+      else errors.push(`${listingId}: refused (protected, unknown, or already removed)`);
+      continue;
+    }
+    try {
+      if (!target || target === 'skip' || target === 'delete') {
+        await deletePublicListing({ supabase, listingId });
+        skipped++;
+      } else {
+        const m = await migrateOneFake({ supabase, listingId, pendingLandlordId: target });
+        if (m.action === 'error') {
+          errors.push(`${listingId}: ${m.error}`);
+          continue;
+        }
+        await deletePublicListing({ supabase, listingId });
+        migrated++;
+      }
+    } catch (err) {
+      errors.push(`${listingId}: ${err.message || err}`);
+    }
+  }
+
+  return NextResponse.json({ migrated, skipped, errors: errors.length, errorDetail: errors });
+}

--- a/src/app/api/admin/pending-landlords/[id]/generate-claim-link/route.js
+++ b/src/app/api/admin/pending-landlords/[id]/generate-claim-link/route.js
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/requireAdmin';
+import { getSupabaseAsService } from '@/lib/supabaseServer';
+import { newClaimToken } from '@/lib/pendingIds';
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+// POST /api/admin/pending-landlords/:id/generate-claim-link
+// Mints a fresh claim token (30-day expiry), flips status to 'claim_sent', and
+// returns the full magic link https://studentx.uk/claim/<token>.
+export async function POST(request, { params }) {
+  const gate = await requireAdminApi(request);
+  if (!gate.ok) return NextResponse.json({ error: gate.error }, { status: gate.status });
+
+  const { id } = await params;
+  const supabase = getSupabaseAsService();
+  const token = newClaimToken();
+  const expiresAt = new Date(Date.now() + THIRTY_DAYS_MS).toISOString();
+
+  const { data, error } = await supabase
+    .from('pending_landlords')
+    .update({ claim_token: token, claim_token_expires_at: expiresAt, status: 'claim_sent' })
+    .eq('id', id)
+    .select('id')
+    .maybeSingle();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data) return NextResponse.json({ error: 'Pending landlord not found' }, { status: 404 });
+
+  const base = (process.env.NEXT_PUBLIC_SITE_URL || 'https://studentx.uk').replace(/\/+$/, '');
+  return NextResponse.json({ url: `${base}/claim/${token}`, claim_token: token, expires_at: expiresAt });
+}

--- a/src/app/api/admin/pending-landlords/[id]/route.js
+++ b/src/app/api/admin/pending-landlords/[id]/route.js
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/requireAdmin';
+import { getSupabaseAsService } from '@/lib/supabaseServer';
+
+const EDITABLE = ['display_name', 'phone', 'email', 'notes'];
+
+// PATCH /api/admin/pending-landlords/:id  { display_name?, phone?, email?, notes? }
+export async function PATCH(request, { params }) {
+  const gate = await requireAdminApi(request);
+  if (!gate.ok) return NextResponse.json({ error: gate.error }, { status: gate.status });
+
+  const { id } = await params;
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  const patch = {};
+  for (const key of EDITABLE) {
+    if (key in body) patch[key] = body[key];
+  }
+  if (!Object.keys(patch).length) {
+    return NextResponse.json({ error: 'No editable fields supplied' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAsService();
+  const { data, error } = await supabase.from('pending_landlords').update(patch).eq('id', id).select('*').maybeSingle();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data) return NextResponse.json({ error: 'Pending landlord not found' }, { status: 404 });
+  return NextResponse.json({ landlord: data });
+}

--- a/src/app/api/admin/pending-landlords/route.js
+++ b/src/app/api/admin/pending-landlords/route.js
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/requireAdmin';
+import { getSupabaseAsService } from '@/lib/supabaseServer';
+import { newPendingLandlordId } from '@/lib/pendingIds';
+
+export const dynamic = 'force-dynamic';
+
+// GET /api/admin/pending-landlords — all pending landlords + all pending listings
+// (used to refresh the dashboard after client-side mutations).
+export async function GET(request) {
+  const gate = await requireAdminApi(request);
+  if (!gate.ok) return NextResponse.json({ error: gate.error }, { status: gate.status });
+
+  const supabase = getSupabaseAsService();
+  const [{ data: landlords }, { data: listings }] = await Promise.all([
+    supabase.from('pending_landlords').select('*').order('created_at', { ascending: false }),
+    supabase.from('pending_listings').select('*').order('created_at', { ascending: false }),
+  ]);
+  return NextResponse.json({ landlords: landlords || [], listings: listings || [] });
+}
+
+// POST /api/admin/pending-landlords  { display_name?, phone?, email?, notes? }
+export async function POST(request) {
+  const gate = await requireAdminApi(request);
+  if (!gate.ok) return NextResponse.json({ error: gate.error }, { status: gate.status });
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  const supabase = getSupabaseAsService();
+  const id = newPendingLandlordId();
+  const { data, error } = await supabase
+    .from('pending_landlords')
+    .insert({
+      id,
+      display_name: body.display_name ?? null,
+      phone: body.phone ?? null,
+      email: body.email ?? null,
+      notes: body.notes ?? null,
+      status: 'pending',
+    })
+    .select('*')
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ id, landlord: data }, { status: 201 });
+}

--- a/src/app/api/admin/pending-listings/[id]/assign/route.js
+++ b/src/app/api/admin/pending-listings/[id]/assign/route.js
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { requireAdminApi } from '@/lib/requireAdmin';
+import { getSupabaseAsService } from '@/lib/supabaseServer';
+
+// POST /api/admin/pending-listings/:id/assign  { pending_landlord_id }
+// Links a pending listing to a pending landlord.
+export async function POST(request, { params }) {
+  const gate = await requireAdminApi(request);
+  if (!gate.ok) return NextResponse.json({ error: gate.error }, { status: gate.status });
+
+  const { id } = await params;
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+  const pendingLandlordId = typeof body?.pending_landlord_id === 'string' ? body.pending_landlord_id : null;
+  if (!pendingLandlordId) {
+    return NextResponse.json({ error: 'pending_landlord_id is required' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAsService();
+
+  const { data: landlord } = await supabase.from('pending_landlords').select('id').eq('id', pendingLandlordId).maybeSingle();
+  if (!landlord) return NextResponse.json({ error: 'pending_landlord_id not found' }, { status: 404 });
+
+  const { data: current } = await supabase.from('pending_listings').select('status').eq('id', id).maybeSingle();
+  if (!current) return NextResponse.json({ error: 'Pending listing not found' }, { status: 404 });
+
+  // Don't clobber a needs_manual_entry / error / published flag — only a plain
+  // 'pending' row graduates to 'assigned'.
+  const nextStatus = current.status === 'pending' ? 'assigned' : current.status;
+
+  const { data, error } = await supabase
+    .from('pending_listings')
+    .update({ pending_landlord_id: pendingLandlordId, status: nextStatus })
+    .eq('id', id)
+    .select('*')
+    .maybeSingle();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ listing: data });
+}

--- a/src/app/api/claim/[token]/publish/route.js
+++ b/src/app/api/claim/[token]/publish/route.js
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { getSupabaseAsService } from '@/lib/supabaseServer';
+import { loadClaimContext, publishPendingLandlord } from '@/lib/pendingPublish';
+
+// POST /api/claim/:token/publish  { edits?: { landlord?, listings? } }
+// PUBLIC but token-gated: the unguessable claim token IS the authorisation, so
+// there is no admin/Supabase session here. Moves the landlord + their pending
+// listings into the public star schema. Idempotent (re-clicking is safe).
+export async function POST(request, { params }) {
+  const { token } = await params;
+  const supabase = getSupabaseAsService();
+
+  const ctx = await loadClaimContext(supabase, token);
+  if (!ctx) {
+    return NextResponse.json({ error: 'This claim link is invalid or has expired.' }, { status: 410 });
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+  const edits = body?.edits && typeof body.edits === 'object' ? body.edits : {};
+
+  const result = await publishPendingLandlord({ supabase, landlord: ctx.landlord, edits });
+  if (!result.landlordId) {
+    return NextResponse.json({ error: 'Publish failed', detail: result.errors }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    landlord_id: result.landlordId,
+    published: result.published,
+    errors: result.errors,
+    already_published: result.alreadyPublished,
+  });
+}

--- a/src/lib/cloudflareEnv.js
+++ b/src/lib/cloudflareEnv.js
@@ -1,0 +1,24 @@
+// Access Cloudflare Worker bindings (Workers AI, execution context) from Next.js
+// route handlers running under @opennextjs/cloudflare. getCloudflareContext() is
+// only available inside the Worker request scope — in plain `next dev` it throws,
+// so every accessor degrades to null and callers handle "AI not available here".
+
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+
+function ctx() {
+  try {
+    return getCloudflareContext();
+  } catch {
+    return null;
+  }
+}
+
+/** The Workers AI binding (env.AI), or null when not running on the Worker. */
+export function getAiBinding() {
+  return ctx()?.env?.AI ?? null;
+}
+
+/** The Worker ExecutionContext (for ctx.waitUntil), or null in dev. */
+export function getExecutionCtx() {
+  return ctx()?.ctx ?? null;
+}

--- a/src/lib/pendingIds.js
+++ b/src/lib/pendingIds.js
@@ -1,0 +1,12 @@
+// Id + claim-token minting for the pending pipeline. Uses Web Crypto, available
+// both on the Cloudflare Worker runtime and in Node 22 (dev/tests).
+
+export const newPendingLandlordId = () => 'pl_' + crypto.randomUUID();
+export const newPendingListingId = () => 'pli_' + crypto.randomUUID();
+
+/** 64 hex chars (256 bits) of CSPRNG — the magic claim-link secret. */
+export function newClaimToken() {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/src/lib/pendingIngest.js
+++ b/src/lib/pendingIngest.js
@@ -1,0 +1,220 @@
+// Site-agnostic listing ingest: bare fetch() + Cloudflare Workers AI extraction.
+// No external API keys, no paid scraping service. Every external dependency
+// (fetch, the AI binding, the Supabase service client) is passed in, so the
+// whole pipeline is unit-testable with mocks.
+
+import {
+  PROPERTY_TYPE_ENUM,
+  parseExtractionJson,
+  resolvePhotoUrl,
+  photoExtFromUrl,
+  sourceTagFromUrl,
+  toIntOrNull,
+} from '@/lib/pendingMappers';
+
+export const EXTRACTION_MODEL = '@cf/meta/llama-3.1-8b-instruct';
+export const PENDING_BUCKET = 'pending-photos';
+const MAX_HTML_CHARS = 24000; // ~6000 tokens for Llama 3.1 8B
+const MIN_HTML_BYTES = 2048; // bodies shorter than this are treated as bot-challenge/empty
+const MAX_PHOTOS = 12;
+const FETCH_TIMEOUT_MS = 15000;
+
+// Realistic latest-Chrome headers. el-GR first because the target sites are Greek.
+export const BROWSER_HEADERS = {
+  'User-Agent':
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+  Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+  'Accept-Language': 'el-GR,el;q=0.9,en-US;q=0.8,en;q=0.7',
+  'Accept-Encoding': 'gzip, deflate, br',
+  'Upgrade-Insecure-Requests': '1',
+  'Sec-Fetch-Dest': 'document',
+  'Sec-Fetch-Mode': 'navigate',
+  'Sec-Fetch-Site': 'none',
+};
+
+// Exact extraction contract from the spec. The model must return ONLY JSON.
+export const EXTRACTION_SYSTEM_PROMPT = `You are a real-estate listing extraction service. Given the HTML body of a single listing page, extract the listing data and return ONLY valid JSON (no commentary, no markdown fences). Use this exact schema:
+
+{
+  "address": string | null,
+  "neighborhood": string | null,
+  "beds": integer | null,
+  "baths": integer | null,
+  "sqm": integer | null,
+  "price_eur_month": integer | null,
+  "property_type": "studio" | "1-bed" | "2-bed" | "3-bed" | "room" | "other",
+  "description": string,
+  "photo_urls": [string],
+  "contact_phone": string | null,
+  "contact_email": string | null
+}
+
+Rules:
+- Return null for any field you cannot confidently determine
+- photo_urls must be absolute URLs (resolve any relative paths against the page origin)
+- price_eur_month must be in EUR per month — convert weekly/daily prices to monthly if needed
+- description should be a clean, paragraph-form summary in English (translate if necessary)
+- Strictly valid JSON. No trailing commas. No commentary outside the JSON object.`;
+
+// A response is "blocked" (bot challenge / error / empty) when we should give up
+// and mark the listing needs_manual_entry rather than feed garbage to the model.
+export function isBlockedResponse(status, body) {
+  if (status === 403 || status === 429 || status >= 500) return true;
+  if (!body || body.length < MIN_HTML_BYTES) return true;
+  const lower = body.slice(0, 4000).toLowerCase();
+  const markers = [
+    'just a moment',
+    'cf-browser-verification',
+    '/cdn-cgi/challenge-platform',
+    'attention required',
+    'captcha-delivery',
+    'please enable javascript and cookies',
+    'verifying you are human',
+  ];
+  return markers.some((m) => lower.includes(m));
+}
+
+// Fetch with browser headers + a hard timeout. Never throws — failures resolve to
+// { ok: false, reason }, so the caller can mark needs_manual_entry and move on.
+export async function fetchListingHtml(url, fetchImpl = fetch) {
+  let res;
+  try {
+    res = await fetchImpl(url, {
+      headers: BROWSER_HEADERS,
+      redirect: 'follow',
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+  } catch {
+    return { ok: false, reason: 'fetch_failed' };
+  }
+  let body = '';
+  try {
+    body = await res.text();
+  } catch {
+    return { ok: false, reason: 'read_failed', status: res.status };
+  }
+  if (isBlockedResponse(res.status, body)) {
+    return { ok: false, reason: 'blocked', status: res.status };
+  }
+  return { ok: true, html: body, finalUrl: res.url || url, status: res.status };
+}
+
+// Strip script/style/noscript/nav/header/footer/comments + best-effort
+// aria-hidden icons, collapse whitespace, truncate to the model budget. Keeps
+// <head> meta (og:image/title) and <img>/<a> so photo URLs survive.
+export function preprocessHtml(html) {
+  if (!html || typeof html !== 'string') return '';
+  let s = html;
+  s = s.replace(/<!--[\s\S]*?-->/g, ' ');
+  s = s.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ');
+  s = s.replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ');
+  s = s.replace(/<noscript\b[^>]*>[\s\S]*?<\/noscript>/gi, ' ');
+  // visual chrome (NB: \b means <header> matches but <head> does not)
+  s = s.replace(/<(nav|footer|header)\b[^>]*>[\s\S]*?<\/\1>/gi, ' ');
+  // common aria-hidden icon wrappers
+  s = s.replace(/<svg\b[^>]*aria-hidden=["']true["'][\s\S]*?<\/svg>/gi, ' ');
+  s = s.replace(/<i\b[^>]*aria-hidden=["']true["'][^>]*>[\s\S]*?<\/i>/gi, ' ');
+  s = s.replace(/[ \t\f\v\r]+/g, ' ');
+  s = s.replace(/(\s*\n\s*){2,}/g, '\n');
+  s = s.trim();
+  if (s.length > MAX_HTML_CHARS) s = s.slice(0, MAX_HTML_CHARS);
+  return s;
+}
+
+// Run the model and parse its JSON. Throws only if the AI binding itself throws
+// (e.g. unavailable) — the caller distinguishes that (status 'error') from a
+// parseable-but-empty result (needs_manual_entry).
+export async function extractListingFields(ai, htmlText) {
+  const result = await ai.run(EXTRACTION_MODEL, {
+    messages: [
+      { role: 'system', content: EXTRACTION_SYSTEM_PROMPT },
+      { role: 'user', content: htmlText },
+    ],
+    max_tokens: 1024,
+    temperature: 0.1,
+  });
+  const text = typeof result === 'string' ? result : result?.response ?? '';
+  return parseExtractionJson(text);
+}
+
+// Download each photo and upload to pending-photos/pending/<listingId>/photo-N.ext.
+// Failures skip that photo (never fatal). Returns [{ path, url }].
+export async function downloadPhotosToBucket({ supabase, listingId, photoUrls, fetchImpl = fetch, max = MAX_PHOTOS }) {
+  const out = [];
+  for (let i = 0; i < photoUrls.length && out.length < max; i++) {
+    const src = photoUrls[i];
+    try {
+      const r = await fetchImpl(src, { headers: BROWSER_HEADERS, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+      if (!r.ok) continue;
+      const ct = r.headers.get('content-type') || '';
+      if (ct && !ct.startsWith('image/')) continue;
+      const buf = await r.arrayBuffer();
+      if (!buf || buf.byteLength === 0) continue;
+      const ext = photoExtFromUrl(src);
+      const path = `pending/${listingId}/photo-${out.length}.${ext}`;
+      const { error } = await supabase.storage
+        .from(PENDING_BUCKET)
+        .upload(path, buf, { contentType: ct || `image/${ext}`, upsert: true });
+      if (error) continue;
+      const { data } = supabase.storage.from(PENDING_BUCKET).getPublicUrl(path);
+      out.push({ path, url: data.publicUrl });
+    } catch {
+      continue;
+    }
+  }
+  return out;
+}
+
+/**
+ * Full ingest for one URL. Returns a pending_listings row object (WITHOUT id /
+ * pending_landlord_id — the caller owns those) plus its status. Side effect:
+ * downloaded photos are uploaded to pending-photos under `id`.
+ *
+ * status:
+ *   - 'pending'             extraction succeeded
+ *   - 'needs_manual_entry'  fetch blocked / body too short / unparseable JSON
+ *   - 'error'              the AI binding threw (e.g. not available in this env)
+ */
+export async function buildPendingListing({ url, ai, supabase, id, fetchImpl = fetch }) {
+  const base = { source_url: url, source_type: sourceTagFromUrl(url), photos_json: [] };
+
+  const fetched = await fetchListingHtml(url, fetchImpl);
+  if (!fetched.ok) return { ...base, status: 'needs_manual_entry' };
+
+  const text = preprocessHtml(fetched.html);
+  if (text.length < 200) return { ...base, status: 'needs_manual_entry' };
+
+  let extracted;
+  try {
+    extracted = await extractListingFields(ai, text);
+  } catch {
+    return { ...base, status: 'error' };
+  }
+  if (!extracted || typeof extracted !== 'object') {
+    return { ...base, status: 'needs_manual_entry' };
+  }
+
+  const origin = fetched.finalUrl || url;
+  const photoUrls = Array.isArray(extracted.photo_urls)
+    ? extracted.photo_urls.map((u) => resolvePhotoUrl(u, origin)).filter(Boolean)
+    : [];
+  const photos = await downloadPhotosToBucket({ supabase, listingId: id, photoUrls, fetchImpl });
+
+  const propertyType = PROPERTY_TYPE_ENUM.includes(extracted.property_type) ? extracted.property_type : 'other';
+
+  return {
+    ...base,
+    status: 'pending',
+    address: typeof extracted.address === 'string' ? extracted.address.slice(0, 500) : null,
+    neighborhood: typeof extracted.neighborhood === 'string' ? extracted.neighborhood.slice(0, 200) : null,
+    beds: toIntOrNull(extracted.beds),
+    baths: toIntOrNull(extracted.baths),
+    sqm: toIntOrNull(extracted.sqm),
+    price_eur_month: toIntOrNull(extracted.price_eur_month),
+    property_type: propertyType,
+    description: typeof extracted.description === 'string' ? extracted.description.slice(0, 4000) : null,
+    photos_json: photos,
+    contact_phone_extracted: typeof extracted.contact_phone === 'string' ? extracted.contact_phone.slice(0, 100) : null,
+    contact_email_extracted: typeof extracted.contact_email === 'string' ? extracted.contact_email.slice(0, 200) : null,
+  };
+}

--- a/src/lib/pendingMappers.js
+++ b/src/lib/pendingMappers.js
@@ -1,0 +1,154 @@
+// Pure, dependency-free helpers shared by the pending-listings pipeline (ingest,
+// publish, fake-migration). Kept side-effect-free so they're unit-testable
+// without a DB, a network, or the Workers-AI binding.
+
+export const PROPERTY_TYPE_ENUM = ['studio', '1-bed', '2-bed', '3-bed', 'room', 'other'];
+
+// Map the pending enum -> an EXISTING public property_types.name. The live
+// property_types table has Studio / 1-Bedroom / 2-Bedroom / 2-Bedroom (x2) /
+// Room in shared apartment — there is NO 3-bedroom and no generic "other", so
+// '3-bed' degrades to '2-Bedroom' and unknown/'other' degrades to the
+// PUBLISH_FALLBACK_TYPE. (Flagged in the report.)
+//
+// TODO(pending-listings, deferred 2026-06-09): add a "3-Bedroom" type and a
+// generic "Other" to the public property_types table in a follow-up PR, then map
+// '3-bed'/'other' to them here instead of degrading to '2-Bedroom'/'Studio'.
+// Intentionally deferred until we see real ingestion results.
+export const PUBLISH_FALLBACK_TYPE = 'Studio';
+const ENUM_TO_TYPE_NAME = {
+  studio: 'Studio',
+  '1-bed': '1-Bedroom',
+  '2-bed': '2-Bedroom',
+  '3-bed': '2-Bedroom',
+  room: 'Room in shared apartment',
+  other: PUBLISH_FALLBACK_TYPE,
+};
+
+export function propertyEnumToTypeName(enumValue) {
+  return ENUM_TO_TYPE_NAME[enumValue] || PUBLISH_FALLBACK_TYPE;
+}
+
+// Reverse: an existing property_types.name -> pending enum, used when migrating
+// fake public listings into pending_listings.
+const TYPE_NAME_TO_ENUM = {
+  Studio: 'studio',
+  '1-Bedroom': '1-bed',
+  '2-Bedroom': '2-bed',
+  '2-Bedroom (x2)': '2-bed',
+  'Room in shared apartment': 'room',
+};
+
+export function typeNameToEnum(name) {
+  return TYPE_NAME_TO_ENUM[name] || 'other';
+}
+
+// Best-effort beds count from a public property_types.name (source listings have
+// no beds column). baths stays unknown (null).
+export function bedsFromTypeName(name) {
+  switch (name) {
+    case 'Studio':
+      return 0;
+    case '1-Bedroom':
+      return 1;
+    case '2-Bedroom':
+    case '2-Bedroom (x2)':
+      return 2;
+    case 'Room in shared apartment':
+      return 1;
+    default:
+      return null;
+  }
+}
+
+// Next 4-digit landlord_id given the current max (e.g. '0106' -> '0107'). Null /
+// empty (no landlords yet) starts at '0100' to match the existing id space.
+// Throws past 9999 (the CHECK domain).
+export function nextLandlordId(currentMax) {
+  const n = currentMax ? parseInt(currentMax, 10) + 1 : 100;
+  if (!Number.isFinite(n) || n > 9999) {
+    throw new Error('landlord_id space exhausted (>9999)');
+  }
+  return String(n).padStart(4, '0');
+}
+
+// Next 7-digit listing_id (LLLLLNN) for a landlord given the landlord's current
+// max listing_id (or null for their first). Throws past 999 listings.
+export function nextListingId(landlordId, currentMaxListingId) {
+  let seq = 1;
+  if (currentMaxListingId) {
+    seq = parseInt(currentMaxListingId.slice(4), 10) + 1;
+  }
+  if (seq > 999) throw new Error('listing sequence exhausted (>999) for ' + landlordId);
+  return landlordId + String(seq).padStart(3, '0');
+}
+
+// Parse the Workers-AI response into the extraction object. The model is told to
+// emit bare JSON, but real models wrap it in ```json fences or add a sentence —
+// so strip fences and, failing a clean parse, grab the first {...} block.
+// Returns the parsed object, or null when nothing parseable is found.
+export function parseExtractionJson(text) {
+  if (typeof text !== 'string') return null;
+  let s = text.trim();
+  // strip ```json ... ``` or ``` ... ``` fences
+  const fence = s.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) s = fence[1].trim();
+  try {
+    return JSON.parse(s);
+  } catch {
+    // fall through to brace extraction
+  }
+  const start = s.indexOf('{');
+  const end = s.lastIndexOf('}');
+  if (start !== -1 && end !== -1 && end > start) {
+    try {
+      return JSON.parse(s.slice(start, end + 1));
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+// Resolve a possibly-relative photo URL against the page origin. Returns null
+// for unusable values (data:, javascript:, blank, unparseable).
+export function resolvePhotoUrl(raw, baseUrl) {
+  if (!raw || typeof raw !== 'string') return null;
+  const v = raw.trim();
+  if (!v || v.startsWith('data:') || v.startsWith('javascript:')) return null;
+  try {
+    return new URL(v, baseUrl).toString();
+  } catch {
+    return null;
+  }
+}
+
+// File extension for an image URL, normalised to a small allowlist. Defaults to
+// 'jpg' when the URL has no usable extension (e.g. /image?id=123).
+export function photoExtFromUrl(url) {
+  try {
+    const path = new URL(url).pathname.toLowerCase();
+    const m = path.match(/\.(jpe?g|png|webp|gif|avif)$/);
+    if (!m) return 'jpg';
+    return m[1] === 'jpeg' ? 'jpg' : m[1];
+  } catch {
+    return 'jpg';
+  }
+}
+
+// Short, human-readable source tag for pending_listings.source_type, derived
+// from the URL hostname (e.g. 'www.spitogatos.gr' -> 'spitogatos.gr').
+export function sourceTagFromUrl(url) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '') || 'scraped';
+  } catch {
+    return 'scraped';
+  }
+}
+
+// Coerce a model-extracted number-ish value to a non-negative integer or null.
+export function toIntOrNull(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const n = typeof value === 'number' ? value : parseInt(String(value).replace(/[^\d.-]/g, ''), 10);
+  if (!Number.isFinite(n) || n < 0) return null;
+  return Math.round(n);
+}

--- a/src/lib/pendingMigrate.js
+++ b/src/lib/pendingMigrate.js
@@ -1,0 +1,116 @@
+// Fake-listings migration: move the seed/fake public listings into the pending
+// pipeline (so their real owners can claim them) and remove them from the public
+// directory. Destructive on the public star schema, so:
+//   * the protected owners (michaelcharlesg, and any "Superlandlord") are
+//     resolved server-side and can NEVER be migrated/deleted, even if a request
+//     names their listing_id;
+//   * staging is idempotent via pending_listings.migrated_from_listing_id (UNIQUE);
+//   * re-runs are safe — already-migrated+deleted listings simply vanish from the
+//     candidate set.
+
+import { newPendingListingId } from '@/lib/pendingIds';
+import { typeNameToEnum, bedsFromTypeName } from '@/lib/pendingMappers';
+
+// Owners whose listings are real and must be preserved. Confirmed with the
+// operator: protect michaelcharlesg (landlord 0106). Matching by BOTH email and
+// name means a future landlord literally named "Superlandlord" is auto-protected
+// too, honouring the original spec's intent even though no such row exists today.
+export const PROTECTED_EMAILS = ['michaelcharlesg@icloud.com'];
+export const PROTECTED_NAMES = ['michaelcharlesg', 'superlandlord'];
+
+function isProtectedLandlord(l) {
+  const email = (l.email || '').toLowerCase();
+  const name = (l.name || '').toLowerCase();
+  return PROTECTED_EMAILS.includes(email) || PROTECTED_NAMES.includes(name);
+}
+
+const LISTING_JOIN = `listing_id, landlord_id, title, description, photos, external_photo_urls, sqm, floor,
+  rent ( monthly_price ), location ( address, neighborhood ), property_types ( name )`;
+
+/** Resolve the set of protected landlord_ids from the live landlords table. */
+export async function getProtectedLandlordIds(supabase) {
+  const { data: landlords } = await supabase.from('landlords').select('landlord_id, name, email');
+  return new Set((landlords || []).filter(isProtectedLandlord).map((l) => l.landlord_id));
+}
+
+/**
+ * List the fake (non-protected) public listings for the wizard grid, flagged
+ * with whether each has already been staged into pending.
+ */
+export async function loadFakeCandidates(supabase) {
+  const protectedIds = await getProtectedLandlordIds(supabase);
+  const { data: listings } = await supabase.from('listings').select(LISTING_JOIN).order('listing_id', { ascending: true });
+  const { data: migrated } = await supabase
+    .from('pending_listings')
+    .select('migrated_from_listing_id')
+    .not('migrated_from_listing_id', 'is', null);
+  const migratedSet = new Set((migrated || []).map((m) => m.migrated_from_listing_id));
+
+  const candidates = (listings || [])
+    .filter((li) => !protectedIds.has(li.landlord_id))
+    .map((li) => ({
+      listing_id: li.listing_id,
+      landlord_id: li.landlord_id,
+      title: li.title || li.location?.address || li.listing_id,
+      neighborhood: li.location?.neighborhood ?? null,
+      price_eur_month: li.rent?.monthly_price != null ? Math.round(Number(li.rent.monthly_price)) : null,
+      property_type: li.property_types?.name ?? null,
+      sqm: li.sqm ?? null,
+      cover: Array.isArray(li.photos) && li.photos.length ? li.photos[0] : null,
+      already_migrated: migratedSet.has(li.listing_id),
+    }));
+
+  return { candidates, protectedLandlordIds: [...protectedIds] };
+}
+
+/** Stage one fake public listing into pending_listings (idempotent). */
+export async function migrateOneFake({ supabase, listingId, pendingLandlordId }) {
+  const { data: li } = await supabase.from('listings').select(LISTING_JOIN).eq('listing_id', listingId).maybeSingle();
+  if (!li) return { listingId, action: 'missing' };
+
+  const typeName = li.property_types?.name;
+  const photos = [...(li.photos || []), ...(li.external_photo_urls || [])]
+    .filter(Boolean)
+    .map((u) => ({ path: null, url: u }));
+
+  const { error } = await supabase.from('pending_listings').insert({
+    id: newPendingListingId(),
+    pending_landlord_id: pendingLandlordId,
+    source_type: 'migrated_fake',
+    migrated_from_listing_id: listingId,
+    address: li.location?.address ?? null,
+    neighborhood: li.location?.neighborhood ?? null,
+    beds: bedsFromTypeName(typeName),
+    baths: null,
+    sqm: li.sqm ?? null,
+    price_eur_month: li.rent?.monthly_price != null ? Math.round(Number(li.rent.monthly_price)) : null,
+    property_type: typeNameToEnum(typeName),
+    description: li.description ?? null,
+    photos_json: photos,
+    status: 'assigned',
+  });
+
+  if (error) {
+    if (error.code === '23505') return { listingId, action: 'already' }; // unique migrated_from_listing_id
+    return { listingId, action: 'error', error: error.message };
+  }
+  return { listingId, action: 'migrated' };
+}
+
+/**
+ * Hard-delete a public listing and clean up its orphaned rent/location rows.
+ * listing_amenities + faculty_distances cascade via their FKs. (No is_public
+ * soft-delete flag exists, and adding one would modify the listings schema,
+ * which the spec forbids — so this is a true delete.)
+ */
+export async function deletePublicListing({ supabase, listingId }) {
+  const { data: li } = await supabase.from('listings').select('rent_id, location_id').eq('listing_id', listingId).maybeSingle();
+  if (!li) return { listingId, deleted: false, reason: 'missing' };
+
+  const { error } = await supabase.from('listings').delete().eq('listing_id', listingId);
+  if (error) return { listingId, deleted: false, reason: error.message };
+
+  if (li.rent_id) await supabase.from('rent').delete().eq('rent_id', li.rent_id);
+  if (li.location_id) await supabase.from('location').delete().eq('location_id', li.location_id);
+  return { listingId, deleted: true };
+}

--- a/src/lib/pendingPublish.js
+++ b/src/lib/pendingPublish.js
@@ -1,0 +1,263 @@
+// Publish + claim-context logic for the pending-listings pipeline. This is the
+// JS mirror of the SQL validated (in a rolled-back transaction) against the live
+// star schema: mint a landlord_id, then per pending listing insert rent +
+// location, resolve property_type_id, mint the 7-digit listing_id, copy photos
+// into the public listing-photos bucket, and flip the pending rows to published.
+//
+// All writes use the service-role client (RLS denies anon/authenticated on the
+// pending_* tables), and the caller is responsible for having authorised the
+// request first (valid claim token).
+
+import {
+  propertyEnumToTypeName,
+  nextLandlordId,
+  nextListingId,
+  photoExtFromUrl,
+  PUBLISH_FALLBACK_TYPE,
+} from '@/lib/pendingMappers';
+
+const LISTING_BUCKET = 'listing-photos';
+const FETCH_TIMEOUT_MS = 15000;
+
+/**
+ * Validate a claim token and load everything the claim page / publish route
+ * needs. Returns { landlord, listings } when the token is valid and unexpired,
+ * or null otherwise (unknown token, or past claim_token_expires_at).
+ */
+export async function loadClaimContext(supabase, token) {
+  if (!token) return null;
+  const { data: landlord, error } = await supabase
+    .from('pending_landlords')
+    .select('*')
+    .eq('claim_token', token)
+    .maybeSingle();
+  if (error || !landlord) return null;
+
+  if (landlord.claim_token_expires_at && new Date(landlord.claim_token_expires_at).getTime() < Date.now()) {
+    return null; // expired
+  }
+
+  const { data: listings } = await supabase
+    .from('pending_listings')
+    .select('*')
+    .eq('pending_landlord_id', landlord.id)
+    .order('created_at', { ascending: true });
+
+  return { landlord, listings: listings || [] };
+}
+
+async function maxLandlordId(supabase) {
+  const { data } = await supabase
+    .from('landlords')
+    .select('landlord_id')
+    .order('landlord_id', { ascending: false })
+    .limit(1);
+  return data && data.length ? data[0].landlord_id : null;
+}
+
+// Highest existing listing_id for a landlord (null if none). Lets publish resume
+// the per-landlord sequence after a partial run instead of restarting at 001.
+async function maxListingIdForLandlord(supabase, landlordId) {
+  const { data } = await supabase
+    .from('listings')
+    .select('listing_id')
+    .eq('landlord_id', landlordId)
+    .order('listing_id', { ascending: false })
+    .limit(1);
+  return data && data.length ? data[0].listing_id : null;
+}
+
+async function resolvePropertyTypeId(supabase, enumValue) {
+  const wanted = propertyEnumToTypeName(enumValue);
+  let { data } = await supabase.from('property_types').select('property_type_id').eq('name', wanted).maybeSingle();
+  if (!data && wanted !== PUBLISH_FALLBACK_TYPE) {
+    ({ data } = await supabase.from('property_types').select('property_type_id').eq('name', PUBLISH_FALLBACK_TYPE).maybeSingle());
+  }
+  return data?.property_type_id ?? null;
+}
+
+// Move one pending listing's photos into the public listing-photos bucket and
+// return the public URLs to store on listings.photos[].
+//   - migrated_fake: photos are already public listing-photos / external URLs —
+//     carry them straight over (no re-download).
+//   - ingested: download from pending-photos and re-upload under the new
+//     listing_id. On any failure, fall back to the (public) pending URL so a
+//     listing never publishes with zero photos due to a transient copy error.
+async function materializeListingPhotos({ supabase, listingId, photosJson, sourceType, fetchImpl }) {
+  const arr = Array.isArray(photosJson) ? photosJson : [];
+  const urls = arr.map((p) => (typeof p === 'string' ? p : p?.url)).filter(Boolean);
+  if (sourceType === 'migrated_fake') return urls;
+
+  const out = [];
+  for (let i = 0; i < urls.length; i++) {
+    const srcUrl = urls[i];
+    try {
+      const r = await fetchImpl(srcUrl, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+      if (!r.ok) {
+        out.push(srcUrl);
+        continue;
+      }
+      const ct = r.headers.get('content-type') || 'image/jpeg';
+      const buf = await r.arrayBuffer();
+      const ext = photoExtFromUrl(srcUrl);
+      const path = `${listingId}/${String(i).padStart(3, '0')}.${ext}`;
+      const { error } = await supabase.storage.from(LISTING_BUCKET).upload(path, buf, { contentType: ct, upsert: true });
+      if (error) {
+        out.push(srcUrl);
+        continue;
+      }
+      const { data } = supabase.storage.from(LISTING_BUCKET).getPublicUrl(path);
+      out.push(data.publicUrl);
+    } catch {
+      out.push(srcUrl);
+    }
+  }
+  return out;
+}
+
+/**
+ * Publish a pending landlord and all their pending listings into the public
+ * star schema. Idempotent: if the landlord already has published_landlord_id,
+ * returns early; per-listing it skips rows that already have a
+ * published_listing_id.
+ *
+ * @returns { landlordId, alreadyPublished, published: [{pendingId, listingId}], skipped, errors }
+ */
+export async function publishPendingLandlord({ supabase, landlord, edits = {}, fetchImpl = fetch }) {
+  const landlordEdits = edits.landlord || {};
+  const listingEdits = edits.listings || {};
+
+  // Reuse an already-minted public landlord if a prior (possibly interrupted)
+  // publish created one; otherwise mint it and record published_landlord_id
+  // IMMEDIATELY, so re-clicking the claim link after a crash mid-publish can't
+  // create a SECOND landlord row. (Residual: a crash in the ~2 statements
+  // between the insert and that write is still possible but the window is tiny;
+  // full atomicity would need a Postgres RPC. Acceptable at current scale.)
+  let landlordId = landlord.published_landlord_id || null;
+  if (!landlordId) {
+    const displayName = (landlordEdits.display_name ?? landlord.display_name) || 'StudentX Landlord';
+    const phone = landlordEdits.phone ?? landlord.phone;
+    let email = (landlordEdits.email ?? landlord.email) || null;
+    const contactInfo = phone || email || 'Contact via StudentX';
+
+    // landlords.email is UNIQUE — if this email already belongs to a landlord,
+    // publish without it rather than hit a 23505.
+    if (email) {
+      const { data: clash } = await supabase.from('landlords').select('landlord_id').eq('email', email).maybeSingle();
+      if (clash) email = null;
+    }
+
+    // NOTE: this read-then-insert mint of landlord_id is not concurrency-safe
+    // under two simultaneous first-time publishes (both could pick the same id;
+    // one PK-fails). Fine for the current manually-clicked, low-volume claim
+    // flow; revisit with a DB sequence if volume grows.
+    landlordId = nextLandlordId(await maxLandlordId(supabase));
+    const { error: llErr } = await supabase.from('landlords').insert({
+      landlord_id: landlordId,
+      name: displayName,
+      contact_info: contactInfo,
+      ...(email ? { email } : {}),
+    });
+    if (llErr) {
+      return { landlordId: null, alreadyPublished: false, published: [], skipped: [], errors: [`landlord insert: ${llErr.message}`] };
+    }
+    await supabase.from('pending_landlords').update({ published_landlord_id: landlordId }).eq('id', landlord.id);
+  }
+
+  const { data: pendingListings } = await supabase
+    .from('pending_listings')
+    .select('*')
+    .eq('pending_landlord_id', landlord.id)
+    .neq('status', 'published')
+    .is('published_listing_id', null)
+    .order('created_at', { ascending: true });
+
+  // Already fully published (landlord pre-existed and nothing is left): no-op.
+  if (landlord.published_landlord_id && (pendingListings || []).length === 0) {
+    return { landlordId, alreadyPublished: true, published: [], skipped: [], errors: [] };
+  }
+
+  const published = [];
+  const skipped = [];
+  const errors = [];
+  // Resume-safe: continue the per-landlord sequence after any listings a prior
+  // partial publish already created (null => first listing is <id>001).
+  let currentMax = await maxListingIdForLandlord(supabase, landlordId);
+
+  for (const pl of pendingListings || []) {
+    const ed = listingEdits[pl.id] || {};
+    const address = ed.address ?? pl.address;
+    const neighborhood = ed.neighborhood ?? pl.neighborhood;
+    const price = ed.price_eur_month ?? pl.price_eur_month;
+    const description = ed.description ?? pl.description;
+    const propertyType = ed.property_type ?? pl.property_type;
+    const photoCount = Array.isArray(pl.photos_json) ? pl.photos_json.length : 0;
+
+    // Skip a still-empty listing (e.g. an unedited needs_manual_entry row)
+    // instead of publishing a junk row with fallback address/price.
+    if (!address && !neighborhood && price == null && !description && photoCount === 0) {
+      skipped.push(pl.id);
+      continue;
+    }
+
+    try {
+      const propertyTypeId = await resolvePropertyTypeId(supabase, propertyType);
+      if (!propertyTypeId) throw new Error('no property_type_id');
+
+      const { data: rentRow, error: rentErr } = await supabase
+        .from('rent')
+        .insert({ monthly_price: price || null, currency: 'EUR', bills_included: false, deposit: 0 })
+        .select('rent_id')
+        .single();
+      if (rentErr) throw rentErr;
+
+      const { data: locRow, error: locErr } = await supabase
+        .from('location')
+        .insert({ address: address || neighborhood || 'Thessaloniki', neighborhood: neighborhood || 'Unknown', lat: null, lng: null })
+        .select('location_id')
+        .single();
+      if (locErr) throw locErr;
+
+      const listingId = nextListingId(landlordId, currentMax);
+      const photos = await materializeListingPhotos({
+        supabase,
+        listingId,
+        photosJson: pl.photos_json,
+        sourceType: pl.source_type,
+        fetchImpl,
+      });
+
+      const { error: liErr } = await supabase.from('listings').insert({
+        listing_id: listingId,
+        landlord_id: landlordId,
+        title: (address || neighborhood || 'Listing').slice(0, 80),
+        rent_id: rentRow.rent_id,
+        location_id: locRow.location_id,
+        property_type_id: propertyTypeId,
+        description: description || null,
+        photos,
+        external_photo_urls: [],
+        sqm: pl.sqm || null,
+        is_featured: false,
+      });
+      if (liErr) throw liErr;
+
+      await supabase
+        .from('pending_listings')
+        .update({ status: 'published', published_listing_id: listingId, claimed_at: new Date().toISOString() })
+        .eq('id', pl.id);
+
+      published.push({ pendingId: pl.id, listingId });
+      currentMax = listingId;
+    } catch (err) {
+      errors.push(`listing ${pl.id}: ${err.message || err}`);
+    }
+  }
+
+  await supabase
+    .from('pending_landlords')
+    .update({ status: 'claimed', claimed_at: new Date().toISOString(), published_landlord_id: landlordId })
+    .eq('id', landlord.id);
+
+  return { landlordId, alreadyPublished: false, published, skipped, errors };
+}

--- a/src/lib/requireAdmin.js
+++ b/src/lib/requireAdmin.js
@@ -1,0 +1,79 @@
+import { cache } from 'react';
+import { cookies } from 'next/headers';
+import { SB_ACCESS_TOKEN_COOKIE } from '@/lib/authCookies';
+import { extractToken, getUserFromToken, getSupabaseWithToken } from '@/lib/supabaseServer';
+
+/**
+ * Admin gate for the pending-listings pipeline.
+ *
+ * Reuses the existing admin model (already used by /api/admin/metrics and
+ * /api/admin/verifications): a normal Supabase-authenticated user whose email
+ * is in the ADMIN_EMAILS allowlist. There is intentionally NO separate
+ * password / ADMIN_TOKEN — the operator signs in through the normal login and
+ * is allowlisted by email.
+ *
+ * IMPORTANT (operational): ADMIN_EMAILS is read from process.env and is NOT set
+ * anywhere in this repo. Until the operator runs
+ *   wrangler secret put ADMIN_EMAILS --name studentx
+ * (value e.g. michaelcharlesg@icloud.com), isAdminEmail() returns false for
+ * everyone and ALL admin routes — old and new — return 403/redirect.
+ */
+export function isAdminEmail(email) {
+  if (!email) return false;
+  const allow = (process.env.ADMIN_EMAILS || '')
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+  return allow.includes(String(email).toLowerCase());
+}
+
+/**
+ * Server-component gate, mirroring requireLandlord(). Resolves the admin from
+ * the sb-access-token cookie. Returns one of:
+ *   - { user, supabase, token } — authenticated AND allowlisted (an admin)
+ *   - { kind: 'not-admin', email } — valid session but email not allowlisted
+ *   - null — no cookie / invalid-expired JWT (a guest)
+ *
+ * Page usage:
+ *   const admin = await requireAdmin();
+ *   if (!admin) redirect(`/property/thessaloniki/landlord/login?next=${...}`);
+ *   if (admin.kind === 'not-admin') return <NotAuthorized email={admin.email} />;
+ *
+ * Wrapped in React.cache() so a layout + page share one round-trip, like the
+ * requireStudent / requireLandlord helpers.
+ */
+export const requireAdmin = cache(async function requireAdmin() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(SB_ACCESS_TOKEN_COOKIE)?.value;
+  if (!token) return null;
+
+  const user = await getUserFromToken(token);
+  if (!user) return null;
+
+  if (!isAdminEmail(user.email)) {
+    return { kind: 'not-admin', email: user.email ?? null };
+  }
+
+  const supabase = getSupabaseWithToken(token);
+  return { user, supabase, token };
+});
+
+/**
+ * Route-handler gate (Bearer token in the Authorization header), mirroring the
+ * inline isAdmin() pattern in the existing admin API routes. Returns a
+ * discriminated result so callers can early-return the right status:
+ *   - { ok: true, user, token }
+ *   - { ok: false, status: 401, error } — missing / invalid token
+ *   - { ok: false, status: 403, error } — valid token, not allowlisted
+ */
+export async function requireAdminApi(request) {
+  const token = extractToken(request);
+  if (!token) return { ok: false, status: 401, error: 'Unauthorized' };
+
+  const user = await getUserFromToken(token);
+  if (!user) return { ok: false, status: 401, error: 'Unauthorized' };
+
+  if (!isAdminEmail(user.email)) return { ok: false, status: 403, error: 'Forbidden' };
+
+  return { ok: true, user, token };
+}

--- a/supabase/migrations/059_pending_listings_pipeline.sql
+++ b/supabase/migrations/059_pending_listings_pipeline.sql
@@ -1,0 +1,123 @@
+-- 059_pending_listings_pipeline
+--
+-- Consent-gated pre-population pipeline.
+--
+-- Adds a PRIVATE staging area for housing listings that have been ingested from
+-- external sites (Spitogatos, XE.gr, …) or migrated out of the existing fake
+-- seed data, BEFORE a landlord has consented to publish them. Nothing in here is
+-- ever shown on the public directory: a pending listing only becomes a real
+-- public `listings` row when the landlord opens their magic claim link and
+-- clicks "Publish", which copies the data into the existing public star schema
+-- (landlords → rent/location/property_types → listings).
+--
+-- Storage layer note (vs. the original Cloudflare-D1/R2-flavoured spec): this
+-- repo is Supabase Postgres + Supabase Storage, so the pending tables ship as a
+-- normal numbered migration and ingested photos go to a new `pending-photos`
+-- Storage bucket rather than D1/R2. The LLM extraction still runs on Cloudflare
+-- Workers AI (no external API keys). Concrete adaptations:
+--   * TEXT ids are app-minted ('pl_<uuid>' / 'pli_<uuid>'), not D1 rowids.
+--   * TIMESTAMPTZ columns instead of INTEGER epochs — matches every other table.
+--   * photos_json is JSONB (array of { path, url }) instead of a TEXT blob.
+--   * migrated_from_listing_id / published_* columns make the fake-listings
+--     migration and the publish step idempotent (safe to re-run / re-click).
+--
+-- RLS: both tables have RLS ENABLED with NO policies, and all privileges revoked
+-- from anon/authenticated. They are reachable ONLY through the service-role
+-- client (getSupabaseAsService) from server code that has already authorised the
+-- caller — the admin email allowlist for /admin/*, or a valid, unexpired claim
+-- token for /claim/*. This guarantees a pending row is never readable by a
+-- public/anon Supabase client.
+--
+-- APPLY ORDERING (per CLAUDE.md): apply to prod during PR review, before the
+-- consuming routes deploy. Nothing public SELECTs these tables, so a pre-deploy
+-- gap is harmless; the new /admin and /claim routes simply 500 until it lands.
+
+-- ---------------------------------------------------------------------------
+-- pending_landlords — pre-account landlord records (no auth.users link yet)
+-- ---------------------------------------------------------------------------
+create table if not exists public.pending_landlords (
+  id                      text primary key,
+  display_name            text,
+  phone                   text,
+  email                   text,
+  notes                   text,
+  status                  text not null default 'pending'
+                            check (status in ('pending', 'claim_sent', 'claimed', 'archived')),
+  claim_token             text unique,
+  claim_token_expires_at  timestamptz,
+  published_landlord_id   text,           -- public landlords.landlord_id minted at publish (audit + idempotency)
+  created_at              timestamptz not null default now(),
+  updated_at              timestamptz not null default now(),
+  claimed_at              timestamptz
+);
+
+-- ---------------------------------------------------------------------------
+-- pending_listings — staged listings awaiting landlord consent
+-- ---------------------------------------------------------------------------
+create table if not exists public.pending_listings (
+  id                        text primary key,
+  pending_landlord_id       text references public.pending_landlords(id) on delete set null,
+  source_url                text,
+  source_type               text not null,       -- 'scraped' | '<hostname>' | 'migrated_fake' | 'manual'
+  migrated_from_listing_id  text unique,          -- source public listing_id; idempotency key for the fake migration
+  address                   text,
+  neighborhood              text,
+  beds                      integer,
+  baths                     integer,
+  sqm                       integer,
+  price_eur_month           integer,
+  property_type             text,                 -- enum-ish: studio|1-bed|2-bed|3-bed|room|other
+  description               text,
+  photos_json               jsonb not null default '[]'::jsonb,  -- array of { path, url }
+  contact_phone_extracted   text,
+  contact_email_extracted   text,
+  published_listing_id      text,                 -- public listings.listing_id minted at publish (audit + idempotency)
+  status                    text not null default 'pending'
+                              check (status in ('pending', 'assigned', 'needs_manual_entry', 'published', 'error')),
+  created_at                timestamptz not null default now(),
+  updated_at                timestamptz not null default now(),
+  claimed_at                timestamptz
+);
+
+create index if not exists idx_pending_listings_landlord on public.pending_listings(pending_landlord_id);
+create index if not exists idx_pending_listings_status   on public.pending_listings(status);
+create index if not exists idx_pending_landlords_token   on public.pending_landlords(claim_token);
+
+-- updated_at auto-touch — reuses update_updated_at() defined in migration 001.
+drop trigger if exists trigger_pending_landlords_updated_at on public.pending_landlords;
+create trigger trigger_pending_landlords_updated_at
+  before update on public.pending_landlords
+  for each row execute function update_updated_at();
+
+drop trigger if exists trigger_pending_listings_updated_at on public.pending_listings;
+create trigger trigger_pending_listings_updated_at
+  before update on public.pending_listings
+  for each row execute function update_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- Lockdown: service-role-only access.
+-- RLS enabled + zero policies => anon/authenticated are denied every operation.
+-- Privileges revoked as belt-and-braces; service_role bypasses RLS and is
+-- granted explicitly so the server-side service client keeps working.
+-- ---------------------------------------------------------------------------
+alter table public.pending_landlords enable row level security;
+alter table public.pending_listings  enable row level security;
+
+revoke all on public.pending_landlords from anon, authenticated;
+revoke all on public.pending_listings  from anon, authenticated;
+
+grant all on public.pending_landlords to service_role;
+grant all on public.pending_listings  to service_role;
+
+-- ---------------------------------------------------------------------------
+-- pending-photos Storage bucket — holds photos downloaded from external
+-- listings during ingest, under unguessable keys pending/<pending_listing_id>/.
+-- Public-read like listing-photos / landlord-photos so the (server-gated) admin
+-- dashboard and (token-gated) claim page can render thumbnails by URL without
+-- minting signed URLs. No write policy is created, so only the service role
+-- (which bypasses storage RLS) can upload — exactly how the ingest route writes.
+-- On publish, ingested photos are copied into the public `listing-photos` bucket.
+-- ---------------------------------------------------------------------------
+insert into storage.buckets (id, name, public)
+values ('pending-photos', 'pending-photos', true)
+on conflict (id) do nothing;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,6 +12,13 @@
   "main": "cf/worker-entry.mjs",
   "compatibility_date": "2025-04-01",
   "compatibility_flags": ["nodejs_compat"],
+  // Workers AI binding — powers site-agnostic listing extraction
+  // (@cf/meta/llama-3.1-8b-instruct) in the pending-listings ingest pipeline.
+  // No external API keys. Only bound on the Worker (preview/deploy), NOT in
+  // `next dev`; route handlers read it via getCloudflareContext().env.AI.
+  // NB: the pending tables + photos live in Supabase Postgres + a `pending-photos`
+  // Storage bucket (migration 059), so no D1/R2 bindings are needed here.
+  "ai": { "binding": "AI" },
   "assets": {
     "directory": ".open-next/assets",
     "binding": "ASSETS"


### PR DESCRIPTION
## Summary

Consent-gated pre-population pipeline: ingest external housing listings into private **pending** tables, send each landlord a magic claim link, and let them publish to the public directory. Includes a one-time, idempotent wizard to migrate the existing fake seed listings into the same flow. **Nothing is exposed publicly until a landlord clicks Publish.**

Free to operate — bare `fetch()` + **Cloudflare Workers AI** (`@cf/meta/llama-3.1-8b-instruct`) for extraction; no external API keys, no paid scraper.

## Architecture (differs from the original D1/R2 brief — confirmed with operator)

- **Storage:** Supabase Postgres + Supabase Storage (`pending-photos` bucket), **not D1/R2** — matches the existing stack. Migration `059` (RLS service-role-only; anon/authenticated denied).
- **Admin auth:** reuses the existing `ADMIN_EMAILS` allowlist + Supabase session via a new server-side `requireAdmin()` (mirrors `requireLandlord`). **No new `ADMIN_TOKEN`.**
- **Workers AI** binding added to `wrangler.jsonc` (`AI`).

## What's included

- `pending_landlords` / `pending_listings` tables, idempotency/audit columns, `pending-photos` bucket (migration `059`).
- Admin: `/admin/dashboard` (ingest single/batch, create + assign landlords, generate claim links) and `/admin/migrate-fake-listings` wizard.
- Claim: `/claim/:token` + token-gated, idempotent and resume-safe publish into the public star schema.
- 32 new unit tests (extraction failure modes, mappers, admin gate).

## ⚠️ Required after merge

`ADMIN_EMAILS` is **not currently set in prod**, so all admin routes (existing `/admin/metrics`, `/admin/verifications`, and the new ones) return 403 until:

```bash
wrangler secret put ADMIN_EMAILS --name studentx   # paste: michaelcharlesg@icloud.com
```

Also apply migration `059` to prod during review (per the CLAUDE.md migration-ordering convention).

## Testing

- Migration + publish (happy path **and** crash-resume) + idempotent fake-migration + delete/orphan-cleanup validated against the live schema in rolled-back transactions.
- `npm run test` 258/258, `npm run lint` 0 errors, `npm run build` green.
- **Not** exercised: live URL ingestion (Workers AI only runs on the Worker; deferred to a separate workflow) — verify on `npm run preview` / deploy.

## Review

Independent pre-commit review: **APPROVE (final)** — verified RLS is service-role-only with no anon read path, `requireAdmin` gates every new route/page before any work, the fake-listings migration **cannot** touch michaelcharlesg's listings (server-side guard, by email + name), and the claim/publish path is idempotent and resume-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
