### PR TITLE
P2: subject page + test list

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,10 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // OpenNext/Cloudflare build output (gitignored, like .next/). Generated
+    // by `npm run cf:build`; not ours to lint. CI runs lint before build so
+    // it never sees this, but a local cf:build leaves it behind.
+    ".open-next/**",
     // Sub-agent worktrees (PR #53 gitignore). Each agent worktree is a
     // full copy of the repo including its own .next/ build artifacts;
     // without this ignore, eslint walks them and duplicates every

--- a/src/app/[locale]/student/ausom/semester-2/[subject]/page.js
+++ b/src/app/[locale]/student/ausom/semester-2/[subject]/page.js
@@ -1,0 +1,108 @@
+import { notFound } from 'next/navigation';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { Link } from '@/i18n/navigation';
+import TestCard from '@/components/practice/TestCard';
+import { getSubjectIndex, listSubjectsWithContent } from '@/lib/practice/content';
+
+// Content lives in the bundled manifest (no runtime fs on Workers), so we can
+// pre-render every subject that has an index.json. Unknown subjects still fall
+// through to notFound() below.
+export function generateStaticParams() {
+  return listSubjectsWithContent().map((subject) => ({ subject }));
+}
+
+export async function generateMetadata({ params }) {
+  const { subject } = await params;
+  const index = getSubjectIndex(subject);
+  if (!index) return {};
+  return { title: `${index.title} — AUSoM Practice Tests` };
+}
+
+export default async function SubjectPage({ params }) {
+  const { locale, subject } = await params;
+  setRequestLocale(locale);
+
+  const index = getSubjectIndex(subject);
+  if (!index) notFound();
+
+  const t = await getTranslations({ locale, namespace: 'student.practice' });
+
+  // Topic tests first, mock exams last, order otherwise preserved.
+  const tests = [...index.tests].sort((a, b) => {
+    const rank = (kind) => (kind === 'mock' ? 1 : 0);
+    return rank(a.kind) - rank(b.kind);
+  });
+
+  return (
+    <div>
+      <div style={{ maxWidth: 460, margin: '0 auto', padding: '32px 24px 0' }}>
+        <Link
+          href="/student/ausom/semester-2"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 6,
+            fontSize: 13,
+            fontWeight: 600,
+            color: 'rgba(10,37,64,0.45)',
+            textDecoration: 'none',
+            letterSpacing: '-0.1px',
+          }}
+        >
+          <span style={{ fontSize: 16, lineHeight: 1 }}>←</span> {t('back')}
+        </Link>
+      </div>
+
+      <section
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          padding: '48px 24px 64px',
+        }}
+      >
+        <div style={{ width: '100%', maxWidth: 460 }}>
+          <h1
+            style={{
+              fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+              fontWeight: 600,
+              fontSize: 34,
+              letterSpacing: '-0.02em',
+              lineHeight: 1.1,
+              color: '#0a2540',
+              margin: '0 0 28px',
+            }}
+          >
+            {index.title}
+          </h1>
+
+          {tests.length === 0 ? (
+            <p
+              style={{
+                fontSize: 15,
+                lineHeight: 1.5,
+                color: 'rgba(10,37,64,0.6)',
+                margin: 0,
+              }}
+            >
+              {t('emptyState')}
+            </p>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              {tests.map((test) => (
+                <TestCard
+                  key={test.id}
+                  href={`/student/ausom/semester-2/${subject}/${test.id}`}
+                  title={test.title}
+                  kind={test.kind}
+                  kindLabel={test.kind === 'mock' ? t('mockExam') : t('topicTest')}
+                  countLabel={t('questionCount', { count: test.questionCount })}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/[locale]/student/ausom/semester-2/page.js
+++ b/src/app/[locale]/student/ausom/semester-2/page.js
@@ -1,6 +1,7 @@
 import { setRequestLocale } from 'next-intl/server';
 import Link from 'next/link';
 import HubButton from '@/components/HubButton';
+import { listSubjectsWithContent } from '@/lib/practice/content';
 
 export function generateMetadata() {
   return { title: 'Semester 2 — AUSoM Practice Tests' };
@@ -12,15 +13,19 @@ export default async function Semester2Page({ params }) {
   return <Semester2Content />;
 }
 
+// Slugs are the single source of truth shared with content/practice/... and
+// PLAN.md §1. Subjects that have published tests (listSubjectsWithContent)
+// link to their subject page; the rest keep the "Soon" treatment.
 const SUBJECTS = [
-  { id: 'med-informatics', label: 'Medical Informatics' },
-  { id: 'anatomy-1',       label: 'Anatomy I' },
-  { id: 'histology',       label: 'General Histology' },
-  { id: 'biochemistry-1',  label: 'Biochemistry I' },
-  { id: 'physiology',      label: 'General Physiology' },
+  { id: 'medical-informatics', label: 'Medical Informatics' },
+  { id: 'anatomy-1',           label: 'Anatomy I' },
+  { id: 'general-histology',   label: 'General Histology' },
+  { id: 'biochemistry-1',      label: 'Biochemistry I' },
+  { id: 'general-physiology',  label: 'General Physiology' },
 ];
 
 function Semester2Content() {
+  const withContent = new Set(listSubjectsWithContent());
   return (
     <div>
       <div style={{ maxWidth: 460, margin: '0 auto', padding: '32px 24px 0' }}>
@@ -58,14 +63,23 @@ function Semester2Content() {
             maxWidth: 460,
           }}
         >
-          {SUBJECTS.map((s) => (
-            <HubButton
-              key={s.id}
-              label={s.label}
-              subtext=""
-              comingSoon
-            />
-          ))}
+          {SUBJECTS.map((s) =>
+            withContent.has(s.id) ? (
+              <HubButton
+                key={s.id}
+                label={s.label}
+                subtext=""
+                href={`/student/ausom/semester-2/${s.id}`}
+              />
+            ) : (
+              <HubButton
+                key={s.id}
+                label={s.label}
+                subtext=""
+                comingSoon
+              />
+            )
+          )}
         </div>
       </section>
     </div>

--- a/src/components/practice/TestCard.js
+++ b/src/components/practice/TestCard.js
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState } from 'react';
+import { Link } from '@/i18n/navigation';
+
+// Sibling of HubButton in the same "Stripe-modern" family — identical radius,
+// shadows, hover lift and tokens, extended with a kind badge + question count.
+// Mock exams render with an iris-tinted surface so they read as distinct.
+const ACCENT = '#635BFF';
+const INK = '#0a2540';
+
+function ArrowUpRight({ style }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+         strokeLinecap="round" strokeLinejoin="round" style={style}>
+      <path d="M7 17 17 7" />
+      <path d="M7 7h10v10" />
+    </svg>
+  );
+}
+
+export default function TestCard({ href, title, kind, kindLabel, countLabel }) {
+  const [hover, setHover] = useState(false);
+  const active = hover;
+  const isMock = kind === 'mock';
+
+  const cardStyle = {
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    textAlign: 'left',
+    borderRadius: 22,
+    padding: '22px 24px',
+    minHeight: 124,
+    textDecoration: 'none',
+    border: `1px solid ${
+      active ? ACCENT : isMock ? 'rgba(99,91,255,0.35)' : 'rgba(10,37,64,0.12)'
+    }`,
+    background: isMock ? '#f6f4ff' : '#ffffff',
+    color: INK,
+    boxShadow: active
+      ? '0 22px 48px -18px rgba(99,91,255,0.30), 0 6px 18px -10px rgba(10,37,64,0.10)'
+      : '0 1px 3px rgba(10,37,64,0.06), 0 10px 28px -12px rgba(10,37,64,0.16)',
+    transform: active ? 'translateY(-2px)' : 'translateY(0)',
+    transition: 'transform 220ms cubic-bezier(.2,.7,.2,1), box-shadow 220ms ease, border-color 220ms ease',
+    cursor: 'pointer',
+    overflow: 'hidden',
+  };
+
+  const arrowStyle = {
+    position: 'absolute',
+    top: 16,
+    right: 16,
+    width: 36,
+    height: 36,
+    borderRadius: 999,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: active ? ACCENT : 'rgba(10,37,64,0.05)',
+    color: active ? '#ffffff' : INK,
+    transform: active ? 'translate(2px,-2px)' : 'translate(0,0)',
+    transition: 'all 240ms cubic-bezier(.2,.7,.2,1)',
+    flexShrink: 0,
+  };
+
+  const badgeStyle = {
+    height: 24,
+    padding: '0 10px',
+    borderRadius: 999,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: isMock ? 'rgba(99,91,255,0.12)' : 'rgba(10,37,64,0.06)',
+    color: isMock ? ACCENT : 'rgba(10,37,64,0.55)',
+    fontSize: 11,
+    fontWeight: 600,
+    letterSpacing: '0.06em',
+    textTransform: 'uppercase',
+  };
+
+  const labelStyle = {
+    fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+    fontWeight: 600,
+    fontSize: 22,
+    letterSpacing: '-0.4px',
+    lineHeight: 1.1,
+    color: active ? ACCENT : INK,
+    transition: 'color 220ms ease',
+  };
+
+  return (
+    <Link
+      href={href}
+      style={cardStyle}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <span aria-hidden="true" style={arrowStyle}>
+        <ArrowUpRight style={{ width: 16, height: 16, strokeWidth: 2 }} />
+      </span>
+      <div style={{ flex: 1 }} />
+      <div>
+        <div style={labelStyle}>{title}</div>
+        <div
+          style={{
+            marginTop: 10,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            flexWrap: 'wrap',
+          }}
+        >
+          <span style={badgeStyle}>{kindLabel}</span>
+          <span style={{ fontSize: 13.5, lineHeight: 1.4, color: 'rgba(10,37,64,0.6)' }}>
+            {countLabel}
+          </span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -839,6 +839,13 @@
       "gateTitle": "Sign in to save listings",
       "gateBody": "Create a free student account to build your shortlist and pick up right where you left off — it takes about a minute.",
       "close": "Close"
+    },
+    "practice": {
+      "back": "Semester 2",
+      "topicTest": "Topic test",
+      "mockExam": "Mock exam",
+      "questionCount": "{count, plural, one {# question} other {# questions}}",
+      "emptyState": "Tests coming soon"
     }
   },
   "loaders": {


### PR DESCRIPTION
Stacked on #(P1 data-model branch). Implements PLAN.md prompt **P2**.

## Changes
- **Slug reconciliation** — semester-2 `SUBJECTS` ids now match PLAN §1 (`medical-informatics`, `general-histology`, `general-physiology`). Grepped first: the old ids existed only in this file, no public URLs affected.
- **New route** `…/semester-2/[subject]/page.js` — server component via `getSubjectIndex()`; unknown subject → `notFound()`. Header (title + locale-aware next-intl back link), one card per test (title, kind badge, question count). Mock exam sorted **last** and **visually distinct**. `generateStaticParams()` prerenders subjects with content.
- **Semester-2 page (minimal)** — subjects in `listSubjectsWithContent()` render as `HubButton` links; the rest keep `comingSoon`. No restyle.
- **Empty state** — subject with an index but zero tests shows "Tests coming soon".
- **TestCard** — sibling of `HubButton` in the Stripe-modern family (same radius/shadows/tokens) extended with the badge/count row.
- **next-intl** — `student.practice` chrome strings, en.json only.
- **eslint** — ignore `.open-next/**` (gitignored build artifact, mirrors existing `.next/**`).

## Acceptance
- `npm run validate:tests` ✅
- `npm run lint` ✅ (0 errors)
- `npm run cf:build` ✅ — both routes prerender as SSG; `anatomy-1` statically generated, unknown subjects fall through to `notFound()`.
- Semester page shows **Anatomy I** as a live link, the other four still **Soon**.
- 375px: reuses the existing mobile-verified container pattern; badge/count row is `flexWrap`-safe.

Note: `TestCard` links to `…/[subject]/[testId]`, which 404s until the P3 player route lands — expected at this stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)