### PR TITLE
feat: simplify homepage

### DIFF
--- a/src/app/[locale]/about/page.js
+++ b/src/app/[locale]/about/page.js
@@ -1,3 +1,4 @@
+import { redirect } from 'next/navigation';
 import { setRequestLocale } from 'next-intl/server';
 import Link from 'next/link';
 
@@ -20,7 +21,7 @@ export function generateMetadata() {
 export default async function AboutPage({ params }) {
   const { locale } = await params;
   setRequestLocale(locale);
-  return <AboutContent />;
+  redirect(`/${locale}`);
 }
 
 function Section({ eyebrow, heading, children, style }) {

--- a/src/app/[locale]/page.js
+++ b/src/app/[locale]/page.js
@@ -8,10 +8,9 @@ export default async function HomePage({ params }) {
   const t = await getTranslations({ locale, namespace: 'home' });
 
   const buttons = [
-    { id: 'directory', label: t('directory'), subtext: t('directorySub'), href: '/property' },
-    { id: 'services',  label: t('services'),  subtext: t('servicesSub'),  href: '/student' },
-    { id: 'blog',      label: t('blog'),      subtext: t('blogSub'),      href: 'https://blog.studentx.uk', external: true },
-    { id: 'about',     label: t('about'),     subtext: t('aboutSub'),     href: '/about' },
+    { id: 'directory', label: t('directory'), href: '/property' },
+    { id: 'services',  label: t('services'),  href: '/student' },
+    { id: 'blog',      label: t('blog'),      href: 'https://blog.studentx.uk', external: true },
   ];
 
   return (
@@ -30,29 +29,6 @@ export default async function HomePage({ params }) {
           gap: 28,
         }}
       >
-        <div style={{ textAlign: 'center', maxWidth: 520 }}>
-          <p
-            style={{
-              margin: 0,
-              color: 'rgba(10,37,64,0.7)',
-              fontSize: 'clamp(14px, 1.4vw, 17px)',
-              lineHeight: 1.55,
-            }}
-          >
-            {t('tagline')}
-          </p>
-          <p
-            style={{
-              margin: '6px 0 0',
-              color: 'rgba(10,37,64,0.5)',
-              fontSize: 'clamp(12px, 1.1vw, 14px)',
-              lineHeight: 1.5,
-            }}
-          >
-            {t('descriptor')}
-          </p>
-        </div>
-
         <div
           style={{
             display: 'flex',
@@ -63,7 +39,7 @@ export default async function HomePage({ params }) {
           }}
         >
           {buttons.map((b) => (
-            <HubButton key={b.id} label={b.label} subtext={b.subtext} href={b.href} external={b.external} comingSoon={b.comingSoon} />
+            <HubButton key={b.id} label={b.label} href={b.href} external={b.external} comingSoon={b.comingSoon} />
           ))}
         </div>
 

--- a/src/components/HubButton.js
+++ b/src/components/HubButton.js
@@ -115,9 +115,11 @@ export default function HubButton({ label, subtext, href, external = false, comi
       <div style={{ flex: 1 }} />
       <div>
         <div style={labelStyle}>{label}</div>
-        <div style={{ marginTop: 5, fontSize: 13.5, lineHeight: 1.4, color: 'rgba(10,37,64,0.6)' }}>
-          {subtext}
-        </div>
+        {subtext && (
+          <div style={{ marginTop: 5, fontSize: 13.5, lineHeight: 1.4, color: 'rgba(10,37,64,0.6)' }}>
+            {subtext}
+          </div>
+        )}
       </div>
     </>
   );

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -978,16 +978,9 @@
     "loadingCycle": ["Loading"]
   },
   "home": {
-    "tagline": "For students, by students",
-    "descriptor": "Curated student housing and services.",
     "blog": "Blog",
-    "blogSub": "Insights & tactical strategies",
-    "directory": "Directory",
-    "directorySub": "Curated rentals, filtered by your commute",
-    "services": "Student Services",
-    "servicesSub": "Setting you up in your city",
-    "about": "About Us",
-    "aboutSub": "Our story and why we built this",
+    "directory": "Accommodation",
+    "services": "Services",
     "comingSoon": "Soon",
     "copyright": "© {year} StudentX"
   }


### PR DESCRIPTION
## Summary

- Rename hub buttons: Directory → Accommodation, Student Services → Services, Blog stays Blog
- Remove "For students, by students" tagline and descriptor text above the buttons
- Strip subtext from all hub buttons (cleaner card look)
- Remove About Us button; `/about` now redirects to home (content preserved in file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)