### PR TITLE
feat(practice): persist test progress via swappable ProgressStore

### DIFF
--- a/src/app/[locale]/student/ausom/semester-2/[subject]/page.js
+++ b/src/app/[locale]/student/ausom/semester-2/[subject]/page.js
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 import { Link } from '@/i18n/navigation';
 import TestCard from '@/components/practice/TestCard';
+import TestCardProgress from '@/components/practice/TestCardProgress';
 import { getSubjectIndex, listSubjectsWithContent } from '@/lib/practice/content';
 
 // Content lives in the bundled manifest (no runtime fs on Workers), so we can
@@ -90,14 +91,16 @@ export default async function SubjectPage({ params }) {
           ) : (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
               {tests.map((test) => (
-                <TestCard
-                  key={test.id}
-                  href={`/student/ausom/semester-2/${subject}/${test.id}`}
-                  title={test.title}
-                  kind={test.kind}
-                  kindLabel={test.kind === 'mock' ? t('mockExam') : t('topicTest')}
-                  countLabel={t('questionCount', { count: test.questionCount })}
-                />
+                <div key={test.id} style={{ position: 'relative' }}>
+                  <TestCard
+                    href={`/student/ausom/semester-2/${subject}/${test.id}`}
+                    title={test.title}
+                    kind={test.kind}
+                    kindLabel={test.kind === 'mock' ? t('mockExam') : t('topicTest')}
+                    countLabel={t('questionCount', { count: test.questionCount })}
+                  />
+                  <TestCardProgress subject={subject} testId={test.id} />
+                </div>
               ))}
             </div>
           )}

--- a/src/components/practice/ScoreSummary.js
+++ b/src/components/practice/ScoreSummary.js
@@ -89,7 +89,62 @@ function WrongRow({ position, stem, onClick, t }) {
   );
 }
 
-export default function ScoreSummary({ attempt, answers, t, onReview, onRetry }) {
+// Past attempts for this test (the current completion excluded — the parent
+// reads them before saving the new attempt), most recent first.
+function PreviousAttempts({ attempts, t }) {
+  const rows = [...attempts]
+    .sort((a, b) => String(b.finishedAt).localeCompare(String(a.finishedAt)))
+    .map((a) => {
+      const pct = a.total ? Math.round((a.score / a.total) * 100) : 0;
+      const when = a.finishedAt ? new Date(a.finishedAt) : null;
+      const date =
+        when && !Number.isNaN(when.getTime())
+          ? when.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+          : '';
+      return { key: a.finishedAt, date, score: a.score, total: a.total, pct };
+    });
+
+  return (
+    <section style={{ marginTop: 28 }}>
+      <h2 style={sectionHeading}>{t('results.previousAttempts')}</h2>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {rows.map((row) => (
+          <div
+            key={row.key}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 12,
+              padding: '11px 15px',
+              borderRadius: 12,
+              border: '1px solid rgba(10,37,64,0.08)',
+              background: '#ffffff',
+            }}
+          >
+            <span style={{ fontSize: 14, color: 'rgba(10,37,64,0.6)' }}>{row.date}</span>
+            <span
+              style={{
+                fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+                fontSize: 14.5,
+                fontWeight: 600,
+                color: INK,
+              }}
+            >
+              {t('results.previousAttemptScore', {
+                score: row.score,
+                total: row.total,
+                percent: row.pct,
+              })}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function ScoreSummary({ attempt, answers, t, onReview, onRetry, previousAttempts = [] }) {
   const questions = attempt.questions;
   const total = questions.length;
   const score = questions.reduce((acc, q, i) => acc + (answers[i] === q.correct ? 1 : 0), 0);
@@ -200,6 +255,8 @@ export default function ScoreSummary({ attempt, answers, t, onReview, onRetry })
           </div>
         )}
       </section>
+
+      {previousAttempts.length > 0 && <PreviousAttempts attempts={previousAttempts} t={t} />}
 
       <div style={{ marginTop: 32 }}>
         <PrimaryButton onClick={onRetry}>{t('results.retry')}</PrimaryButton>

--- a/src/components/practice/TestCardProgress.js
+++ b/src/components/practice/TestCardProgress.js
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { getProgressStore } from '@/lib/practice/progress';
+
+// Thin client overlay for TestCard. The subject page is a server component and
+// cannot read localStorage, so it renders TestCard (server-renderable) and
+// drops this alongside it inside a position:relative wrapper. On the first SSR
+// pass — and for never-attempted tests — it renders nothing; once mounted it
+// hydrates with the best score + attempt count from the progress store.
+const INK = '#0a2540';
+const ACCENT = '#635BFF';
+
+export default function TestCardProgress({ subject, testId }) {
+  const t = useTranslations('student.practice');
+  const [stats, setStats] = useState(null);
+
+  useEffect(() => {
+    const attempts = getProgressStore().getAttempts(subject, testId);
+    if (attempts.length === 0) return;
+    let best = 0;
+    for (const a of attempts) {
+      const pct = a.total ? Math.round((a.score / a.total) * 100) : 0;
+      if (pct > best) best = pct;
+    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setStats({ best, count: attempts.length });
+  }, [subject, testId]);
+
+  // Nothing on the first SSR pass / hydration, and nothing for never-attempted
+  // tests — keeps the server and client markup identical until real data lands.
+  if (!stats) return null;
+
+  const pill = {
+    height: 24,
+    padding: '0 10px',
+    borderRadius: 999,
+    display: 'inline-flex',
+    alignItems: 'center',
+    fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+    fontSize: 11.5,
+    fontWeight: 600,
+    letterSpacing: '0.01em',
+  };
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 16,
+        left: 24,
+        display: 'flex',
+        gap: 8,
+        pointerEvents: 'none',
+      }}
+    >
+      <span style={{ ...pill, background: 'rgba(99,91,255,0.12)', color: ACCENT }}>
+        {t('bestScore', { percent: stats.best })}
+      </span>
+      <span style={{ ...pill, background: 'rgba(10,37,64,0.06)', color: 'rgba(10,37,64,0.6)' }}>
+        {t('attemptCount', { count: stats.count })}
+      </span>
+    </div>
+  );
+}

--- a/src/components/practice/TestPlayer.js
+++ b/src/components/practice/TestPlayer.js
@@ -1,9 +1,10 @@
 'use client';
 
-import { Suspense, useCallback, useEffect, useState } from 'react';
+import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/navigation';
+import { getProgressStore } from '@/lib/practice/progress';
 import QuestionCard from './QuestionCard';
 import FeedbackPanel from './FeedbackPanel';
 import ScoreSummary from './ScoreSummary';
@@ -43,15 +44,88 @@ function toDisplayQuestion(q, originalIndex, shuffleOptions) {
   };
 }
 
-// A fresh attempt. The first render shuffles question order only (options stay
-// in authored order); Retry passes shuffleOptions=true to also scramble each
-// question's options — defeating positional memory on a repeat run.
-function buildAttempt(test, shuffleOptions = false) {
-  const order = shuffle(test.questions.map((_, i) => i));
+// Build an attempt from an explicit question order (array of original indices).
+function buildAttemptFromOrder(test, order, shuffleOptions) {
   const questions = order.map((origIdx) =>
     toDisplayQuestion(test.questions[origIdx], origIdx, shuffleOptions),
   );
   return { order, questions };
+}
+
+// A fresh attempt. The first render shuffles question order only (options stay
+// in authored order); Retry passes shuffleOptions=true to also scramble each
+// question's options — defeating positional memory on a repeat run.
+function buildAttempt(test, shuffleOptions = false) {
+  return buildAttemptFromOrder(test, shuffle(test.questions.map((_, i) => i)), shuffleOptions);
+}
+
+/* ---------- progress persistence mapping (internal state ⇄ store records) ----------
+
+   Internal `answers` is positional: answers[pos] = display-option index | null.
+   Persisted records use AUTHORED option indices so they survive option shuffles
+   and mean something to a future Supabase store. These helpers translate both
+   ways. */
+
+// Mid-test snapshot: the shuffled question-id order plus the answers given so far.
+function toSnapshot(test, subject, attempt, answers) {
+  const order = attempt.questions.map((q) => q.id);
+  const answered = [];
+  attempt.questions.forEach((q, pos) => {
+    const displayIdx = answers[pos];
+    if (displayIdx == null) return;
+    answered.push({
+      questionId: q.id,
+      chosen: q.displayOptions[displayIdx].originalIndex,
+      correct: q.displayOptions[q.correct].originalIndex,
+    });
+  });
+  return { testId: test.id, subject, version: test.version, order, answers: answered };
+}
+
+// Rebuild the exact attempt + positional answers from a saved snapshot.
+function fromSnapshot(test, snapshot) {
+  const idToIndex = new Map(test.questions.map((q, i) => [q.id, i]));
+  const order = (snapshot.order || [])
+    .map((id) => idToIndex.get(id))
+    .filter((i) => typeof i === 'number');
+
+  // If the saved order doesn't cover the test 1:1 (content drift / corruption),
+  // fall back to a fresh shuffle rather than rendering a broken attempt.
+  const attempt =
+    order.length === test.questions.length
+      ? buildAttemptFromOrder(test, order, false)
+      : buildAttempt(test);
+
+  const answers = test.questions.map(() => null);
+  const byQuestion = new Map((snapshot.answers || []).map((a) => [a.questionId, a]));
+  attempt.questions.forEach((q, pos) => {
+    const saved = byQuestion.get(q.id);
+    if (!saved) return;
+    const displayIdx = q.displayOptions.findIndex((o) => o.originalIndex === saved.chosen);
+    if (displayIdx >= 0) answers[pos] = displayIdx;
+  });
+  return { attempt, answers };
+}
+
+// Completed attempt record for saveAttempt().
+function toAttempt(test, subject, attempt, answers, startedAt) {
+  let score = 0;
+  const list = attempt.questions.map((q, pos) => {
+    const displayIdx = answers[pos];
+    const chosen = displayIdx == null ? null : q.displayOptions[displayIdx].originalIndex;
+    if (displayIdx != null && displayIdx === q.correct) score += 1;
+    return { questionId: q.id, chosen, correct: q.displayOptions[q.correct].originalIndex };
+  });
+  return {
+    testId: test.id,
+    subject,
+    version: test.version,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    score,
+    total: attempt.questions.length,
+    answers: list,
+  };
 }
 
 /* ---------- layout helpers ---------- */
@@ -139,6 +213,41 @@ function PlayerSkeleton() {
   );
 }
 
+// Shown on mount when a saved in-progress snapshot exists for this test+version.
+function ResumeBanner({ current, total, onContinue, onStartOver, t }) {
+  return (
+    <div
+      style={{
+        borderRadius: 22,
+        border: '1px solid rgba(99,91,255,0.25)',
+        background: '#f6f4ff',
+        padding: '24px 24px 22px',
+        boxShadow: '0 10px 28px -16px rgba(10,37,64,0.16)',
+      }}
+    >
+      <h2
+        style={{
+          fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+          fontWeight: 600,
+          fontSize: 20,
+          letterSpacing: '-0.01em',
+          color: '#0a2540',
+          margin: '0 0 6px',
+        }}
+      >
+        {t('resume.title')}
+      </h2>
+      <p style={{ margin: '0 0 18px', fontSize: 14.5, lineHeight: 1.5, color: 'rgba(10,37,64,0.6)' }}>
+        {t('resume.description', { current, total })}
+      </p>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 14, flexWrap: 'wrap' }}>
+        <PrimaryButton onClick={onContinue}>{t('resume.continue')}</PrimaryButton>
+        <TextButton onClick={onStartOver}>{t('resume.startOver')}</TextButton>
+      </div>
+    </div>
+  );
+}
+
 /* ---------- player ---------- */
 
 // `onReportIssue` is the stable hook P5 will pass to wire up the ReportIssueModal.
@@ -170,6 +279,14 @@ function TestPlayerInner({ test, subject, onReportIssue }) {
   const [finished, setFinished] = useState(false);
   const [reviewIndex, setReviewIndex] = useState(null);
 
+  // Progress persistence. `resume` holds a saved snapshot awaiting a
+  // Continue/Start-over decision; `previousAttempts` are the prior completions
+  // shown in the score summary (captured before the current one is saved).
+  const [resume, setResume] = useState(null);
+  const [previousAttempts, setPreviousAttempts] = useState([]);
+  const startedAtRef = useRef(null);
+  const savedRef = useRef(false); // guards saveAttempt against duplicate finishes
+
   // The attempt is built with Math.random (shuffle), so it MUST NOT render
   // during SSR — server and client would disagree and React would throw a
   // hydration mismatch. Gate the randomized UI behind a client-only mount flag;
@@ -178,9 +295,44 @@ function TestPlayerInner({ test, subject, onReportIssue }) {
   // set-state-in-effect rule is intentionally disabled for this one line.
   const [mounted, setMounted] = useState(false);
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect
+    /* eslint-disable react-hooks/set-state-in-effect */
     setMounted(true);
+    startedAtRef.current = new Date().toISOString();
+
+    // Offer to resume a saved in-progress snapshot for this exact test version.
+    // A version mismatch (content edited since) is silently discarded so the
+    // user always starts fresh against the current questions.
+    const store = getProgressStore();
+    const snapshot = store.getInProgress(subject, test.id);
+    if (snapshot && snapshot.version === test.version && snapshot.answers.length > 0) {
+      setResume(snapshot);
+    } else if (snapshot) {
+      store.clearInProgress(subject, test.id);
+    }
+    /* eslint-enable react-hooks/set-state-in-effect */
+    // Mount-only: `test`/`subject` are stable for a given page render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Persist a snapshot after every answer so a refresh can resume in place.
+  // Skipped while the resume offer is pending and once the test is finished.
+  useEffect(() => {
+    if (!mounted || finished || resume) return;
+    if (answers.every((a) => a == null)) return;
+    getProgressStore().saveInProgress(toSnapshot(test, subject, attempt, answers));
+  }, [mounted, finished, resume, answers, attempt, test, subject]);
+
+  // On finish: capture prior attempts (for the summary), record this attempt,
+  // then clear the in-progress snapshot. The savedRef guard makes it idempotent
+  // across re-renders / strict-mode double-invokes; it resets on retry.
+  useEffect(() => {
+    if (!finished || savedRef.current) return;
+    savedRef.current = true;
+    const store = getProgressStore();
+    setPreviousAttempts(store.getAttempts(subject, test.id));
+    store.saveAttempt(toAttempt(test, subject, attempt, answers, startedAtRef.current));
+    store.clearInProgress(subject, test.id);
+  }, [finished, attempt, answers, test, subject]);
 
   // Admin deep-link: ?review=<questionId> → read-only review of that question.
   const deepLinkIndex = reviewId ? test.questions.findIndex((q) => q.id === reviewId) : -1;
@@ -218,12 +370,41 @@ function TestPlayerInner({ test, subject, onReportIssue }) {
     setCurrent(0);
     setFinished(false);
     setReviewIndex(null);
+    startedAtRef.current = new Date().toISOString();
+    savedRef.current = false;
   }, [test]);
+
+  // Resume offer → restore the exact saved attempt and jump to the first
+  // unanswered question.
+  const handleContinue = useCallback(() => {
+    const { attempt: restored, answers: restoredAnswers } = fromSnapshot(test, resume);
+    const firstUnanswered = restoredAnswers.findIndex((a) => a == null);
+    setAttempt(restored);
+    setAnswers(restoredAnswers);
+    setCurrent(firstUnanswered === -1 ? restoredAnswers.length - 1 : firstUnanswered);
+    setFinished(false);
+    setReviewIndex(null);
+    savedRef.current = false;
+    setResume(null);
+  }, [test, resume]);
+
+  // Resume offer → discard the snapshot and begin a fresh shuffled attempt.
+  const handleStartOver = useCallback(() => {
+    getProgressStore().clearInProgress(subject, test.id);
+    setAttempt(buildAttempt(test));
+    setAnswers(test.questions.map(() => null));
+    setCurrent(0);
+    setFinished(false);
+    setReviewIndex(null);
+    startedAtRef.current = new Date().toISOString();
+    savedRef.current = false;
+    setResume(null);
+  }, [test, subject]);
 
   // Keyboard: 1–5 selects an option while ANSWERING; Enter advances once
   // ANSWERED. Disabled in finished / review / lightbox-open states.
   useEffect(() => {
-    if (!mounted || finished || deepLinkQuestion || lightbox) return undefined;
+    if (!mounted || finished || deepLinkQuestion || lightbox || resume) return undefined;
     function onKey(e) {
       const el = e.target;
       if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) {
@@ -244,7 +425,7 @@ function TestPlayerInner({ test, subject, onReportIssue }) {
     }
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [mounted, finished, deepLinkQuestion, lightbox, answers, current, attempt, handleSelect, handleAdvance]);
+  }, [mounted, finished, deepLinkQuestion, lightbox, resume, answers, current, attempt, handleSelect, handleAdvance]);
 
   const lightboxEl = lightbox ? (
     <Lightbox
@@ -300,6 +481,27 @@ function TestPlayerInner({ test, subject, onReportIssue }) {
             t={t}
             onReview={setReviewIndex}
             onRetry={handleRetry}
+            previousAttempts={previousAttempts}
+          />
+        </Shell>
+        {lightboxEl}
+      </>
+    );
+  }
+
+  // 3.5) RESUME OFFER — a saved snapshot for this test+version is awaiting a
+  // Continue / Start-over decision before the attempt is shown.
+  if (resume) {
+    const answeredSoFar = resume.answers.length;
+    return (
+      <>
+        <Shell back={<BackRow href={listHref} label={t('review.backToTests')} />}>
+          <ResumeBanner
+            current={Math.min(answeredSoFar + 1, test.questions.length)}
+            total={test.questions.length}
+            onContinue={handleContinue}
+            onStartOver={handleStartOver}
+            t={t}
           />
         </Shell>
         {lightboxEl}

--- a/src/lib/practice/progress.js
+++ b/src/lib/practice/progress.js
@@ -1,0 +1,169 @@
+/**
+ * Progress persistence for practice tests.
+ *
+ * The UI talks only to the {@link ProgressStore} interface, never to
+ * localStorage directly. That keeps the storage backend swappable: a future
+ * Supabase-backed implementation can satisfy the same interface and replace
+ * {@link LocalStorageProgressStore} via {@link getProgressStore} without
+ * touching a single UI component.
+ *
+ * Two record shapes are persisted per test:
+ *   - Attempt        — a completed run (score + per-question answers).
+ *   - AttemptSnapshot — the serializable mid-test state TestPlayer saves after
+ *                       every answer, so a refresh can resume in place.
+ *
+ * Storage keys are namespaced and versioned:
+ *   sx:practice:v1:{subject}:{testId}:attempts  → Attempt[]
+ *   sx:practice:v1:{subject}:{testId}:wip       → AttemptSnapshot
+ *
+ * Robustness: every localStorage access is wrapped in try/catch and corrupt or
+ * missing data degrades to empty/null. Reads never throw and writes never throw
+ * — private mode, quota-exceeded, and SSR (no `localStorage`) all degrade
+ * silently. The store is safe to call from a client component's effect.
+ */
+
+/**
+ * One answered question within an Attempt or AttemptSnapshot. Indices are
+ * AUTHORED option indices (stable across option shuffles), not display indices.
+ * @typedef {Object} AttemptAnswer
+ * @property {string} questionId
+ * @property {number|null} chosen  Authored index of the option the user chose.
+ * @property {number} correct      Authored index of the correct option.
+ */
+
+/**
+ * A completed run.
+ * @typedef {Object} Attempt
+ * @property {string} testId
+ * @property {string} subject
+ * @property {number} version     Test version this attempt was taken against.
+ * @property {string} startedAt   ISO timestamp.
+ * @property {string} finishedAt  ISO timestamp.
+ * @property {number} score
+ * @property {number} total
+ * @property {AttemptAnswer[]} answers
+ */
+
+/**
+ * Serializable mid-test state — enough to rebuild the exact same attempt.
+ * @typedef {Object} AttemptSnapshot
+ * @property {string} testId
+ * @property {string} subject
+ * @property {number} version       Test version; a mismatch on load is discarded.
+ * @property {string[]} order       Shuffled question-id array (the attempt order).
+ * @property {AttemptAnswer[]} answers  Partial — only questions answered so far.
+ */
+
+/**
+ * Storage backend contract. Implementations must never throw.
+ * @typedef {Object} ProgressStore
+ * @property {(subject: string, testId: string) => Attempt[]} getAttempts
+ * @property {(attempt: Attempt) => void} saveAttempt
+ * @property {(subject: string, testId: string) => (AttemptSnapshot|null)} getInProgress
+ * @property {(snapshot: AttemptSnapshot) => void} saveInProgress
+ * @property {(subject: string, testId: string) => void} clearInProgress
+ */
+
+const NS = 'sx:practice:v1';
+
+function attemptsKey(subject, testId) {
+  return `${NS}:${subject}:${testId}:attempts`;
+}
+
+function wipKey(subject, testId) {
+  return `${NS}:${subject}:${testId}:wip`;
+}
+
+// --- guarded localStorage access (never throws) ---------------------------
+
+function readJSON(key) {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch {
+    // Missing storage (SSR), private-mode read errors, or corrupt JSON.
+    return null;
+  }
+}
+
+function writeJSON(key, value) {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Private mode, quota exceeded, or SSR — degrade silently.
+  }
+}
+
+function removeKey(key) {
+  try {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.removeItem(key);
+  } catch {
+    // Nothing actionable — degrade silently.
+  }
+}
+
+/**
+ * localStorage-backed {@link ProgressStore}.
+ * @implements {ProgressStore}
+ */
+export class LocalStorageProgressStore {
+  /**
+   * @param {string} subject
+   * @param {string} testId
+   * @returns {Attempt[]} Oldest-first; empty array when absent or corrupt.
+   */
+  getAttempts(subject, testId) {
+    const data = readJSON(attemptsKey(subject, testId));
+    return Array.isArray(data) ? data : [];
+  }
+
+  /** @param {Attempt} attempt */
+  saveAttempt(attempt) {
+    if (!attempt || !attempt.subject || !attempt.testId) return;
+    const existing = this.getAttempts(attempt.subject, attempt.testId);
+    existing.push(attempt);
+    writeJSON(attemptsKey(attempt.subject, attempt.testId), existing);
+  }
+
+  /**
+   * @param {string} subject
+   * @param {string} testId
+   * @returns {AttemptSnapshot|null} null when absent or shape is invalid.
+   */
+  getInProgress(subject, testId) {
+    const data = readJSON(wipKey(subject, testId));
+    if (!data || typeof data !== 'object') return null;
+    if (!Array.isArray(data.order) || !Array.isArray(data.answers)) return null;
+    return data;
+  }
+
+  /** @param {AttemptSnapshot} snapshot */
+  saveInProgress(snapshot) {
+    if (!snapshot || !snapshot.subject || !snapshot.testId) return;
+    writeJSON(wipKey(snapshot.subject, snapshot.testId), snapshot);
+  }
+
+  /**
+   * @param {string} subject
+   * @param {string} testId
+   */
+  clearInProgress(subject, testId) {
+    removeKey(wipKey(subject, testId));
+  }
+}
+
+let instance = null;
+
+/**
+ * Returns the process-wide {@link ProgressStore}. Client-side only — call from
+ * effects/handlers, not during render or on the server.
+ * @returns {ProgressStore}
+ */
+export function getProgressStore() {
+  if (!instance) instance = new LocalStorageProgressStore();
+  return instance;
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -846,6 +846,8 @@
       "mockExam": "Mock exam",
       "questionCount": "{count, plural, one {# question} other {# questions}}",
       "emptyState": "Tests coming soon",
+      "bestScore": "Best {percent}%",
+      "attemptCount": "{count, plural, one {# attempt} other {# attempts}}",
       "player": {
         "progress": "Question {current} of {total}",
         "progressBarLabel": "Test progress",
@@ -860,6 +862,12 @@
         "viewFullSize": "View full-size image",
         "lightboxLabel": "Explanation image",
         "closeLightbox": "Close image",
+        "resume": {
+          "title": "Resume your attempt?",
+          "description": "Pick up where you left off, from question {current} of {total}.",
+          "continue": "Continue",
+          "startOver": "Start over"
+        },
         "results": {
           "title": "Your results",
           "scoreValue": "{score} / {total}",
@@ -868,7 +876,9 @@
           "topicScore": "{correct} / {total}",
           "reviewMistakes": "Review your mistakes",
           "allCorrect": "Perfect score — nothing to review.",
-          "retry": "Retry test"
+          "retry": "Retry test",
+          "previousAttempts": "Previous attempts",
+          "previousAttemptScore": "{score} / {total} · {percent}%"
         },
         "review": {
           "label": "Review",


### PR DESCRIPTION
## Summary
Adds progress persistence to the practice-test feature, built against a `ProgressStore` interface so a future Supabase implementation can replace localStorage without touching any UI code (PLAN §0.5 / §4, P4).

## Changes
- **`src/lib/practice/progress.js`** (new) — `ProgressStore` interface (JSDoc), `Attempt` / `AttemptSnapshot` typedefs, `LocalStorageProgressStore` with namespaced `sx:practice:v1:{subject}:{testId}:{attempts|wip}` keys, and `getProgressStore()` factory. Every localStorage access is try/catch-wrapped; corrupt or missing data degrades to empty/null and never throws (private mode, quota, SSR).
- **`src/components/practice/TestPlayer.js`** — on mount, offers a resume banner ("Resume from question X of N" → Continue / Start over) when a snapshot's `version` matches `test.version`; a version mismatch is silently discarded. Saves a snapshot after every answer; on finish records the completed `Attempt` and clears the snapshot. Persisted answers use stable authored option indices.
- **`src/components/practice/TestCardProgress.js`** (new) — thin client overlay adding best-score + attempt-count to `TestCard`; renders nothing on the first SSR pass and for never-attempted tests, then hydrates with real data. `TestCard` itself is untouched.
- **`src/components/practice/ScoreSummary.js`** — new "Previous attempts" section (date + score, most recent first); excludes the just-finished run, so the first completion shows nothing.
- **`src/app/[locale]/student/ausom/semester-2/[subject]/page.js`** — wraps each `TestCard` to overlay `TestCardProgress`.
- **`src/messages/en.json`** — resume banner, previous-attempts, and card-progress strings (no hardcoded English in JSX).

## Verification
- `npm run validate:tests` ✓
- `npm run lint` ✓ (0 errors)
- `npm run cf:build` ✓
- `npm run test` ✓ (258 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)