### PR TITLE
Fix AUSoM service card image rendering fullscreen on /student

### DIFF
--- a/src/app/[locale]/student/page.js
+++ b/src/app/[locale]/student/page.js
@@ -69,7 +69,7 @@ function ServicesContent() {
               <Link
                 key={sq.id}
                 href={sq.href}
-                className="block aspect-square overflow-hidden rounded-[22px] border border-night/10 bg-white shadow-[0_1px_3px_rgba(10,37,64,0.06),0_10px_28px_-12px_rgba(10,37,64,0.16)] transition-all duration-[220ms] ease-[cubic-bezier(.2,.7,.2,1)] hover:-translate-y-0.5 hover:border-blue hover:shadow-[0_22px_48px_-18px_rgba(99,91,255,0.30),0_6px_18px_-10px_rgba(10,37,64,0.10)]"
+                className="relative block aspect-square overflow-hidden rounded-[22px] border border-night/10 bg-white shadow-[0_1px_3px_rgba(10,37,64,0.06),0_10px_28px_-12px_rgba(10,37,64,0.16)] transition-all duration-[220ms] ease-[cubic-bezier(.2,.7,.2,1)] hover:-translate-y-0.5 hover:border-blue hover:shadow-[0_22px_48px_-18px_rgba(99,91,255,0.30),0_6px_18px_-10px_rgba(10,37,64,0.10)]"
                 style={{ textDecoration: 'none' }}
               >
                 <Image


### PR DESCRIPTION
## Problem
On `/student`, the active service card ("AUSoM Practice Test") rendered its image fullscreen across the viewport instead of inside its tile, and hovering snapped the image into the tile and back out — a visible glitch.

## Root cause
The card `<Link>` renders an `<a>` wrapping a Next.js `<Image fill>`. `fill` makes the image `position: absolute` with 100% width/height, so it sizes to its nearest positioned ancestor. The `<a>` was `position: static`, so the containing block was the viewport. The `hover:-translate-y-0.5` transform briefly made the `<a>` a containing block, causing the snap.

## Fix
Add `relative` to the `<Link>` class list so the `<a>` is always the image's containing block. One-line change in `src/app/[locale]/student/page.js`.

Only the active card uses `<Image fill>`; the inactive placeholder tiles are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)