### PR TITLE
feat(practice): report error / propose edit (P5)

### DIFF
--- a/src/components/practice/ReportIssueModal.js
+++ b/src/components/practice/ReportIssueModal.js
@@ -1,0 +1,380 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+import { PrimaryButton } from './PlayerButton';
+
+const ACCENT = '#635BFF';
+const INK = '#0a2540';
+const MESSAGE_MIN = 5;
+const MESSAGE_MAX = 2000;
+
+// The edit-loop entry point (PLAN.md §3/§4). Inserts one row into
+// public.question_reports via the ANON browser client. The security model is
+// anon-key + insert-only RLS: this component only ever INSERTs — it never reads
+// the table back. `proposed_change` and `reporter_email` are omitted entirely
+// when blank so the DB stores NULL rather than an empty string.
+export default function ReportIssueModal({ subject, testId, questionId, testVersion, onClose }) {
+  const t = useTranslations('student.practice.report');
+
+  const [kind, setKind] = useState('error');
+  const [message, setMessage] = useState('');
+  const [proposedChange, setProposedChange] = useState('');
+  const [email, setEmail] = useState('');
+  const [website, setWebsite] = useState(''); // honeypot — humans never see it
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(false);
+  const [done, setDone] = useState(false);
+
+  const dialogRef = useRef(null);
+  const firstFieldRef = useRef(null);
+
+  // Escape closes; focus the first field on open.
+  useEffect(() => {
+    function onKey(e) {
+      if (e.key === 'Escape') onClose();
+    }
+    window.addEventListener('keydown', onKey);
+    firstFieldRef.current?.focus();
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const trimmedMessage = message.trim();
+  const canSubmit = !submitting && trimmedMessage.length >= MESSAGE_MIN;
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (!canSubmit) return;
+
+    // Honeypot: a filled "website" field means a bot. Show the same success
+    // state, but never touch the database.
+    if (website.trim() !== '') {
+      setDone(true);
+      return;
+    }
+
+    setSubmitting(true);
+    setError(false);
+    try {
+      const row = {
+        subject,
+        test_id: testId,
+        question_id: questionId,
+        test_version: testVersion,
+        kind,
+        message: trimmedMessage,
+      };
+      if (kind === 'edit' && proposedChange.trim() !== '') {
+        row.proposed_change = proposedChange.trim();
+      }
+      if (email.trim() !== '') {
+        row.reporter_email = email.trim();
+      }
+
+      const supabase = getSupabaseBrowser();
+      // Insert only — no .select(). Anon may write but never read this table.
+      const { error: insertError } = await supabase.from('question_reports').insert(row);
+      if (insertError) {
+        setError(true);
+      } else {
+        setDone(true);
+      }
+    } catch {
+      setError(true);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      role="presentation"
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 1000,
+        background: 'rgba(10,37,64,0.5)',
+        backdropFilter: 'blur(2px)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 20,
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t('title')}
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: '100%',
+          maxWidth: 460,
+          maxHeight: 'calc(100vh - 40px)',
+          overflowY: 'auto',
+          background: '#ffffff',
+          borderRadius: 22,
+          boxShadow: '0 30px 80px -24px rgba(10,37,64,0.45)',
+          padding: '26px 26px 24px',
+          position: 'relative',
+        }}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={t('close')}
+          style={{
+            position: 'absolute',
+            top: 16,
+            right: 16,
+            appearance: 'none',
+            border: 'none',
+            background: 'rgba(10,37,64,0.05)',
+            borderRadius: 999,
+            width: 32,
+            height: 32,
+            cursor: 'pointer',
+            color: 'rgba(10,37,64,0.55)',
+            fontSize: 17,
+            lineHeight: 1,
+          }}
+        >
+          ✕
+        </button>
+
+        {done ? (
+          <div style={{ padding: '12px 0 4px' }}>
+            <h2
+              style={{
+                fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+                fontWeight: 600,
+                fontSize: 20,
+                letterSpacing: '-0.01em',
+                color: INK,
+                margin: '0 0 8px',
+              }}
+            >
+              {t('successTitle')}
+            </h2>
+            <p style={{ margin: '0 0 20px', fontSize: 14.5, lineHeight: 1.55, color: 'rgba(10,37,64,0.6)' }}>
+              {t('successBody')}
+            </p>
+            <PrimaryButton onClick={onClose}>{t('done')}</PrimaryButton>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <h2
+              style={{
+                fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+                fontWeight: 600,
+                fontSize: 20,
+                letterSpacing: '-0.01em',
+                color: INK,
+                margin: '0 26px 18px 0',
+              }}
+            >
+              {t('title')}
+            </h2>
+
+            {/* kind toggle */}
+            <div
+              role="group"
+              aria-label={t('title')}
+              style={{
+                display: 'flex',
+                gap: 8,
+                padding: 4,
+                background: '#f6f4ff',
+                borderRadius: 14,
+                marginBottom: 18,
+              }}
+            >
+              {[
+                { value: 'error', label: t('kindError') },
+                { value: 'edit', label: t('kindEdit') },
+              ].map((opt) => {
+                const active = kind === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={() => setKind(opt.value)}
+                    style={{
+                      flex: 1,
+                      appearance: 'none',
+                      border: 'none',
+                      borderRadius: 11,
+                      padding: '10px 12px',
+                      cursor: 'pointer',
+                      fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+                      fontWeight: 600,
+                      fontSize: 14,
+                      letterSpacing: '-0.01em',
+                      color: active ? '#ffffff' : 'rgba(10,37,64,0.6)',
+                      background: active ? ACCENT : 'transparent',
+                      boxShadow: active ? '0 8px 20px -12px rgba(99,91,255,0.7)' : 'none',
+                      transition: 'background 160ms ease, color 160ms ease',
+                    }}
+                  >
+                    {opt.label}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* message */}
+            <label style={labelStyle} htmlFor="report-message">
+              {t('messageLabel')}
+            </label>
+            <textarea
+              id="report-message"
+              ref={firstFieldRef}
+              value={message}
+              onChange={(e) => setMessage(e.target.value.slice(0, MESSAGE_MAX))}
+              placeholder={t('messagePlaceholder')}
+              rows={4}
+              maxLength={MESSAGE_MAX}
+              required
+              style={textareaStyle}
+            />
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                margin: '6px 2px 16px',
+                fontSize: 12.5,
+                color: 'rgba(10,37,64,0.45)',
+              }}
+            >
+              <span>{t('messageHint')}</span>
+              <span aria-live="polite">{t('charCount', { count: message.length, max: MESSAGE_MAX })}</span>
+            </div>
+
+            {/* proposed_change — only for an edit */}
+            {kind === 'edit' && (
+              <>
+                <label style={labelStyle} htmlFor="report-change">
+                  {t('proposedChangeLabel')}
+                </label>
+                <textarea
+                  id="report-change"
+                  value={proposedChange}
+                  onChange={(e) => setProposedChange(e.target.value.slice(0, MESSAGE_MAX))}
+                  placeholder={t('proposedChangePlaceholder')}
+                  rows={3}
+                  maxLength={MESSAGE_MAX}
+                  style={{ ...textareaStyle, marginBottom: 16 }}
+                />
+              </>
+            )}
+
+            {/* optional email */}
+            <label style={labelStyle} htmlFor="report-email">
+              {t('emailLabel')}
+            </label>
+            <input
+              id="report-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder={t('emailPlaceholder')}
+              style={inputStyle}
+            />
+            <div style={{ margin: '6px 2px 18px', fontSize: 12.5, color: 'rgba(10,37,64,0.45)' }}>
+              {t('emailHint')}
+            </div>
+
+            {/* honeypot — hidden from humans, tempting to bots */}
+            <div aria-hidden="true" style={{ position: 'absolute', left: '-9999px', top: 'auto', width: 1, height: 1, overflow: 'hidden' }}>
+              <label htmlFor="website">Website</label>
+              <input
+                id="website"
+                name="website"
+                type="text"
+                tabIndex={-1}
+                autoComplete="off"
+                value={website}
+                onChange={(e) => setWebsite(e.target.value)}
+              />
+            </div>
+
+            {error && (
+              <p
+                role="alert"
+                style={{
+                  margin: '0 0 14px',
+                  padding: '10px 12px',
+                  borderRadius: 12,
+                  background: 'rgba(255,95,162,0.1)',
+                  color: '#b3265f',
+                  fontSize: 13.5,
+                  lineHeight: 1.45,
+                }}
+              >
+                {t('error')}
+              </p>
+            )}
+
+            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <button
+                type="submit"
+                disabled={!canSubmit}
+                style={{
+                  appearance: 'none',
+                  border: 'none',
+                  borderRadius: 14,
+                  padding: '14px 24px',
+                  background: ACCENT,
+                  color: '#ffffff',
+                  fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+                  fontWeight: 600,
+                  fontSize: 15.5,
+                  letterSpacing: '-0.01em',
+                  cursor: canSubmit ? 'pointer' : 'not-allowed',
+                  opacity: canSubmit ? 1 : 0.5,
+                  boxShadow: '0 10px 26px -14px rgba(99,91,255,0.45)',
+                  transition: 'opacity 160ms ease',
+                }}
+              >
+                {submitting ? t('submitting') : t('submit')}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const labelStyle = {
+  display: 'block',
+  marginBottom: 6,
+  fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+  fontWeight: 600,
+  fontSize: 13.5,
+  letterSpacing: '-0.01em',
+  color: INK,
+};
+
+const inputStyle = {
+  width: '100%',
+  boxSizing: 'border-box',
+  appearance: 'none',
+  border: '1px solid rgba(10,37,64,0.14)',
+  borderRadius: 12,
+  padding: '12px 14px',
+  fontSize: 14.5,
+  fontFamily: 'var(--font-inter, system-ui, sans-serif)',
+  color: INK,
+  background: '#ffffff',
+  outline: 'none',
+};
+
+const textareaStyle = {
+  ...inputStyle,
+  resize: 'vertical',
+  lineHeight: 1.5,
+};

--- a/src/components/practice/TestPlayer.js
+++ b/src/components/practice/TestPlayer.js
@@ -9,6 +9,7 @@ import QuestionCard from './QuestionCard';
 import FeedbackPanel from './FeedbackPanel';
 import ScoreSummary from './ScoreSummary';
 import Lightbox from './Lightbox';
+import ReportIssueModal from './ReportIssueModal';
 import { PrimaryButton, TextButton } from './PlayerButton';
 
 const ACCENT = '#635BFF';
@@ -250,8 +251,10 @@ function ResumeBanner({ current, total, onContinue, onStartOver, t }) {
 
 /* ---------- player ---------- */
 
-// `onReportIssue` is the stable hook P5 will pass to wire up the ReportIssueModal.
-// In P3 it is left undefined, so the "Report an issue" button renders but is inert.
+// `onReportIssue` is the stable hook from P3. P5 wires it to the ReportIssueModal:
+// when no explicit handler is passed (the normal case), the player owns its own
+// modal state and the "Report an issue" button opens it. A parent may still
+// override by passing `onReportIssue` (e.g. for testing).
 export default function TestPlayer(props) {
   return (
     <Suspense fallback={<PlayerSkeleton />}>
@@ -271,6 +274,27 @@ function TestPlayerInner({ test, subject, onReportIssue }) {
   const [lightbox, setLightbox] = useState(null); // { src, alt } | null
   const openLightbox = useCallback((src, alt) => setLightbox({ src, alt }), []);
   const closeLightbox = useCallback(() => setLightbox(null), []);
+
+  // Report-issue modal. The P3 hook passes { subject, testId, questionId, version };
+  // store it as the modal's context (mapping version → testVersion). A parent-
+  // supplied `onReportIssue` wins; otherwise we open our own modal.
+  const [reportCtx, setReportCtx] = useState(null);
+  const handleReportIssue = useCallback(
+    (ctx) => {
+      if (onReportIssue) {
+        onReportIssue(ctx);
+        return;
+      }
+      setReportCtx({
+        subject: ctx.subject,
+        testId: ctx.testId,
+        questionId: ctx.questionId,
+        testVersion: ctx.version,
+      });
+    },
+    [onReportIssue],
+  );
+  const closeReport = useCallback(() => setReportCtx(null), []);
 
   // Live attempt state.
   const [attempt, setAttempt] = useState(() => buildAttempt(test));
@@ -404,7 +428,7 @@ function TestPlayerInner({ test, subject, onReportIssue }) {
   // Keyboard: 1–5 selects an option while ANSWERING; Enter advances once
   // ANSWERED. Disabled in finished / review / lightbox-open states.
   useEffect(() => {
-    if (!mounted || finished || deepLinkQuestion || lightbox || resume) return undefined;
+    if (!mounted || finished || deepLinkQuestion || lightbox || resume || reportCtx) return undefined;
     function onKey(e) {
       const el = e.target;
       if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) {
@@ -425,7 +449,17 @@ function TestPlayerInner({ test, subject, onReportIssue }) {
     }
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [mounted, finished, deepLinkQuestion, lightbox, resume, answers, current, attempt, handleSelect, handleAdvance]);
+  }, [mounted, finished, deepLinkQuestion, lightbox, resume, reportCtx, answers, current, attempt, handleSelect, handleAdvance]);
+
+  const reportEl = reportCtx ? (
+    <ReportIssueModal
+      subject={reportCtx.subject}
+      testId={reportCtx.testId}
+      questionId={reportCtx.questionId}
+      testVersion={reportCtx.testVersion}
+      onClose={closeReport}
+    />
+  ) : null;
 
   const lightboxEl = lightbox ? (
     <Lightbox
@@ -581,7 +615,7 @@ function TestPlayerInner({ test, subject, onReportIssue }) {
         >
           <TextButton
             onClick={() =>
-              onReportIssue?.({ subject, testId: test.id, questionId: aq.id, version: test.version })
+              handleReportIssue({ subject, testId: test.id, questionId: aq.id, version: test.version })
             }
           >
             {t('reportIssue')}
@@ -594,6 +628,7 @@ function TestPlayerInner({ test, subject, onReportIssue }) {
         </div>
       </Shell>
       {lightboxEl}
+      {reportEl}
     </>
   );
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -885,6 +885,27 @@
           "backToResults": "Back to results",
           "backToTests": "Back to tests"
         }
+      },
+      "report": {
+        "title": "Report an issue",
+        "close": "Close",
+        "kindError": "Report an error",
+        "kindEdit": "Propose an edit",
+        "messageLabel": "What's wrong?",
+        "messagePlaceholder": "Describe the problem with this question…",
+        "messageHint": "At least 5 characters",
+        "charCount": "{count} / {max}",
+        "proposedChangeLabel": "Suggested fix (optional)",
+        "proposedChangePlaceholder": "How should it read instead?",
+        "emailLabel": "Your email (optional)",
+        "emailPlaceholder": "you@example.com",
+        "emailHint": "Only if you'd like us to follow up.",
+        "submit": "Send report",
+        "submitting": "Sending…",
+        "successTitle": "Thanks — we review every report.",
+        "successBody": "We read every report and use it to fix and improve these questions.",
+        "error": "Something went wrong and your report wasn't sent. Please try again.",
+        "done": "Done"
       }
     }
   },

--- a/supabase/migrations/060_question_reports.sql
+++ b/supabase/migrations/060_question_reports.sql
@@ -1,0 +1,45 @@
+-- 060_question_reports
+--
+-- Backs the practice-test edit loop (PLAN.md §3). Every practice question has a
+-- "Report an issue" entry point; the ReportIssueModal inserts a row here via the
+-- public anon key. The admin review page (/admin/practice-reports) reads and
+-- mutates these rows server-side ONLY, through the service-role client
+-- (getSupabaseAsService), which bypasses RLS.
+--
+-- SECURITY MODEL: anon (and authenticated) may INSERT and nothing else. There
+-- are intentionally NO select/update/delete policies for those roles — with RLS
+-- enabled, an operation without a matching policy is denied, so the anon key
+-- cannot read, edit, or remove reports even though it can file them. Reads and
+-- status mutations happen only via the service role.
+create table public.question_reports (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  subject text not null,
+  test_id text not null,
+  question_id text not null,
+  test_version int not null,                 -- version the reporter saw
+  kind text not null check (kind in ('error', 'edit')),
+  message text not null check (char_length(message) between 5 and 2000),
+  proposed_change text check (char_length(proposed_change) <= 2000),
+  reporter_email text,                       -- optional, for follow-up
+  status text not null default 'open'
+    check (status in ('open', 'accepted', 'rejected', 'resolved')),
+  admin_note text,
+  resolved_at timestamptz
+);
+
+alter table public.question_reports enable row level security;
+
+create policy "anyone_can_insert" on public.question_reports
+  for insert to anon, authenticated with check (true);
+
+-- intentionally NO select/update/delete policies for anon/authenticated:
+-- the admin page reads and updates via the service-role key, server-side only.
+
+-- Table-level grants: lock the column/verb surface to INSERT for the public
+-- roles so the only thing anon/authenticated can attempt is filing a report
+-- (RLS above is the second gate). The service_role keeps its full grants and
+-- bypasses RLS for the admin page. Belt-and-braces against Supabase default
+-- privileges that would otherwise grant ALL on new public tables.
+revoke all on public.question_reports from anon, authenticated;
+grant insert on public.question_reports to anon, authenticated;


### PR DESCRIPTION
Implements P5 of the practice-test plan: the **report error / propose edit** edit loop.

## What's here
- **Migration `060_question_reports.sql`** — `question_reports` table per PLAN §3. RLS enabled with a single **insert-only** policy for `anon`/`authenticated`; intentionally **no** select/update/delete policies (the admin page reads/mutates via service-role only). Table grants locked to `INSERT` as a second gate against Supabase default privileges.
- **`ReportIssueModal`** — kind toggle (error/edit), message textarea (5–2000, live counter), edit-only `proposed_change`, optional email, honeypot (`name="website"` → fake success, no insert). Inserts via the anon browser client and **never** `.select()`s back. Success keeps the modal open with the thanks message; errors retry inline and preserve typed text; submit disabled in-flight and below 5 chars; X / backdrop / Escape close.
- **`TestPlayer`** — wires the existing P3 `onReportIssue` hook to open the modal (maps `version → test_version`); suppresses keyboard nav while the modal is open.
- **`en.json`** — `student.practice.report.*` chrome strings.

## Migration ordering
✅ Migration already applied to prod manually before merge (per CONVENTIONS §4 ordering rule).

## Security checks
- No `.select()` on `question_reports` anywhere — only `.insert()`.
- No `SUPABASE_SERVICE_ROLE_KEY` / `getSupabaseAsService` in any `'use client'` file.

## Verification
- `npm run validate:tests` ✓
- `npm run lint` ✓ (0 errors)
- `npm run cf:build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)