### PR TITLE
fix: unlock semester-2 subject cards once content ships

### DIFF
--- a/src/app/[locale]/student/ausom/semester-2/page.js
+++ b/src/app/[locale]/student/ausom/semester-2/page.js
@@ -1,6 +1,7 @@
 import { setRequestLocale } from 'next-intl/server';
 import Link from 'next/link';
 import HubButton from '@/components/HubButton';
+import { listSubjectsWithContent } from '@/lib/practice/content';
 
 export function generateMetadata() {
   return { title: 'Semester 2 — AUSoM Practice Tests' };
@@ -94,6 +95,11 @@ const SUBJECTS = [
 ];
 
 function Semester2Content() {
+  // A subject becomes clickable the moment it has published content (an
+  // index.json in the manifest); the rest keep the "Soon" treatment. This is
+  // the single gate — adding content is all it takes to light a card up.
+  const published = new Set(listSubjectsWithContent());
+
   return (
     <div>
       <div style={{ maxWidth: 460, margin: '0 auto', padding: '32px 24px 0' }}>
@@ -131,15 +137,19 @@ function Semester2Content() {
             maxWidth: 460,
           }}
         >
-          {SUBJECTS.map((s) => (
-            <HubButton
-              key={s.id}
-              label={s.label}
-              subtext=""
-              comingSoon
-              illustration={s.illustration}
-            />
-          ))}
+          {SUBJECTS.map((s) => {
+            const live = published.has(s.id);
+            return (
+              <HubButton
+                key={s.id}
+                label={s.label}
+                subtext=""
+                href={live ? `/student/ausom/semester-2/${s.id}` : undefined}
+                comingSoon={!live}
+                illustration={s.illustration}
+              />
+            );
+          })}
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Problem
The semester-2 subject list (`src/app/[locale]/student/ausom/semester-2/page.js`) rendered **every** card with a hardcoded `comingSoon` prop and no `href`. So General Histology stayed gated as "Soon" and was not clickable — even though its image-ID practice content merged in #276.

## Fix
Derive each card's clickable state from `listSubjectsWithContent()`:

```js
const published = new Set(listSubjectsWithContent());
// ...
const live = published.has(s.id);
<HubButton href={live ? `/student/ausom/semester-2/${s.id}` : undefined} comingSoon={!live} ... />
```

A subject now lights up and links to its subject page the moment its `index.json` is in the manifest. Adding content is the single gate — no per-subject UI edit required. This matches the intent already documented in the file's comment ("subjects with published tests link… the rest keep the Soon treatment"), which was never actually implemented.

## Effect
- **General Histology** → now a live link to `/student/ausom/semester-2/general-histology`
- Medical Informatics, Anatomy I, Biochemistry I, General Physiology → remain "Soon" (no content yet)

## Notes
- ESLint passes on the changed file.
- Only this page was audited. If another entry point lists subjects, it would need the same manifest-driven gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)