### PR TITLE
P3: practice-test player (TestPlayer + question/feedback/score UI)

### DIFF
--- a/src/app/[locale]/student/ausom/semester-2/[subject]/[testId]/page.js
+++ b/src/app/[locale]/student/ausom/semester-2/[subject]/[testId]/page.js
@@ -1,0 +1,38 @@
+import { notFound } from 'next/navigation';
+import { setRequestLocale } from 'next-intl/server';
+import TestPlayer from '@/components/practice/TestPlayer';
+import { getSubjectIndex, getTest, listSubjectsWithContent } from '@/lib/practice/content';
+
+// Every test lives in the bundled manifest (no runtime fs on Workers), so both
+// the [subject] and [testId] levels can be fully pre-rendered. The parent
+// [subject]/page.js enumerates subjects; this level enumerates that subject's
+// tests. Unknown subject/test still falls through to notFound() below.
+export function generateStaticParams({ params }) {
+  // In a deeper dynamic segment, generateStaticParams receives the parent's
+  // already-resolved params. Fall back to scanning every subject if absent.
+  const subjects = params?.subject ? [params.subject] : listSubjectsWithContent();
+  return subjects.flatMap((subject) => {
+    const index = getSubjectIndex(subject);
+    return (index?.tests ?? []).map((test) => ({ subject, testId: test.id }));
+  });
+}
+
+export async function generateMetadata({ params }) {
+  const { subject, testId } = await params;
+  const test = getTest(subject, testId);
+  if (!test) return {};
+  return { title: `${test.title} — AUSoM Practice Tests` };
+}
+
+export default async function TestPage({ params }) {
+  const { locale, subject, testId } = await params;
+  setRequestLocale(locale);
+
+  const test = getTest(subject, testId);
+  if (!test) notFound();
+
+  // The player is a client component: it reads ?review client-side and owns the
+  // attempt state machine. The plain JSON test object is serializable, so it
+  // crosses the server→client boundary as-is.
+  return <TestPlayer test={test} subject={subject} />;
+}

--- a/src/components/practice/FeedbackPanel.js
+++ b/src/components/practice/FeedbackPanel.js
@@ -1,0 +1,138 @@
+'use client';
+
+// Explanation panel shown after a question is answered (and in review mode).
+//
+// Render rules (PLAN.md P3):
+//   - explanation.image set  → screenshot (max-height ~320px, click opens a
+//     lightbox), then caption (normal text) and source (muted, smaller).
+//   - explanation.text set   → the text.
+//   - image and text are NOT mutually exclusive — show both when both are set,
+//     image first, text below.
+// `result` ('correct' | 'incorrect' | null) drives an optional status header;
+// null in the admin deep-link review where there is no chosen answer.
+
+const INK = '#0a2540';
+
+const SUCCESS = { text: '#0f7a3d', bg: 'rgba(22,163,74,0.12)', border: 'rgba(22,163,74,0.32)' };
+const DANGER = { text: '#b42318', bg: 'rgba(220,38,38,0.10)', border: 'rgba(220,38,38,0.30)' };
+
+function CheckIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor"
+         strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  );
+}
+
+function CrossIcon() {
+  return (
+    <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor"
+         strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M18 6 6 18" />
+      <path d="m6 6 12 12" />
+    </svg>
+  );
+}
+
+export default function FeedbackPanel({ explanation, result, onZoom, t }) {
+  const { image, imageAlt, caption, source, text } = explanation || {};
+  const tone = result === 'correct' ? SUCCESS : result === 'incorrect' ? DANGER : null;
+
+  return (
+    <div
+      style={{
+        marginTop: 18,
+        borderRadius: 18,
+        border: '1px solid rgba(10,37,64,0.08)',
+        background: '#f6f4ff',
+        padding: 18,
+      }}
+    >
+      {tone && (
+        <div
+          role="status"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 7,
+            padding: '5px 12px',
+            borderRadius: 999,
+            background: tone.bg,
+            border: `1px solid ${tone.border}`,
+            color: tone.text,
+            fontWeight: 600,
+            fontSize: 13,
+            marginBottom: 14,
+          }}
+        >
+          {result === 'correct' ? <CheckIcon /> : <CrossIcon />}
+          {result === 'correct' ? t('resultCorrect') : t('resultIncorrect')}
+        </div>
+      )}
+
+      {image && (
+        <figure style={{ margin: 0 }}>
+          <button
+            type="button"
+            onClick={() => onZoom(image, imageAlt || '')}
+            aria-label={t('viewFullSize')}
+            style={{
+              display: 'block',
+              width: '100%',
+              padding: 0,
+              border: '1px solid rgba(10,37,64,0.10)',
+              borderRadius: 12,
+              overflow: 'hidden',
+              background: '#ffffff',
+              cursor: 'zoom-in',
+              lineHeight: 0,
+            }}
+          >
+            <img
+              src={image}
+              alt={imageAlt || ''}
+              style={{
+                display: 'block',
+                width: '100%',
+                maxHeight: 320,
+                objectFit: 'contain',
+                background: '#ffffff',
+              }}
+            />
+          </button>
+          {caption && (
+            <figcaption
+              style={{
+                margin: '12px 0 0',
+                fontSize: 14.5,
+                lineHeight: 1.5,
+                color: INK,
+              }}
+            >
+              {caption}
+            </figcaption>
+          )}
+          {source && (
+            <p style={{ margin: '6px 0 0', fontSize: 12.5, color: 'rgba(10,37,64,0.5)' }}>
+              {source}
+            </p>
+          )}
+        </figure>
+      )}
+
+      {text && (
+        <p
+          style={{
+            margin: image ? '14px 0 0' : 0,
+            fontSize: 14.5,
+            lineHeight: 1.55,
+            color: INK,
+          }}
+        >
+          {text}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/practice/Lightbox.js
+++ b/src/components/practice/Lightbox.js
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+// Full-screen image lightbox for FeedbackPanel screenshots. Inline-styled to
+// stay in the practice-test "Stripe-modern" family. Closes on Escape and on a
+// click outside the image; locks body scroll and restores focus on unmount.
+
+export default function Lightbox({ src, alt, label, closeLabel, onClose }) {
+  const closeBtnRef = useRef(null);
+
+  useEffect(() => {
+    const previouslyFocused = document.activeElement;
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    closeBtnRef.current?.focus();
+
+    function onKeyDown(e) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    }
+    // Capture phase so Escape closes the lightbox before any other listener.
+    window.addEventListener('keydown', onKeyDown, true);
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown, true);
+      document.body.style.overflow = prevOverflow;
+      if (previouslyFocused instanceof HTMLElement) previouslyFocused.focus();
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={label}
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 80,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+        background: 'rgba(10,37,64,0.82)',
+        backdropFilter: 'blur(2px)',
+      }}
+    >
+      <button
+        ref={closeBtnRef}
+        type="button"
+        onClick={onClose}
+        aria-label={closeLabel}
+        style={{
+          position: 'absolute',
+          top: 16,
+          right: 16,
+          width: 44,
+          height: 44,
+          borderRadius: 999,
+          border: 'none',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'rgba(255,255,255,0.14)',
+          color: '#ffffff',
+          cursor: 'pointer',
+        }}
+      >
+        <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor"
+             strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M18 6 6 18" />
+          <path d="m6 6 12 12" />
+        </svg>
+      </button>
+
+      {/* Stop propagation so a click on the image itself never closes. */}
+      <img
+        src={src}
+        alt={alt}
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          maxWidth: '100%',
+          maxHeight: '100%',
+          objectFit: 'contain',
+          borderRadius: 12,
+          boxShadow: '0 24px 60px -20px rgba(10,37,64,0.6)',
+          cursor: 'default',
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/practice/PlayerButton.js
+++ b/src/components/practice/PlayerButton.js
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState } from 'react';
+
+const ACCENT = '#635BFF';
+const INK = '#0a2540';
+
+// Iris-fill CTA (Next question / See results / Retry test) — same lift + shadow
+// language as HubButton, sized as a pill button.
+export function PrimaryButton({ children, onClick, type = 'button' }) {
+  const [hover, setHover] = useState(false);
+  return (
+    <button
+      type={type}
+      onClick={onClick}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        appearance: 'none',
+        border: 'none',
+        borderRadius: 14,
+        padding: '14px 24px',
+        background: ACCENT,
+        color: '#ffffff',
+        fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+        fontWeight: 600,
+        fontSize: 15.5,
+        letterSpacing: '-0.01em',
+        cursor: 'pointer',
+        boxShadow: hover
+          ? '0 18px 40px -16px rgba(99,91,255,0.55), 0 6px 16px -10px rgba(10,37,64,0.18)'
+          : '0 10px 26px -14px rgba(99,91,255,0.45)',
+        transform: hover ? 'translateY(-1px)' : 'translateY(0)',
+        transition: 'transform 200ms cubic-bezier(.2,.7,.2,1), box-shadow 200ms ease',
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+// Quiet text button (Report an issue / Back to results).
+export function TextButton({ children, onClick, ariaLabel }) {
+  const [hover, setHover] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        appearance: 'none',
+        background: 'none',
+        border: 'none',
+        padding: 4,
+        color: 'rgba(10,37,64,0.55)',
+        fontSize: 13.5,
+        fontWeight: 600,
+        cursor: 'pointer',
+        textDecoration: hover ? 'underline' : 'none',
+        textUnderlineOffset: 3,
+        transition: 'color 160ms ease',
+        ...(hover ? { color: INK } : null),
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/practice/QuestionCard.js
+++ b/src/components/practice/QuestionCard.js
@@ -1,0 +1,172 @@
+'use client';
+
+import { useState } from 'react';
+import { prettifyTopic } from '@/lib/practice/format';
+
+// Stem + options for one question. Reused in three places:
+//   - live ANSWERING/ANSWERED states (locked once answered)
+//   - the post-test review of a wrong question (locked, chosen set)
+//   - the admin ?review deep-link (locked, chosen = null)
+//
+// When `locked`, options stop accepting clicks and reveal correctness: the
+// correct option reads success (green), and a chosen-wrong option reads danger
+// (red). Visible "Correct answer" / "Your answer" tags carry the same meaning
+// without relying on colour alone.
+
+const INK = '#0a2540';
+const ACCENT = '#635BFF';
+
+const SUCCESS = { text: '#0f7a3d', bg: 'rgba(22,163,74,0.10)', border: 'rgba(22,163,74,0.45)', solid: '#16a34a' };
+const DANGER = { text: '#b42318', bg: 'rgba(220,38,38,0.08)', border: 'rgba(220,38,38,0.45)', solid: '#dc2626' };
+
+function AnswerTag({ tone, children }) {
+  return (
+    <span
+      style={{
+        marginLeft: 'auto',
+        flexShrink: 0,
+        padding: '3px 9px',
+        borderRadius: 999,
+        background: tone.bg,
+        color: tone.text,
+        border: `1px solid ${tone.border}`,
+        fontSize: 11,
+        fontWeight: 600,
+        letterSpacing: '0.02em',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+export default function QuestionCard({ question, chosen, locked, onSelect, t }) {
+  const [hover, setHover] = useState(-1);
+
+  return (
+    <div>
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          height: 24,
+          padding: '0 11px',
+          borderRadius: 999,
+          background: 'rgba(99,91,255,0.10)',
+          color: ACCENT,
+          fontSize: 11,
+          fontWeight: 600,
+          letterSpacing: '0.06em',
+          textTransform: 'uppercase',
+        }}
+      >
+        {prettifyTopic(question.topic)}
+      </span>
+
+      <h2
+        style={{
+          fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+          fontWeight: 600,
+          fontSize: 22,
+          letterSpacing: '-0.01em',
+          lineHeight: 1.3,
+          color: INK,
+          margin: '16px 0 22px',
+        }}
+      >
+        {question.stem}
+      </h2>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {question.displayOptions.map((opt, i) => {
+          const isCorrect = locked && i === question.correct;
+          const isChosenWrong = locked && i === chosen && i !== question.correct;
+          const isHover = !locked && hover === i;
+
+          let border = 'rgba(10,37,64,0.14)';
+          let background = '#ffffff';
+          let color = INK;
+          let badgeBg = 'rgba(10,37,64,0.06)';
+          let badgeColor = INK;
+          let opacity = 1;
+
+          if (isCorrect) {
+            border = SUCCESS.border;
+            background = SUCCESS.bg;
+            color = INK;
+            badgeBg = SUCCESS.solid;
+            badgeColor = '#ffffff';
+          } else if (isChosenWrong) {
+            border = DANGER.border;
+            background = DANGER.bg;
+            color = INK;
+            badgeBg = DANGER.solid;
+            badgeColor = '#ffffff';
+          } else if (locked) {
+            // other options in a locked card recede
+            opacity = 0.6;
+          } else if (isHover) {
+            border = ACCENT;
+            background = '#f6f4ff';
+          }
+
+          return (
+            <button
+              key={`${opt.originalIndex}-${i}`}
+              type="button"
+              disabled={locked}
+              // While answering, expose the 1–5 position to screen readers (it
+              // backs the number-key shortcut); when locked, let the visible
+              // option + answer tag form the accessible name instead.
+              aria-label={locked ? undefined : `${t('optionPosition', { number: i + 1 })}: ${opt.text}`}
+              onClick={() => !locked && onSelect?.(i)}
+              onMouseEnter={() => setHover(i)}
+              onMouseLeave={() => setHover(-1)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 13,
+                width: '100%',
+                textAlign: 'left',
+                padding: '14px 16px',
+                borderRadius: 14,
+                border: `1.5px solid ${border}`,
+                background,
+                color,
+                opacity,
+                cursor: locked ? 'default' : 'pointer',
+                transition: 'border-color 160ms ease, background 160ms ease',
+                fontSize: 15.5,
+                lineHeight: 1.4,
+              }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  flexShrink: 0,
+                  width: 28,
+                  height: 28,
+                  borderRadius: 999,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  background: badgeBg,
+                  color: badgeColor,
+                  fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+                  fontSize: 13.5,
+                  fontWeight: 700,
+                }}
+              >
+                {i + 1}
+              </span>
+              <span style={{ flex: 1, minWidth: 0, overflowWrap: 'anywhere' }}>{opt.text}</span>
+              {isCorrect && <AnswerTag tone={SUCCESS}>{t('correctAnswer')}</AnswerTag>}
+              {isChosenWrong && <AnswerTag tone={DANGER}>{t('yourAnswer')}</AnswerTag>}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/practice/ScoreSummary.js
+++ b/src/components/practice/ScoreSummary.js
@@ -1,0 +1,218 @@
+'use client';
+
+import { useState } from 'react';
+import { prettifyTopic } from '@/lib/practice/format';
+import { PrimaryButton } from './PlayerButton';
+
+// FINISHED state. Shows the overall score, a per-topic breakdown, and a list of
+// wrongly answered questions; clicking one opens it in read-only review (handled
+// by the parent via onReview). "Retry test" rebuilds a fresh shuffled attempt.
+
+const INK = '#0a2540';
+const ACCENT = '#635BFF';
+const DANGER = '#dc2626';
+
+function topicBreakdown(questions, answers) {
+  const map = new Map();
+  questions.forEach((q, i) => {
+    const entry = map.get(q.topic) || { topic: q.topic, correct: 0, total: 0 };
+    entry.total += 1;
+    if (answers[i] === q.correct) entry.correct += 1;
+    map.set(q.topic, entry);
+  });
+  return [...map.values()];
+}
+
+function WrongRow({ position, stem, onClick, t }) {
+  const [hover, setHover] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`${t('review.label')}: ${stem}`}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        width: '100%',
+        textAlign: 'left',
+        padding: '13px 15px',
+        borderRadius: 14,
+        border: `1px solid ${hover ? ACCENT : 'rgba(10,37,64,0.12)'}`,
+        background: '#ffffff',
+        cursor: 'pointer',
+        transition: 'border-color 160ms ease',
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          flexShrink: 0,
+          width: 26,
+          height: 26,
+          borderRadius: 999,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'rgba(220,38,38,0.10)',
+          color: DANGER,
+          fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+          fontSize: 13,
+          fontWeight: 700,
+        }}
+      >
+        {position}
+      </span>
+      <span
+        style={{
+          flex: 1,
+          fontSize: 14.5,
+          lineHeight: 1.4,
+          color: INK,
+          display: '-webkit-box',
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: 'vertical',
+          overflow: 'hidden',
+        }}
+      >
+        {stem}
+      </span>
+      <span aria-hidden="true" style={{ flexShrink: 0, color: 'rgba(10,37,64,0.4)' }}>
+        <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor"
+             strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="m9 18 6-6-6-6" />
+        </svg>
+      </span>
+    </button>
+  );
+}
+
+export default function ScoreSummary({ attempt, answers, t, onReview, onRetry }) {
+  const questions = attempt.questions;
+  const total = questions.length;
+  const score = questions.reduce((acc, q, i) => acc + (answers[i] === q.correct ? 1 : 0), 0);
+  const percent = total === 0 ? 0 : Math.round((score / total) * 100);
+
+  const topics = topicBreakdown(questions, answers);
+  const wrong = questions
+    .map((q, i) => ({ q, i }))
+    .filter(({ q, i }) => answers[i] !== q.correct);
+
+  return (
+    <div>
+      <h1
+        style={{
+          fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+          fontWeight: 600,
+          fontSize: 30,
+          letterSpacing: '-0.02em',
+          lineHeight: 1.1,
+          color: INK,
+          margin: '0 0 20px',
+        }}
+      >
+        {t('results.title')}
+      </h1>
+
+      {/* Score card */}
+      <div
+        style={{
+          borderRadius: 22,
+          border: '1px solid rgba(99,91,255,0.25)',
+          background: '#f6f4ff',
+          padding: '26px 24px',
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 14,
+          boxShadow: '0 10px 28px -16px rgba(10,37,64,0.16)',
+        }}
+      >
+        <span
+          style={{
+            fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+            fontWeight: 700,
+            fontSize: 40,
+            letterSpacing: '-0.02em',
+            color: ACCENT,
+          }}
+        >
+          {t('results.scoreValue', { score, total })}
+        </span>
+        <span style={{ fontSize: 18, fontWeight: 600, color: 'rgba(10,37,64,0.55)' }}>
+          {t('results.percent', { percent })}
+        </span>
+      </div>
+
+      {/* Per-topic breakdown */}
+      <section style={{ marginTop: 28 }}>
+        <h2 style={sectionHeading}>{t('results.byTopic')}</h2>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          {topics.map((row) => (
+            <div
+              key={row.topic}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 12,
+                padding: '11px 15px',
+                borderRadius: 12,
+                border: '1px solid rgba(10,37,64,0.08)',
+                background: '#ffffff',
+              }}
+            >
+              <span style={{ fontSize: 14.5, color: INK }}>{prettifyTopic(row.topic)}</span>
+              <span
+                style={{
+                  fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+                  fontSize: 14.5,
+                  fontWeight: 600,
+                  color: row.correct === row.total ? '#0f7a3d' : 'rgba(10,37,64,0.6)',
+                }}
+              >
+                {t('results.topicScore', { correct: row.correct, total: row.total })}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Wrong-answer review list */}
+      <section style={{ marginTop: 28 }}>
+        <h2 style={sectionHeading}>{t('results.reviewMistakes')}</h2>
+        {wrong.length === 0 ? (
+          <p style={{ margin: 0, fontSize: 14.5, color: 'rgba(10,37,64,0.6)' }}>
+            {t('results.allCorrect')}
+          </p>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {wrong.map(({ q, i }) => (
+              <WrongRow
+                key={q.id}
+                position={i + 1}
+                stem={q.stem}
+                onClick={() => onReview(i)}
+                t={t}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <div style={{ marginTop: 32 }}>
+        <PrimaryButton onClick={onRetry}>{t('results.retry')}</PrimaryButton>
+      </div>
+    </div>
+  );
+}
+
+const sectionHeading = {
+  fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+  fontWeight: 600,
+  fontSize: 16,
+  letterSpacing: '-0.01em',
+  color: INK,
+  margin: '0 0 12px',
+};

--- a/src/components/practice/TestPlayer.js
+++ b/src/components/practice/TestPlayer.js
@@ -1,0 +1,397 @@
+'use client';
+
+import { Suspense, useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/navigation';
+import QuestionCard from './QuestionCard';
+import FeedbackPanel from './FeedbackPanel';
+import ScoreSummary from './ScoreSummary';
+import Lightbox from './Lightbox';
+import { PrimaryButton, TextButton } from './PlayerButton';
+
+const ACCENT = '#635BFF';
+const COLUMN = 560;
+
+/* ---------- attempt construction (pure, never mutates the loaded JSON) ---------- */
+
+// Fisher-Yates on a *copy* — the source array is untouched.
+function shuffle(arr) {
+  const a = arr.slice();
+  for (let i = a.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+// Turn a loaded question into the display form the player renders: options
+// carry their original index so `correct` can be re-mapped after a shuffle.
+function toDisplayQuestion(q, originalIndex, shuffleOptions) {
+  const pairs = q.options.map((text, i) => ({ text, originalIndex: i }));
+  const displayOptions = shuffleOptions ? shuffle(pairs) : pairs;
+  const correct = displayOptions.findIndex((o) => o.originalIndex === q.correct);
+  return {
+    id: q.id,
+    type: q.type,
+    stem: q.stem,
+    topic: q.topic,
+    explanation: q.explanation,
+    displayOptions,
+    correct,
+    originalIndex,
+  };
+}
+
+// A fresh attempt. The first render shuffles question order only (options stay
+// in authored order); Retry passes shuffleOptions=true to also scramble each
+// question's options — defeating positional memory on a repeat run.
+function buildAttempt(test, shuffleOptions = false) {
+  const order = shuffle(test.questions.map((_, i) => i));
+  const questions = order.map((origIdx) =>
+    toDisplayQuestion(test.questions[origIdx], origIdx, shuffleOptions),
+  );
+  return { order, questions };
+}
+
+/* ---------- layout helpers ---------- */
+
+function BackRow({ href, onClick, label }) {
+  const style = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 6,
+    fontSize: 13,
+    fontWeight: 600,
+    color: 'rgba(10,37,64,0.45)',
+    textDecoration: 'none',
+    background: 'none',
+    border: 'none',
+    padding: 0,
+    cursor: 'pointer',
+    letterSpacing: '-0.1px',
+  };
+  const inner = (
+    <>
+      <span aria-hidden="true" style={{ fontSize: 16, lineHeight: 1 }}>
+        ←
+      </span>{' '}
+      {label}
+    </>
+  );
+  if (href) {
+    return (
+      <Link href={href} style={style}>
+        {inner}
+      </Link>
+    );
+  }
+  return (
+    <button type="button" onClick={onClick} style={style}>
+      {inner}
+    </button>
+  );
+}
+
+function Shell({ back, children }) {
+  return (
+    <div>
+      <div style={{ maxWidth: COLUMN, margin: '0 auto', padding: '32px 24px 0' }}>{back}</div>
+      <section
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          padding: '28px 24px 64px',
+        }}
+      >
+        <div style={{ width: '100%', maxWidth: COLUMN }}>{children}</div>
+      </section>
+    </div>
+  );
+}
+
+function PlayerSkeleton() {
+  const bar = (width, height) => (
+    <div style={{ width, height, borderRadius: 8, background: 'rgba(10,37,64,0.06)' }} />
+  );
+  return (
+    <div aria-hidden="true">
+      <div style={{ maxWidth: COLUMN, margin: '0 auto', padding: '32px 24px 0' }}>{bar(90, 14)}</div>
+      <section
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          padding: '28px 24px 64px',
+        }}
+      >
+        <div style={{ width: '100%', maxWidth: COLUMN, display: 'flex', flexDirection: 'column', gap: 14 }}>
+          {bar('40%', 14)}
+          {bar('90%', 26)}
+          {bar('100%', 54)}
+          {bar('100%', 54)}
+          {bar('100%', 54)}
+          {bar('100%', 54)}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+/* ---------- player ---------- */
+
+// `onReportIssue` is the stable hook P5 will pass to wire up the ReportIssueModal.
+// In P3 it is left undefined, so the "Report an issue" button renders but is inert.
+export default function TestPlayer(props) {
+  return (
+    <Suspense fallback={<PlayerSkeleton />}>
+      <TestPlayerInner {...props} />
+    </Suspense>
+  );
+}
+
+function TestPlayerInner({ test, subject, onReportIssue }) {
+  const t = useTranslations('student.practice.player');
+  const searchParams = useSearchParams();
+  const reviewId = searchParams.get('review');
+
+  const listHref = `/student/ausom/semester-2/${subject}`;
+
+  // Shared lightbox across every mode.
+  const [lightbox, setLightbox] = useState(null); // { src, alt } | null
+  const openLightbox = useCallback((src, alt) => setLightbox({ src, alt }), []);
+  const closeLightbox = useCallback(() => setLightbox(null), []);
+
+  // Live attempt state.
+  const [attempt, setAttempt] = useState(() => buildAttempt(test));
+  const [answers, setAnswers] = useState(() => test.questions.map(() => null));
+  const [current, setCurrent] = useState(0);
+  const [finished, setFinished] = useState(false);
+  const [reviewIndex, setReviewIndex] = useState(null);
+
+  // The attempt is built with Math.random (shuffle), so it MUST NOT render
+  // during SSR — server and client would disagree and React would throw a
+  // hydration mismatch. Gate the randomized UI behind a client-only mount flag;
+  // the server (and the first client paint) render the deterministic skeleton.
+  // The set-on-mount is the whole point here (flip to client rendering), so the
+  // set-state-in-effect rule is intentionally disabled for this one line.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
+
+  // Admin deep-link: ?review=<questionId> → read-only review of that question.
+  const deepLinkIndex = reviewId ? test.questions.findIndex((q) => q.id === reviewId) : -1;
+  const deepLinkQuestion = deepLinkIndex >= 0 ? test.questions[deepLinkIndex] : null;
+
+  const total = attempt.questions.length;
+  const aq = attempt.questions[current];
+  const answered = answers[current] != null;
+  const isLast = current === total - 1;
+  const answeredCount = answers.filter((a) => a != null).length;
+
+  const handleSelect = useCallback(
+    (displayIdx) => {
+      setAnswers((prev) => {
+        if (prev[current] != null) return prev; // locked after first pick
+        if (displayIdx < 0 || displayIdx >= attempt.questions[current].displayOptions.length) {
+          return prev;
+        }
+        const next = prev.slice();
+        next[current] = displayIdx;
+        return next;
+      });
+    },
+    [current, attempt],
+  );
+
+  const handleAdvance = useCallback(() => {
+    if (current < total - 1) setCurrent(current + 1);
+    else setFinished(true);
+  }, [current, total]);
+
+  const handleRetry = useCallback(() => {
+    setAttempt(buildAttempt(test, true));
+    setAnswers(test.questions.map(() => null));
+    setCurrent(0);
+    setFinished(false);
+    setReviewIndex(null);
+  }, [test]);
+
+  // Keyboard: 1–5 selects an option while ANSWERING; Enter advances once
+  // ANSWERED. Disabled in finished / review / lightbox-open states.
+  useEffect(() => {
+    if (!mounted || finished || deepLinkQuestion || lightbox) return undefined;
+    function onKey(e) {
+      const el = e.target;
+      if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) {
+        return;
+      }
+      if (answers[current] == null) {
+        if (e.key >= '1' && e.key <= '5') {
+          const idx = Number(e.key) - 1;
+          if (idx < attempt.questions[current].displayOptions.length) {
+            e.preventDefault();
+            handleSelect(idx);
+          }
+        }
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        handleAdvance();
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [mounted, finished, deepLinkQuestion, lightbox, answers, current, attempt, handleSelect, handleAdvance]);
+
+  const lightboxEl = lightbox ? (
+    <Lightbox
+      src={lightbox.src}
+      alt={lightbox.alt}
+      label={t('lightboxLabel')}
+      closeLabel={t('closeLightbox')}
+      onClose={closeLightbox}
+    />
+  ) : null;
+
+  // Until mounted on the client, render the deterministic skeleton (see the
+  // mount-flag note above) so SSR and hydration agree.
+  if (!mounted) return <PlayerSkeleton />;
+
+  // 1) Admin deep-link review (read-only, no chosen answer).
+  if (deepLinkQuestion) {
+    const dq = toDisplayQuestion(deepLinkQuestion, deepLinkIndex, false);
+    return (
+      <>
+        <Shell back={<BackRow href={listHref} label={t('review.backToTests')} />}>
+          <QuestionCard question={dq} chosen={null} locked t={t} />
+          <FeedbackPanel explanation={dq.explanation} result={null} onZoom={openLightbox} t={t} />
+        </Shell>
+        {lightboxEl}
+      </>
+    );
+  }
+
+  // 2) Reviewing a wrong answer from the score summary (read-only).
+  if (finished && reviewIndex != null) {
+    const rq = attempt.questions[reviewIndex];
+    const result = answers[reviewIndex] === rq.correct ? 'correct' : 'incorrect';
+    return (
+      <>
+        <Shell back={<BackRow onClick={() => setReviewIndex(null)} label={t('review.backToResults')} />}>
+          <QuestionCard question={rq} chosen={answers[reviewIndex]} locked t={t} />
+          <FeedbackPanel explanation={rq.explanation} result={result} onZoom={openLightbox} t={t} />
+        </Shell>
+        {lightboxEl}
+      </>
+    );
+  }
+
+  // 3) FINISHED — score summary.
+  if (finished) {
+    return (
+      <>
+        <Shell back={<BackRow href={listHref} label={t('review.backToTests')} />}>
+          <ScoreSummary
+            attempt={attempt}
+            answers={answers}
+            t={t}
+            onReview={setReviewIndex}
+            onRetry={handleRetry}
+          />
+        </Shell>
+        {lightboxEl}
+      </>
+    );
+  }
+
+  // 4) ANSWERING / ANSWERED.
+  return (
+    <>
+      <Shell back={<BackRow href={listHref} label={t('review.backToTests')} />}>
+        <div style={{ marginBottom: 24 }}>
+          <div style={{ marginBottom: 10 }}>
+            <span
+              style={{
+                fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+                fontWeight: 600,
+                fontSize: 14,
+                letterSpacing: '-0.01em',
+                color: 'rgba(10,37,64,0.55)',
+              }}
+            >
+              {t('progress', { current: current + 1, total })}
+            </span>
+          </div>
+          <div
+            role="progressbar"
+            aria-label={t('progressBarLabel')}
+            aria-valuenow={answeredCount}
+            aria-valuemin={0}
+            aria-valuemax={total}
+            style={{
+              height: 6,
+              borderRadius: 999,
+              background: 'rgba(10,37,64,0.08)',
+              overflow: 'hidden',
+            }}
+          >
+            <div
+              style={{
+                height: '100%',
+                width: `${(answeredCount / total) * 100}%`,
+                background: ACCENT,
+                borderRadius: 999,
+                transition: 'width 280ms cubic-bezier(.2,.7,.2,1)',
+              }}
+            />
+          </div>
+        </div>
+
+        <QuestionCard
+          question={aq}
+          chosen={answers[current]}
+          locked={answered}
+          onSelect={handleSelect}
+          t={t}
+        />
+
+        {answered && (
+          <FeedbackPanel
+            explanation={aq.explanation}
+            result={answers[current] === aq.correct ? 'correct' : 'incorrect'}
+            onZoom={openLightbox}
+            t={t}
+          />
+        )}
+
+        <div
+          style={{
+            marginTop: 26,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 12,
+            flexWrap: 'wrap',
+          }}
+        >
+          <TextButton
+            onClick={() =>
+              onReportIssue?.({ subject, testId: test.id, questionId: aq.id, version: test.version })
+            }
+          >
+            {t('reportIssue')}
+          </TextButton>
+          {answered && (
+            <PrimaryButton onClick={handleAdvance}>
+              {isLast ? t('seeResults') : t('next')}
+            </PrimaryButton>
+          )}
+        </div>
+      </Shell>
+      {lightboxEl}
+    </>
+  );
+}

--- a/src/lib/practice/format.js
+++ b/src/lib/practice/format.js
@@ -1,0 +1,13 @@
+/** Display helpers for practice-test content (presentation only). */
+
+/**
+ * Turn a topic slug into a readable label: "upper-limb" → "Upper limb".
+ * Pure cosmetic — the slug itself stays the source of truth in the JSON.
+ * @param {string} slug
+ * @returns {string}
+ */
+export function prettifyTopic(slug) {
+  if (!slug) return '';
+  const spaced = slug.replace(/[-_]+/g, ' ').trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -845,7 +845,37 @@
       "topicTest": "Topic test",
       "mockExam": "Mock exam",
       "questionCount": "{count, plural, one {# question} other {# questions}}",
-      "emptyState": "Tests coming soon"
+      "emptyState": "Tests coming soon",
+      "player": {
+        "progress": "Question {current} of {total}",
+        "progressBarLabel": "Test progress",
+        "reportIssue": "Report an issue",
+        "next": "Next question",
+        "seeResults": "See results",
+        "resultCorrect": "Correct",
+        "resultIncorrect": "Not quite",
+        "correctAnswer": "Correct answer",
+        "yourAnswer": "Your answer",
+        "optionPosition": "Option {number}",
+        "viewFullSize": "View full-size image",
+        "lightboxLabel": "Explanation image",
+        "closeLightbox": "Close image",
+        "results": {
+          "title": "Your results",
+          "scoreValue": "{score} / {total}",
+          "percent": "{percent}%",
+          "byTopic": "By topic",
+          "topicScore": "{correct} / {total}",
+          "reviewMistakes": "Review your mistakes",
+          "allCorrect": "Perfect score — nothing to review.",
+          "retry": "Retry test"
+        },
+        "review": {
+          "label": "Review",
+          "backToResults": "Back to results",
+          "backToTests": "Back to tests"
+        }
+      }
     }
   },
   "loaders": {


### PR DESCRIPTION
Implements **P3** of the practice-tests plan — the interactive test player for AUSoM Semester 2.

## What's here
- **Route** `src/app/[locale]/student/ausom/semester-2/[subject]/[testId]/page.js` — server component loads the test via `getTest()` (unknown → `notFound()`) and hands it to the client `TestPlayer`. `generateStaticParams` at **both** the `[subject]` and `[testId]` levels → both routes are SSG (`anatomy-1/upper-limb` and `anatomy-1/mock-exam` in the prerender manifest).
- **`TestPlayer`** — `ANSWERING → ANSWERED → FINISHED` state machine. Fisher-Yates shuffle on copies (question order on first render; question **and** option order on Retry, remapping `correct` each time — never mutates the loaded JSON). Keyboard `1–5` selects / `Enter` advances. `?review=<questionId>` opens that question read-only (for P6's admin deep-link). Inert "Report an issue" button wired to a stable `onReportIssue` prop for P5.
- **`QuestionCard` / `FeedbackPanel` / `ScoreSummary` / `Lightbox` / `PlayerButton`** — wrong answer shows danger + success, correct shows success only; FeedbackPanel renders image (≤320px, click → lightbox that closes on Escape/outside-click) + caption + source and/or text (both when both set); score X/N + %, per-topic breakdown, wrong-question review.
- Randomized UI is gated behind a client-only mount flag so SSR and hydration agree (fixes a `Math.random` hydration mismatch caught during verification).
- All UI chrome strings go through next-intl (`student.practice.player`); test content stays English-only JSON.

## Styling
Matches the HubButton Stripe-modern family — iris `#635BFF`, ink `#0a2540`, parchment `#f6f4ff`, Inter/Inter Tight, radius 22, soft shadows.

## Verification
- `npm run validate:tests`, `npm run lint` (0 errors), and `npm run cf:build` all pass.
- Playwright walk of **both** fixtures — 29 checks (wrong/correct states, FeedbackPanel, lightbox open + Escape + outside-click, retry-from-zero, `?review=q01` read-only, keyboard 1–5/Enter, results + per-topic + review, mock-exam run-through, 375px no-overflow) — all pass with **no console errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)