### PR TITLE
Fix /property hub globe + city selector on mobile and tablet

### DIFF
--- a/src/components/property/HubBackground.js
+++ b/src/components/property/HubBackground.js
@@ -431,16 +431,33 @@ export default function HubBackground() {
         zIndex: 0,
       }}
     >
-      <canvas
-        ref={canvasRef}
+      {/* Fixed viewport frame: on phones/tablets the hub content (city
+          list) is much taller than the viewport, and sizing the canvas to
+          the full scroll height breaks the sphere geometry (R/cyS derive
+          from canvas height) — the dome degenerates into scattered dot
+          noise behind the list. A position:fixed frame keeps the dome
+          composed against the visible viewport at every page height and
+          scroll offset (sticky can't work here: the page wrapper's
+          overflow:hidden would become its scrollport). The canvas drops to
+          30% opacity below lg so the city list stays readable over it. */}
+      <div
         style={{
-          position: 'absolute',
+          position: 'fixed',
           inset: 0,
-          width: '100%',
-          height: '100%',
-          opacity: 0.9,
+          pointerEvents: 'none',
         }}
-      />
+      >
+        <canvas
+          ref={canvasRef}
+          className="opacity-30 lg:opacity-90"
+          style={{
+            position: 'absolute',
+            inset: 0,
+            width: '100%',
+            height: '100%',
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/property/HubDiagram.js
+++ b/src/components/property/HubDiagram.js
@@ -10,10 +10,11 @@ const GlobeLoader = dynamic(() => import('@/components/GlobeLoader'), { ssr: fal
 const CityGlobeLoader = dynamic(() => import('@/components/CityGlobeLoader'), { ssr: false });
 
 // Multi-country hub diagram — renders the hub → country → city neural-net
-// SVG on desktop (≥768 px) and a touch-friendly vertical city list on
-// mobile (<768 px). Both layouts are always in the DOM; CSS media queries
-// toggle visibility so the correct layout shows from first paint with no
-// hydration flash. The animated globe canvas (HubBackground) sits behind
+// SVG on desktop (≥1024 px) and a touch-friendly vertical city list below
+// that (phones AND portrait tablets / landscape phones — the SVG's fixed
+// 1180×620 viewBox shrinks to unreadable label sizes under ~1024 px wide).
+// Both layouts are always in the DOM; CSS media queries toggle visibility
+// so the correct layout shows from first paint with no hydration flash. The animated globe canvas (HubBackground) sits behind
 // the diagram in the parent; per-city sub-trees keep their own Propylaea
 // aesthetic untouched.
 
@@ -512,8 +513,8 @@ export default function HubDiagram() {
 
       {/* Diagram / city list container */}
       <div className="px-5 pt-4 pb-6 md:px-14 md:py-8 flex-1 min-h-0 flex flex-col gap-4">
-        {/* ── Mobile: touch-friendly city list (<768 px) ── */}
-        <div className="md:hidden">
+        {/* ── Mobile / tablet: touch-friendly city list (<1024 px) ── */}
+        <div className="lg:hidden">
           <MobileHubList
             orderedCountries={orderedCountries}
             activeCity={activeCity}
@@ -528,8 +529,8 @@ export default function HubDiagram() {
           />
         </div>
 
-        {/* ── Desktop: neural-net SVG diagram (≥768 px) ── */}
-        <div className="hidden md:block" style={{ flex: 1, position: 'relative', minHeight: 0 }}>
+        {/* ── Desktop: neural-net SVG diagram (≥1024 px) ── */}
+        <div className="hidden lg:block" style={{ flex: 1, position: 'relative', minHeight: 0 }}>
           <svg
             viewBox={`0 0 ${VB_W} ${VB_H}`}
             preserveAspectRatio="xMinYMid meet"
@@ -744,7 +745,7 @@ export default function HubDiagram() {
 
         {/* Desktop search bar */}
         <div
-          className="hidden md:flex"
+          className="hidden lg:flex"
           style={{
             fontSize: 13,
             color: T.inkSoft,


### PR DESCRIPTION
## Problem

The `/property` hub was not optimised for smaller screens (reported against https://studentx.uk/property):

1. **Portrait tablets & landscape phones (768–1024 px)** got the desktop neural-net SVG city selector, which has a fixed 1180×620 viewBox. At those widths it scaled down to unreadable label sizes, and on landscape phones the UK/Ireland nodes were clipped off the bottom of the viewport.
2. **Phones (<768 px)** got the touch list correctly, but the animated globe background (`HubBackground`) sizes its sphere geometry from the canvas height — and the canvas stretched over the full scroll height of the tall city list. The dome degenerated into random dot noise scattered behind the list text, hurting readability.

## Fix

- **HubDiagram**: raise the desktop-SVG breakpoint from `md` (768 px) to `lg` (1024 px). Portrait tablets and landscape phones now get the touch-friendly vertical city list; the SVG only renders at widths where it is actually legible.
- **HubBackground**: pin the globe canvas in a `position: fixed` full-viewport frame instead of `absolute inset-0` over the scroll-height container. The dome is now always composed against the visible viewport regardless of content height, and stays in place as the list scrolls over it. (`sticky` can't work here — the page wrapper's `overflow: hidden` would become its scrollport.) Below `lg` the canvas drops to 30 % opacity so the list stays readable over the dots.

## Scope check (other screens audited at 390 px / 820 px / 844×390)

Home, Thessaloniki landing, results, quiz, about, landlord login, coming-soon city pages, and /student all render correctly on mobile — the hub was the only broken surface. The 200×200 GlobeLoader / CityGlobeLoader transition overlays are viewport-independent and fine.

## Verification

- Local screenshots at 390×844, 820×1180, 844×390, 1440×900: mobile/tablet show the clean list with subtle globe texture; desktop composition is pixel-equivalent to prod.
- `npm run lint` (only the pre-existing `cf/worker-entry.mjs` warning) and `npm run test` (258/258) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)