### PR TITLE
feat: everything-app student account hub + Holiday Gigs section

### DIFF
--- a/src/app/[locale]/gigs/[id]/page.js
+++ b/src/app/[locale]/gigs/[id]/page.js
@@ -4,6 +4,7 @@ import { Link } from '@/i18n/navigation';
 import { getSupabase } from '@/lib/supabase';
 import { transformGig } from '@/lib/transformGig';
 import GigInquiryForm from '@/components/GigInquiryForm';
+import GigFavoriteButton from '@/components/GigFavoriteButton';
 
 const CURRENCY_SYMBOL = { EUR: '€', GBP: '£', USD: '$' };
 
@@ -138,7 +139,8 @@ export default async function GigDetailPage({ params }) {
             )}
           </article>
 
-          <aside className="lg:sticky lg:top-6 lg:self-start">
+          <aside className="lg:sticky lg:top-6 lg:self-start space-y-4">
+            <GigFavoriteButton gigId={gig.gig_id} withLabel className="w-full justify-center" />
             <GigInquiryForm gigId={gig.gig_id} />
           </aside>
         </div>

--- a/src/app/[locale]/gigs/[id]/page.js
+++ b/src/app/[locale]/gigs/[id]/page.js
@@ -1,10 +1,10 @@
-import Image from 'next/image';
 import { setRequestLocale, getTranslations } from 'next-intl/server';
 import { Link } from '@/i18n/navigation';
 import { getSupabase } from '@/lib/supabase';
 import { transformGig } from '@/lib/transformGig';
 import GigInquiryForm from '@/components/GigInquiryForm';
 import GigFavoriteButton from '@/components/GigFavoriteButton';
+import ListingGallery from '@/components/listing/ListingGallery';
 
 const CURRENCY_SYMBOL = { EUR: '€', GBP: '£', USD: '$' };
 
@@ -68,32 +68,11 @@ export default async function GigDetailPage({ params }) {
         </Link>
 
         {photos.length > 0 && (
-          <div className="mt-4 overflow-hidden rounded-sm">
-            <div className="relative aspect-[16/9] w-full bg-parchment">
-              <Image
-                src={photos[0]}
-                alt={gig.title}
-                fill
-                priority
-                sizes="(max-width: 1024px) 100vw, 896px"
-                className="object-cover"
-              />
-            </div>
-            {photos.length > 1 && (
-              <div className="mt-2 grid grid-cols-4 gap-2">
-                {photos.slice(1, 5).map((src, i) => (
-                  <div key={i} className="relative aspect-[4/3] bg-parchment">
-                    <Image
-                      src={src}
-                      alt={`${gig.title} ${i + 2}`}
-                      fill
-                      sizes="(max-width: 1024px) 25vw, 220px"
-                      className="rounded-sm object-cover"
-                    />
-                  </div>
-                ))}
-              </div>
-            )}
+          <div className="mt-4">
+            {/* Same gallery + full-screen lightbox (zoom / swipe / keyboard)
+                as the property listing pages. variantUrl passes the gig CDN
+                URLs through unchanged, so it works on raw photo URLs too. */}
+            <ListingGallery photos={photos} title={gig.title} />
           </div>
         )}
 

--- a/src/app/[locale]/layout.js
+++ b/src/app/[locale]/layout.js
@@ -6,6 +6,7 @@ import { routing } from '@/i18n/routing';
 import Navbar from '@/components/Navbar';
 import SessionSync from '@/components/SessionSync';
 import FavoritesProvider from '@/components/FavoritesProvider';
+import GigFavoritesProvider from '@/components/GigFavoritesProvider';
 import '../globals.css';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://studentx.uk';
@@ -95,8 +96,10 @@ export default async function LocaleLayout({ children, params }) {
         <NextIntlClientProvider locale={locale} messages={messages}>
           <SessionSync />
           <FavoritesProvider>
-            <Navbar />
-            <main className="flex-1">{children}</main>
+            <GigFavoritesProvider>
+              <Navbar />
+              <main className="flex-1">{children}</main>
+            </GigFavoritesProvider>
           </FavoritesProvider>
         </NextIntlClientProvider>
       </body>

--- a/src/app/[locale]/student/account/accommodation/page.js
+++ b/src/app/[locale]/student/account/accommodation/page.js
@@ -1,0 +1,266 @@
+import { Suspense } from 'react';
+import { redirect } from 'next/navigation';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { Link } from '@/i18n/navigation';
+import { requireStudent } from '@/lib/requireStudent';
+import { transformListing } from '@/lib/transformListing';
+import Card from '@/components/ui/Card';
+import Icon from '@/components/ui/Icon';
+import AccountChrome from '@/components/student/AccountChrome';
+import SavedListings from '@/components/student/SavedListings';
+
+/*
+  Accommodation section of the student account: the saved-listings shortlist
+  plus the student's landlord conversations. This is the content that used to
+  live directly on /student/account, relocated under the account hub + tab bar.
+*/
+
+function formatDate(iso) {
+  if (!iso) return '';
+  try {
+    return new Date(iso).toLocaleString('en-GB', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return '';
+  }
+}
+
+export default async function AccommodationAccountPage({ params }) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const auth = await requireStudent();
+  if (!auth || auth.kind === 'wrong-role') {
+    const loginParams = new URLSearchParams({ next: '/student/account/accommodation' });
+    if (auth?.kind === 'wrong-role' && auth.conflict_role) {
+      loginParams.set('roleConflict', auth.conflict_role);
+      if (auth.email) loginParams.set('email', auth.email);
+    }
+    redirect(`/student/login?${loginParams.toString()}`);
+  }
+
+  const t = await getTranslations({ locale, namespace: 'student.account' });
+  const tFav = await getTranslations({ locale, namespace: 'student.favorites' });
+  const { student } = auth;
+
+  return (
+    <AccountChrome locale={locale} student={student} active="accommodation">
+      <section className="mb-12">
+        <h2 className="font-display text-2xl text-night mb-5">{tFav('panelTitle')}</h2>
+        <Suspense fallback={<SavedSkeleton />}>
+          <SavedSection locale={locale} />
+        </Suspense>
+      </section>
+
+      <section>
+        <h2 className="font-display text-2xl text-night mb-5">{t('title')}</h2>
+        <Suspense fallback={<InquiriesSkeleton />}>
+          <InquiriesSection locale={locale} />
+        </Suspense>
+      </section>
+    </AccountChrome>
+  );
+}
+
+async function SavedSection({ locale }) {
+  const auth = await requireStudent();
+  if (!auth || auth.kind === 'wrong-role') return null;
+
+  const t = await getTranslations({ locale, namespace: 'student.favorites' });
+  const { supabase, student } = auth;
+
+  const { data, error } = await supabase
+    .from('student_favorites')
+    .select(`
+      listing_id,
+      created_at,
+      listings (
+        listing_id,
+        is_featured,
+        title,
+        description,
+        photos,
+        floor,
+        min_duration_months,
+        rent ( monthly_price, currency, bills_included, deposit ),
+        location ( address, neighborhood, lat, lng ),
+        property_types ( name ),
+        landlords ( name, verified_tier, is_verified ),
+        listing_amenities ( amenities ( amenity_id, name ) ),
+        faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
+      )
+    `)
+    .eq('student_id', student.student_id)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return (
+      <p className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-sm px-4 py-3">
+        {t('loadError')}
+      </p>
+    );
+  }
+
+  const listings = (data ?? [])
+    .map((row) => (Array.isArray(row.listings) ? row.listings[0] : row.listings))
+    .filter(Boolean)
+    .map(transformListing);
+
+  return <SavedListings listings={listings} />;
+}
+
+function SavedSkeleton() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-5" aria-busy="true">
+      {[0, 1].map((i) => (
+        <div key={i} className="rounded-sm border border-night/10 bg-white overflow-hidden">
+          <div className="aspect-[4/3] bg-parchment animate-pulse" />
+          <div className="p-5 space-y-3">
+            <div className="h-3 w-28 bg-parchment rounded animate-pulse" />
+            <div className="h-5 w-3/4 bg-parchment rounded animate-pulse" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+async function InquiriesSection({ locale }) {
+  const auth = await requireStudent();
+  if (!auth || auth.kind === 'wrong-role') return null;
+
+  const t = await getTranslations({ locale, namespace: 'student.account' });
+  const { supabase } = auth;
+
+  const { data: inquiries, error } = await supabase
+    .from('inquiries')
+    .select(`
+      inquiry_id,
+      listing_id,
+      created_at,
+      last_message_at,
+      student_unread_count,
+      message,
+      listings (
+        listing_id,
+        location ( address, neighborhood ),
+        rent ( monthly_price )
+      )
+    `)
+    .eq('student_user_id', auth.user.id)
+    .order('last_message_at', { ascending: false, nullsFirst: false })
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return (
+      <p className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-sm px-4 py-3">
+        {t('loadError')}
+      </p>
+    );
+  }
+
+  if (!inquiries || inquiries.length === 0) {
+    return (
+      <Card tone="parchment" className="p-12 text-center">
+        <Icon name="message" className="w-12 h-12 mx-auto text-night/30 mb-3" />
+        <p className="font-display text-xl text-night/60 mb-5">{t('empty')}</p>
+        <Link
+          href="/property/thessaloniki/results"
+          className="inline-flex items-center justify-center bg-blue text-white font-sans font-semibold uppercase tracking-[0.08em] text-xs px-5 py-3 rounded hover:bg-night transition-colors"
+        >
+          {t('emptyCta')}
+        </Link>
+      </Card>
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {inquiries.map((inq) => {
+        const listing = inq.listings;
+        const location = Array.isArray(listing?.location) ? listing.location[0] : listing?.location;
+        const rent = Array.isArray(listing?.rent) ? listing.rent[0] : listing?.rent;
+        const address = location?.address || `#${inq.listing_id}`;
+        const neighborhood = location?.neighborhood;
+        const price = rent?.monthly_price;
+        const unread = inq.student_unread_count || 0;
+        const lastWhen = inq.last_message_at ? formatDate(inq.last_message_at) : null;
+
+        return (
+          <li key={inq.inquiry_id}>
+            <Card tone="white" className="p-5 md:p-6">
+              <div className="flex items-start justify-between gap-4 mb-4">
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2 mb-1">
+                    <p className="font-display text-xl text-night truncate">{address}</p>
+                    {unread > 0 && (
+                      <span
+                        aria-label={t('unread', { count: unread })}
+                        className="inline-flex items-center justify-center min-w-5 h-5 rounded-full bg-yellow text-white text-[11px] font-sans font-semibold px-1.5"
+                      >
+                        {unread}
+                      </span>
+                    )}
+                  </div>
+                  {neighborhood && <p className="label-caps text-night/50">{neighborhood}</p>}
+                </div>
+                <div className="text-right shrink-0">
+                  {price != null && (
+                    <p className="font-display text-xl text-blue">
+                      €{price}
+                      <span className="text-xs text-night/50">/mo</span>
+                    </p>
+                  )}
+                  <p className="mt-1 label-caps text-night/40">
+                    {lastWhen ? t('lastMessageAt', { when: lastWhen }) : t('lastMessageNever')}
+                  </p>
+                </div>
+              </div>
+
+              {inq.message && (
+                <blockquote className="bg-parchment rounded-sm px-5 py-4 text-night/80 leading-relaxed mb-4 font-sans text-sm md:text-base">
+                  {inq.message}
+                </blockquote>
+              )}
+
+              <div className="flex flex-wrap items-center gap-2">
+                <Link
+                  href={`/student/inquiries/${inq.inquiry_id}`}
+                  className="inline-flex items-center justify-center gap-1 bg-blue text-white text-xs font-sans font-semibold uppercase tracking-[0.08em] px-3 py-1.5 rounded hover:bg-night transition-colors"
+                >
+                  <Icon name="message" className="w-3.5 h-3.5" />
+                  {t('openThread')}
+                </Link>
+              </div>
+            </Card>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function InquiriesSkeleton() {
+  return (
+    <ul className="space-y-3" aria-busy="true">
+      {[0, 1, 2].map((i) => (
+        <li key={i}>
+          <Card tone="white" className="p-5 md:p-6">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0 flex-1 space-y-2">
+                <div className="h-6 w-2/3 bg-parchment rounded animate-pulse" />
+                <div className="h-3 w-1/3 bg-parchment rounded animate-pulse" />
+                <div className="h-3 w-3/4 bg-parchment rounded animate-pulse mt-3" />
+              </div>
+              <div className="h-6 w-16 bg-parchment rounded animate-pulse" />
+            </div>
+          </Card>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/app/[locale]/student/account/gigs/page.js
+++ b/src/app/[locale]/student/account/gigs/page.js
@@ -7,7 +7,7 @@ import { transformGig } from '@/lib/transformGig';
 import Card from '@/components/ui/Card';
 import Icon from '@/components/ui/Icon';
 import AccountChrome from '@/components/student/AccountChrome';
-import GigCard from '@/components/GigCard';
+import SavedGigs from '@/components/student/SavedGigs';
 
 /*
   Holiday Gigs section of the student account — mirrors the accommodation
@@ -101,28 +101,9 @@ async function SavedGigsSection({ locale }) {
     .filter(Boolean)
     .map(transformGig);
 
-  if (gigs.length === 0) {
-    return (
-      <Card tone="parchment" className="p-12 text-center">
-        <Icon name="heart" className="w-12 h-12 mx-auto text-night/30 mb-3" />
-        <p className="font-display text-xl text-night/60 mb-5">{tFav('empty')}</p>
-        <Link
-          href="/gigs"
-          className="inline-flex items-center justify-center bg-blue text-white font-sans font-semibold uppercase tracking-[0.08em] text-xs px-5 py-3 rounded hover:bg-night transition-colors"
-        >
-          {tFav('browse')}
-        </Link>
-      </Card>
-    );
-  }
-
-  return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
-      {gigs.map((gig) => (
-        <GigCard key={gig.gig_id} gig={gig} />
-      ))}
-    </div>
-  );
+  // Client wrapper handles the empty state + optimistic unsave (mirrors
+  // SavedListings on the accommodation section).
+  return <SavedGigs gigs={gigs} />;
 }
 
 async function InterestsSection({ locale }) {

--- a/src/app/[locale]/student/account/gigs/page.js
+++ b/src/app/[locale]/student/account/gigs/page.js
@@ -1,0 +1,252 @@
+import { Suspense } from 'react';
+import { redirect } from 'next/navigation';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { Link } from '@/i18n/navigation';
+import { requireStudent } from '@/lib/requireStudent';
+import { transformGig } from '@/lib/transformGig';
+import Card from '@/components/ui/Card';
+import Icon from '@/components/ui/Icon';
+import AccountChrome from '@/components/student/AccountChrome';
+import GigCard from '@/components/GigCard';
+
+/*
+  Holiday Gigs section of the student account — mirrors the accommodation
+  section: a saved-gigs shortlist plus the gigs the student has expressed
+  interest in (their "applications"). Both read the student's own rows under
+  the RLS policies added in migration 062.
+*/
+
+function formatDate(iso) {
+  if (!iso) return '';
+  try {
+    return new Date(iso).toLocaleString('en-GB', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return '';
+  }
+}
+
+export default async function GigsAccountPage({ params }) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const auth = await requireStudent();
+  if (!auth || auth.kind === 'wrong-role') {
+    const loginParams = new URLSearchParams({ next: '/student/account/gigs' });
+    if (auth?.kind === 'wrong-role' && auth.conflict_role) {
+      loginParams.set('roleConflict', auth.conflict_role);
+      if (auth.email) loginParams.set('email', auth.email);
+    }
+    redirect(`/student/login?${loginParams.toString()}`);
+  }
+
+  const t = await getTranslations({ locale, namespace: 'student.account' });
+  const tFav = await getTranslations({ locale, namespace: 'gigs.favorites' });
+  const { student } = auth;
+
+  return (
+    <AccountChrome locale={locale} student={student} active="gigs">
+      <section className="mb-12">
+        <h2 className="font-display text-2xl text-night mb-5">{tFav('panelTitle')}</h2>
+        <Suspense fallback={<GridSkeleton />}>
+          <SavedGigsSection locale={locale} />
+        </Suspense>
+      </section>
+
+      <section>
+        <h2 className="font-display text-2xl text-night mb-5">{t('gigsInterestsTitle')}</h2>
+        <Suspense fallback={<ListSkeleton />}>
+          <InterestsSection locale={locale} />
+        </Suspense>
+      </section>
+    </AccountChrome>
+  );
+}
+
+async function SavedGigsSection({ locale }) {
+  const auth = await requireStudent();
+  if (!auth || auth.kind === 'wrong-role') return null;
+
+  const tFav = await getTranslations({ locale, namespace: 'gigs.favorites' });
+  const { supabase, student } = auth;
+
+  const { data, error } = await supabase
+    .from('gig_favorites')
+    .select(`
+      gig_id,
+      created_at,
+      gigs (
+        gig_id, title, employer_name, description, is_paid, pay_amount,
+        pay_period, currency, country_code, city, lat, lng, available_from,
+        min_duration_weeks, photos, created_at
+      )
+    `)
+    .eq('student_id', student.student_id)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return (
+      <p className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-sm px-4 py-3">
+        {tFav('loadError')}
+      </p>
+    );
+  }
+
+  const gigs = (data ?? [])
+    .map((row) => (Array.isArray(row.gigs) ? row.gigs[0] : row.gigs))
+    .filter(Boolean)
+    .map(transformGig);
+
+  if (gigs.length === 0) {
+    return (
+      <Card tone="parchment" className="p-12 text-center">
+        <Icon name="heart" className="w-12 h-12 mx-auto text-night/30 mb-3" />
+        <p className="font-display text-xl text-night/60 mb-5">{tFav('empty')}</p>
+        <Link
+          href="/gigs"
+          className="inline-flex items-center justify-center bg-blue text-white font-sans font-semibold uppercase tracking-[0.08em] text-xs px-5 py-3 rounded hover:bg-night transition-colors"
+        >
+          {tFav('browse')}
+        </Link>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+      {gigs.map((gig) => (
+        <GigCard key={gig.gig_id} gig={gig} />
+      ))}
+    </div>
+  );
+}
+
+async function InterestsSection({ locale }) {
+  const auth = await requireStudent();
+  if (!auth || auth.kind === 'wrong-role') return null;
+
+  const t = await getTranslations({ locale, namespace: 'student.account' });
+  const { supabase, user } = auth;
+
+  const { data: interests, error } = await supabase
+    .from('gig_inquiries')
+    .select(`
+      inquiry_id,
+      gig_id,
+      created_at,
+      status,
+      message,
+      gigs ( gig_id, title, employer_name, country_code, city )
+    `)
+    .eq('student_user_id', user.id)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return (
+      <p className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-sm px-4 py-3">
+        {t('loadError')}
+      </p>
+    );
+  }
+
+  if (!interests || interests.length === 0) {
+    return (
+      <Card tone="parchment" className="p-12 text-center">
+        <Icon name="message" className="w-12 h-12 mx-auto text-night/30 mb-3" />
+        <p className="font-display text-xl text-night/60 mb-5">{t('gigsInterestsEmpty')}</p>
+        <Link
+          href="/gigs"
+          className="inline-flex items-center justify-center bg-blue text-white font-sans font-semibold uppercase tracking-[0.08em] text-xs px-5 py-3 rounded hover:bg-night transition-colors"
+        >
+          {t('gigsInterestsCta')}
+        </Link>
+      </Card>
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {interests.map((row) => {
+        const gig = Array.isArray(row.gigs) ? row.gigs[0] : row.gigs;
+        const title = gig?.title || 'Gig';
+        const place = [gig?.city, gig?.country_code].filter(Boolean).join(', ');
+        const sentWhen = formatDate(row.created_at);
+
+        return (
+          <li key={row.inquiry_id}>
+            <Card tone="white" className="p-5 md:p-6">
+              <div className="flex items-start justify-between gap-4 mb-3">
+                <div className="min-w-0 flex-1">
+                  <p className="font-display text-xl text-night truncate">{title}</p>
+                  {(gig?.employer_name || place) && (
+                    <p className="label-caps text-night/50">
+                      {[gig?.employer_name, place].filter(Boolean).join(' · ')}
+                    </p>
+                  )}
+                </div>
+                <span className="shrink-0 inline-flex items-center rounded-full bg-blue/10 text-blue text-[11px] font-sans font-semibold uppercase tracking-[0.08em] px-2.5 py-1">
+                  {t('interestStatusSent')}
+                </span>
+              </div>
+
+              {row.message && (
+                <blockquote className="bg-parchment rounded-sm px-5 py-4 text-night/80 leading-relaxed mb-4 font-sans text-sm md:text-base">
+                  {row.message}
+                </blockquote>
+              )}
+
+              <div className="flex items-center justify-between gap-2">
+                <p className="label-caps text-night/40">{t('interestSentOn', { when: sentWhen })}</p>
+                {gig?.gig_id && (
+                  <Link
+                    href={`/gigs/${gig.gig_id}`}
+                    className="inline-flex items-center justify-center gap-1 border border-blue text-blue text-xs font-sans font-semibold uppercase tracking-[0.08em] px-3 py-1.5 rounded hover:bg-blue hover:text-white transition-colors"
+                  >
+                    {t('viewGig')}
+                  </Link>
+                )}
+              </div>
+            </Card>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function GridSkeleton() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-5" aria-busy="true">
+      {[0, 1].map((i) => (
+        <div key={i} className="rounded-sm border border-night/10 bg-white overflow-hidden">
+          <div className="aspect-[4/3] bg-parchment animate-pulse" />
+          <div className="p-5 space-y-3">
+            <div className="h-3 w-28 bg-parchment rounded animate-pulse" />
+            <div className="h-5 w-3/4 bg-parchment rounded animate-pulse" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ListSkeleton() {
+  return (
+    <ul className="space-y-3" aria-busy="true">
+      {[0, 1].map((i) => (
+        <li key={i}>
+          <Card tone="white" className="p-5 md:p-6">
+            <div className="space-y-2">
+              <div className="h-6 w-2/3 bg-parchment rounded animate-pulse" />
+              <div className="h-3 w-1/3 bg-parchment rounded animate-pulse" />
+            </div>
+          </Card>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/app/[locale]/student/account/page.js
+++ b/src/app/[locale]/student/account/page.js
@@ -1,39 +1,22 @@
-import { Suspense } from 'react';
 import { redirect } from 'next/navigation';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
-import { Link } from '@/i18n/navigation';
 import { requireStudent } from '@/lib/requireStudent';
-import { transformListing } from '@/lib/transformListing';
-import Card from '@/components/ui/Card';
-import Icon from '@/components/ui/Icon';
+import HubButton from '@/components/HubButton';
 import SignOutButton from '@/components/student/SignOutButton';
-import SavedListings from '@/components/student/SavedListings';
 
-function formatDate(iso) {
-  if (!iso) return '';
-  try {
-    return new Date(iso).toLocaleString('en-GB', {
-      day: '2-digit',
-      month: 'short',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  } catch {
-    return '';
-  }
-}
-
+/*
+  Student account HUB — the everything-app landing, mirroring the homepage:
+  big buttons that lead into each gated service's section. For now the gated
+  services are Accommodation and Holiday Gigs. The per-section content lives at
+  /student/account/{accommodation,gigs}, which share a tab bar (AccountChrome)
+  so the student can hop between them without coming back here.
+*/
 export default async function StudentAccountPage({ params }) {
   const { locale } = await params;
   setRequestLocale(locale);
 
   const auth = await requireStudent();
   if (!auth || auth.kind === 'wrong-role') {
-    // Not signed in (or signed in as the wrong role, e.g. a landlord) —
-    // bounce to the student login. Preserve the page they were trying
-    // to reach so post-login lands them back here, and carry the
-    // conflict context so the login page can show a "switch to
-    // landlord login" CTA instead of a silent re-prompt.
     const loginParams = new URLSearchParams({ next: '/student/account' });
     if (auth?.kind === 'wrong-role' && auth.conflict_role) {
       loginParams.set('roleConflict', auth.conflict_role);
@@ -43,255 +26,38 @@ export default async function StudentAccountPage({ params }) {
   }
 
   const t = await getTranslations({ locale, namespace: 'student.account' });
-  const tFav = await getTranslations({ locale, namespace: 'student.favorites' });
   const { student } = auth;
 
-  // Page shell renders synchronously — the user sees their name and the
-  // chrome on the first byte. The saved-listings and inquiry SELECTs each
-  // stream in via their own <Suspense> boundary below; both join listings →
-  // location, rent and are the slowest things on this page, so keeping them
-  // off the critical path cuts perceived post-login latency.
+  const buttons = [
+    {
+      id: 'accommodation',
+      label: t('hubAccommodation'),
+      subtext: t('hubAccommodationSub'),
+      href: '/student/account/accommodation',
+    },
+    {
+      id: 'gigs',
+      label: t('hubHolidayGigs'),
+      subtext: t('hubHolidayGigsSub'),
+      href: '/student/account/gigs',
+    },
+  ];
+
   return (
-    <div className="mx-auto max-w-3xl px-5 py-12 md:py-16">
+    <div className="mx-auto max-w-2xl px-5 py-12 md:py-16">
       <div className="flex items-start justify-between gap-4 mb-2">
         <p className="label-caps text-yellow">{t('eyebrow')}</p>
         <SignOutButton />
       </div>
-      <h1 className="font-display text-3xl md:text-4xl text-night mb-2">{t('heading')}</h1>
-      <p className="text-night/60 mb-10">{student.display_name} · {student.email}</p>
+      <h1 className="font-display text-3xl md:text-4xl text-night mb-1">{t('heading')}</h1>
+      <p className="text-night/60 mb-1">{student.display_name} · {student.email}</p>
+      <p className="text-night/60 mb-10">{t('hubSubtitle')}</p>
 
-      {/* Saved / shortlist */}
-      <section className="mb-12">
-        <h2 className="font-display text-2xl text-night mb-5">{tFav('panelTitle')}</h2>
-        <Suspense fallback={<SavedSkeleton />}>
-          <SavedSection locale={locale} />
-        </Suspense>
-      </section>
-
-      {/* Inquiries */}
-      <section>
-        <h2 className="font-display text-2xl text-night mb-5">{t('title')}</h2>
-        <Suspense fallback={<InquiriesSkeleton />}>
-          <InquiriesSection locale={locale} />
-        </Suspense>
-      </section>
+      <div className="flex flex-col gap-4">
+        {buttons.map((b) => (
+          <HubButton key={b.id} label={b.label} subtext={b.subtext} href={b.href} />
+        ))}
+      </div>
     </div>
-  );
-}
-
-async function SavedSection({ locale }) {
-  // requireStudent is React.cache()'d, so this resolves from the
-  // per-request cache populated by the page shell — no extra round-trip.
-  const auth = await requireStudent();
-  if (!auth || auth.kind === 'wrong-role') return null;
-
-  const t = await getTranslations({ locale, namespace: 'student.favorites' });
-  const { supabase, student } = auth;
-
-  // RLS already restricts student_favorites to the caller's rows; the
-  // explicit student_id eq makes intent clear and uses the PK index. The
-  // nested embed pulls everything ListingCard needs in one query, matching
-  // transformListing's expected shape.
-  const { data, error } = await supabase
-    .from('student_favorites')
-    .select(`
-      listing_id,
-      created_at,
-      listings (
-        listing_id,
-        is_featured,
-        title,
-        description,
-        photos,
-        floor,
-        min_duration_months,
-        rent ( monthly_price, currency, bills_included, deposit ),
-        location ( address, neighborhood, lat, lng ),
-        property_types ( name ),
-        landlords ( name, verified_tier, is_verified ),
-        listing_amenities ( amenities ( amenity_id, name ) ),
-        faculty_distances ( faculty_id, walk_minutes, transit_minutes, faculties ( name, university ) )
-      )
-    `)
-    .eq('student_id', student.student_id)
-    .order('created_at', { ascending: false });
-
-  if (error) {
-    return (
-      <p className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-sm px-4 py-3">
-        {t('loadError')}
-      </p>
-    );
-  }
-
-  // PostgREST returns the to-one listings embed as an object; guard for an
-  // array form and for rows whose listing was removed mid-flight.
-  const listings = (data ?? [])
-    .map((row) => (Array.isArray(row.listings) ? row.listings[0] : row.listings))
-    .filter(Boolean)
-    .map(transformListing);
-
-  return <SavedListings listings={listings} />;
-}
-
-function SavedSkeleton() {
-  return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 gap-5" aria-busy="true">
-      {[0, 1].map((i) => (
-        <div
-          key={i}
-          className="rounded-sm border border-night/10 bg-white overflow-hidden"
-        >
-          <div className="aspect-[4/3] bg-parchment animate-pulse" />
-          <div className="p-5 space-y-3">
-            <div className="h-3 w-28 bg-parchment rounded animate-pulse" />
-            <div className="h-5 w-3/4 bg-parchment rounded animate-pulse" />
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-async function InquiriesSection({ locale }) {
-  // requireStudent is wrapped in React.cache() so this second call
-  // resolves from the per-request cache populated by the page shell —
-  // no extra DB or auth work.
-  const auth = await requireStudent();
-  if (!auth || auth.kind === 'wrong-role') return null;
-
-  const t = await getTranslations({ locale, namespace: 'student.account' });
-  const { supabase } = auth;
-
-  const { data: inquiries, error } = await supabase
-    .from('inquiries')
-    .select(`
-      inquiry_id,
-      listing_id,
-      created_at,
-      last_message_at,
-      student_unread_count,
-      message,
-      listings (
-        listing_id,
-        location ( address, neighborhood ),
-        rent ( monthly_price )
-      )
-    `)
-    .eq('student_user_id', auth.user.id)
-    .order('last_message_at', { ascending: false, nullsFirst: false })
-    .order('created_at', { ascending: false });
-
-  if (error) {
-    return (
-      <p className="text-sm text-red-700 bg-red-50 border border-red-200 rounded-sm px-4 py-3">
-        {t('loadError')}
-      </p>
-    );
-  }
-
-  if (!inquiries || inquiries.length === 0) {
-    return (
-      <Card tone="parchment" className="p-12 text-center">
-        <Icon name="message" className="w-12 h-12 mx-auto text-night/30 mb-3" />
-        <p className="font-display text-xl text-night/60 mb-5">{t('empty')}</p>
-        <Link
-          href="/property/thessaloniki/results"
-          className="inline-flex items-center justify-center bg-blue text-white font-sans font-semibold uppercase tracking-[0.08em] text-xs px-5 py-3 rounded hover:bg-night transition-colors"
-        >
-          {t('emptyCta')}
-        </Link>
-      </Card>
-    );
-  }
-
-  return (
-    <ul className="space-y-3">
-      {inquiries.map((inq) => {
-        const listing = inq.listings;
-        const location = Array.isArray(listing?.location) ? listing.location[0] : listing?.location;
-        const rent = Array.isArray(listing?.rent) ? listing.rent[0] : listing?.rent;
-        const address = location?.address || `#${inq.listing_id}`;
-        const neighborhood = location?.neighborhood;
-        const price = rent?.monthly_price;
-        const unread = inq.student_unread_count || 0;
-        const lastWhen = inq.last_message_at ? formatDate(inq.last_message_at) : null;
-
-        return (
-          <li key={inq.inquiry_id}>
-            <Card tone="white" className="p-5 md:p-6">
-              <div className="flex items-start justify-between gap-4 mb-4">
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2 mb-1">
-                    <p className="font-display text-xl text-night truncate">{address}</p>
-                    {unread > 0 && (
-                      <span
-                        aria-label={t('unread', { count: unread })}
-                        className="inline-flex items-center justify-center min-w-5 h-5 rounded-full bg-yellow text-white text-[11px] font-sans font-semibold px-1.5"
-                      >
-                        {unread}
-                      </span>
-                    )}
-                  </div>
-                  {neighborhood && (
-                    <p className="label-caps text-night/50">{neighborhood}</p>
-                  )}
-                </div>
-                <div className="text-right shrink-0">
-                  {price != null && (
-                    <p className="font-display text-xl text-blue">
-                      €{price}
-                      <span className="text-xs text-night/50">/mo</span>
-                    </p>
-                  )}
-                  <p className="mt-1 label-caps text-night/40">
-                    {lastWhen
-                      ? t('lastMessageAt', { when: lastWhen })
-                      : t('lastMessageNever')}
-                  </p>
-                </div>
-              </div>
-
-              {inq.message && (
-                <blockquote className="bg-parchment rounded-sm px-5 py-4 text-night/80 leading-relaxed mb-4 font-sans text-sm md:text-base">
-                  {inq.message}
-                </blockquote>
-              )}
-
-              <div className="flex flex-wrap items-center gap-2">
-                <Link
-                  href={`/student/inquiries/${inq.inquiry_id}`}
-                  className="inline-flex items-center justify-center gap-1 bg-blue text-white text-xs font-sans font-semibold uppercase tracking-[0.08em] px-3 py-1.5 rounded hover:bg-night transition-colors"
-                >
-                  <Icon name="message" className="w-3.5 h-3.5" />
-                  {t('openThread')}
-                </Link>
-              </div>
-            </Card>
-          </li>
-        );
-      })}
-    </ul>
-  );
-}
-
-function InquiriesSkeleton() {
-  return (
-    <ul className="space-y-3" aria-busy="true">
-      {[0, 1, 2].map((i) => (
-        <li key={i}>
-          <Card tone="white" className="p-5 md:p-6">
-            <div className="flex items-start justify-between gap-4">
-              <div className="min-w-0 flex-1 space-y-2">
-                <div className="h-6 w-2/3 bg-parchment rounded animate-pulse" />
-                <div className="h-3 w-1/3 bg-parchment rounded animate-pulse" />
-                <div className="h-3 w-3/4 bg-parchment rounded animate-pulse mt-3" />
-              </div>
-              <div className="h-6 w-16 bg-parchment rounded animate-pulse" />
-            </div>
-          </Card>
-        </li>
-      ))}
-    </ul>
   );
 }

--- a/src/app/api/me/gig-favorites/route.js
+++ b/src/app/api/me/gig-favorites/route.js
@@ -1,0 +1,110 @@
+import { NextResponse } from 'next/server';
+import { extractToken, getUserFromToken, getSupabaseWithToken } from '@/lib/supabaseServer';
+
+// Per-user data — never cache.
+const NO_STORE = { 'Cache-Control': 'private, no-store' };
+
+// gigs.gig_id is a UUID (migration 061). Reject anything else before it
+// reaches the DB / RLS layer.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function unauthenticated() {
+  return NextResponse.json(
+    { error: 'UNAUTHENTICATED' },
+    { status: 401, headers: NO_STORE },
+  );
+}
+
+/**
+ * Resolve the caller to a student row from the Bearer token. Mirrors
+ * /api/me/favorites (the accommodation shortlist) — same auth shape, gig table.
+ */
+async function resolveStudent(request) {
+  const token = extractToken(request);
+  if (!token) return { error: unauthenticated() };
+
+  const user = await getUserFromToken(token);
+  if (!user) return { error: unauthenticated() };
+
+  const supabase = getSupabaseWithToken(token);
+  const { data: student } = await supabase
+    .from('students')
+    .select('student_id')
+    .eq('auth_user_id', user.id)
+    .maybeSingle();
+
+  if (!student) return { error: unauthenticated() };
+  return { supabase, studentId: student.student_id };
+}
+
+// GET — list the signed-in student's saved gigs, newest first.
+export async function GET(request) {
+  const ctx = await resolveStudent(request);
+  if (ctx.error) return ctx.error;
+
+  const { data, error } = await ctx.supabase
+    .from('gig_favorites')
+    .select('gig_id, created_at')
+    .eq('student_id', ctx.studentId)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    return NextResponse.json({ error: 'FETCH_FAILED' }, { status: 500, headers: NO_STORE });
+  }
+
+  return NextResponse.json({ favorites: data ?? [] }, { headers: NO_STORE });
+}
+
+// POST { gig_id } — save a gig. Idempotent: re-saving returns ok.
+export async function POST(request) {
+  const ctx = await resolveStudent(request);
+  if (ctx.error) return ctx.error;
+
+  const body = await request.json().catch(() => ({}));
+  const gigId = typeof body.gig_id === 'string' ? body.gig_id.trim() : '';
+  if (!UUID_RE.test(gigId)) {
+    return NextResponse.json({ error: 'INVALID_GIG_ID' }, { status: 400, headers: NO_STORE });
+  }
+
+  const { error } = await ctx.supabase
+    .from('gig_favorites')
+    .insert({ student_id: ctx.studentId, gig_id: gigId });
+
+  if (error) {
+    if (error.code === '23505') {
+      // already saved — treat as success.
+      return NextResponse.json({ ok: true, already: true }, { headers: NO_STORE });
+    }
+    if (error.code === '23503') {
+      // the gig doesn't exist.
+      return NextResponse.json({ error: 'GIG_NOT_FOUND' }, { status: 404, headers: NO_STORE });
+    }
+    return NextResponse.json({ error: 'SAVE_FAILED' }, { status: 500, headers: NO_STORE });
+  }
+
+  return NextResponse.json({ ok: true }, { status: 201, headers: NO_STORE });
+}
+
+// DELETE ?gig_id=… — unsave a gig. Id rides in the query string so the
+// request stays body-less (safest DELETE shape on the Workers runtime).
+export async function DELETE(request) {
+  const ctx = await resolveStudent(request);
+  if (ctx.error) return ctx.error;
+
+  const gigId = (new URL(request.url).searchParams.get('gig_id') || '').trim();
+  if (!UUID_RE.test(gigId)) {
+    return NextResponse.json({ error: 'INVALID_GIG_ID' }, { status: 400, headers: NO_STORE });
+  }
+
+  const { error } = await ctx.supabase
+    .from('gig_favorites')
+    .delete()
+    .eq('student_id', ctx.studentId)
+    .eq('gig_id', gigId);
+
+  if (error) {
+    return NextResponse.json({ error: 'DELETE_FAILED' }, { status: 500, headers: NO_STORE });
+  }
+
+  return NextResponse.json({ ok: true }, { headers: NO_STORE });
+}

--- a/src/components/GigCard.js
+++ b/src/components/GigCard.js
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { Link } from '@/i18n/navigation';
 import Pill from '@/components/ui/Pill';
 import Icon from '@/components/ui/Icon';
+import GigFavoriteButton from '@/components/GigFavoriteButton';
 
 /*
   Holiday Gigs card — sibling of ListingCard, trimmed for jobs. Shows role,
@@ -111,6 +112,10 @@ export default function GigCard({ gig, fromQuery = '' }) {
         aria-label={gig.title}
         className="absolute inset-0 z-0 rounded-sm focus-visible:outline-2 focus-visible:outline-yellow focus-visible:outline-offset-2"
       />
+
+      {/* Save toggle — over the photo's top-left, above the stretched link.
+          The right corner is reserved for the Paid/Unpaid badge. */}
+      <GigFavoriteButton gigId={gig.gig_id} className="absolute top-3 left-3 z-10" />
     </div>
   );
 }

--- a/src/components/GigFavoriteButton.js
+++ b/src/components/GigFavoriteButton.js
@@ -1,0 +1,60 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import Icon from '@/components/ui/Icon';
+import { useGigFavorites } from '@/components/GigFavoritesProvider';
+
+/*
+  Save / heart toggle for a single gig. Sibling of FavoriteButton (listings).
+  Two looks: default (icon-only pill over the GigCard photo) and withLabel
+  (outlined button for the gig detail page). State lives in GigFavoritesProvider.
+*/
+export default function GigFavoriteButton({ gigId, withLabel = false, className = '' }) {
+  const t = useTranslations('gigs.favorites');
+  const { isFavorited, toggle } = useGigFavorites();
+  const saved = isFavorited(gigId);
+
+  const ariaLabel = saved ? t('removeAria') : t('saveAria');
+
+  function handleClick(e) {
+    // The card itself is a link; don't navigate when the heart is tapped.
+    e.preventDefault();
+    e.stopPropagation();
+    toggle(gigId);
+  }
+
+  if (withLabel) {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        aria-pressed={saved}
+        aria-label={ariaLabel}
+        className={`inline-flex items-center gap-2 rounded-sm border px-4 py-2.5 font-sans font-semibold uppercase tracking-[0.08em] text-xs transition-colors ${
+          saved
+            ? 'border-magenta bg-magenta/5 text-magenta'
+            : 'border-night/20 text-night/70 hover:border-magenta hover:text-magenta'
+        } ${className}`}
+      >
+        <Icon name="heart" className="w-4 h-4" fill={saved ? 'currentColor' : 'none'} />
+        {saved ? t('saved') : t('save')}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-pressed={saved}
+      aria-label={ariaLabel}
+      className={`inline-flex items-center justify-center w-9 h-9 rounded-full bg-white/85 backdrop-blur-sm shadow-[0_1px_6px_-1px_rgba(10,20,54,0.3)] transition-all hover:bg-white hover:scale-105 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-magenta ${className}`}
+    >
+      <Icon
+        name="heart"
+        className={`w-[18px] h-[18px] transition-colors ${saved ? 'text-magenta' : 'text-night/45'}`}
+        fill={saved ? 'currentColor' : 'none'}
+      />
+    </button>
+  );
+}

--- a/src/components/GigFavoritesProvider.js
+++ b/src/components/GigFavoritesProvider.js
@@ -1,0 +1,202 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from 'react';
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/navigation';
+import { useAccessToken } from '@/lib/useAccessToken';
+import Card from '@/components/ui/Card';
+import Icon from '@/components/ui/Icon';
+import { safeNextPath } from '@/lib/safeNext';
+
+/*
+  Client context backing the Holiday Gigs "save" toggles. Direct sibling of
+  FavoritesProvider (accommodation shortlist) — same optimistic-toggle +
+  sign-in-gate machinery, pointed at /api/me/gig-favorites and keyed on gig_id.
+
+  Mounted once high in the tree so every GigCard heart on /gigs/results, the
+  save button on a gig detail page, and the Saved gigs panel in the account
+  all read/mutate one shared Set.
+
+  Auth state from useAccessToken(): null → resolving (ignore clicks);
+  '' → signed out (a click opens the gate); token → signed in (toggles hit
+  the API optimistically).
+*/
+
+const NOOP = {
+  favorites: new Set(),
+  loaded: false,
+  isFavorited: () => false,
+  toggle: () => {},
+};
+
+const GigFavoritesContext = createContext(null);
+
+export function useGigFavorites() {
+  return useContext(GigFavoritesContext) ?? NOOP;
+}
+
+export default function GigFavoritesProvider({ children }) {
+  const token = useAccessToken();
+  const [favorites, setFavorites] = useState(() => new Set());
+  const [loaded, setLoaded] = useState(false);
+  const [gateOpen, setGateOpen] = useState(false);
+
+  const pendingRef = useRef(new Set());
+
+  useEffect(() => {
+    if (token === null) return;
+
+    let cancelled = false;
+    (async () => {
+      if (token === '') {
+        if (!cancelled) {
+          setFavorites(new Set());
+          setLoaded(true);
+        }
+        return;
+      }
+      try {
+        const res = await fetch('/api/me/gig-favorites', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const data = res.ok ? await res.json().catch(() => ({})) : {};
+        if (cancelled) return;
+        setFavorites(new Set((data.favorites || []).map((f) => f.gig_id)));
+        setLoaded(true);
+      } catch {
+        if (cancelled) return;
+        setFavorites(new Set());
+        setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  const isFavorited = useCallback((id) => favorites.has(id), [favorites]);
+
+  const toggle = useCallback(async (id) => {
+    if (!token) {
+      if (token === '') setGateOpen(true);
+      return;
+    }
+    if (pendingRef.current.has(id)) return;
+    pendingRef.current.add(id);
+
+    const wasSaved = favorites.has(id);
+    setFavorites((prev) => {
+      const next = new Set(prev);
+      if (wasSaved) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+    const rollback = () =>
+      setFavorites((prev) => {
+        const next = new Set(prev);
+        if (wasSaved) next.add(id);
+        else next.delete(id);
+        return next;
+      });
+
+    try {
+      const res = wasSaved
+        ? await fetch(`/api/me/gig-favorites?gig_id=${encodeURIComponent(id)}`, {
+            method: 'DELETE',
+            headers: { Authorization: `Bearer ${token}` },
+          })
+        : await fetch('/api/me/gig-favorites', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ gig_id: id }),
+          });
+
+      if (!res.ok) {
+        rollback();
+        if (res.status === 401) setGateOpen(true);
+      }
+    } catch {
+      rollback();
+    } finally {
+      pendingRef.current.delete(id);
+    }
+  }, [token, favorites]);
+
+  const value = useMemo(
+    () => ({ favorites, loaded, isFavorited, toggle }),
+    [favorites, loaded, isFavorited, toggle],
+  );
+
+  return (
+    <GigFavoritesContext.Provider value={value}>
+      {children}
+      <GigFavoriteAuthGate open={gateOpen} onClose={() => setGateOpen(false)} />
+    </GigFavoritesContext.Provider>
+  );
+}
+
+function GigFavoriteAuthGate({ open, onClose }) {
+  const t = useTranslations('student.gate');
+  const tGig = useTranslations('gigs.favorites');
+
+  if (!open) return null;
+
+  const raw =
+    typeof window !== 'undefined'
+      ? window.location.pathname + window.location.search
+      : '';
+  const safeNext = safeNextPath(raw);
+  const nextQuery = safeNext ? `?next=${encodeURIComponent(safeNext)}` : '';
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-night/60" onClick={onClose} />
+      <Card tone="white" className="relative z-10 w-full max-w-md p-8 text-center">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={tGig('close')}
+          className="absolute top-4 right-4 p-1 text-night/50 hover:text-night transition-colors"
+        >
+          <Icon name="x" className="w-5 h-5" />
+        </button>
+
+        <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-magenta/15 mb-5">
+          <Icon name="heart" className="w-6 h-6 text-magenta" fill="currentColor" />
+        </div>
+
+        <h2 className="font-display text-2xl text-night leading-tight mb-3">
+          {tGig('gateTitle')}
+        </h2>
+        <p className="text-night/70 leading-relaxed mb-8">{tGig('gateBody')}</p>
+
+        <div className="space-y-3">
+          <Link
+            href={`/student/signup${nextQuery}`}
+            className="inline-flex items-center justify-center w-full bg-blue text-white font-sans font-semibold uppercase tracking-[0.08em] text-xs px-5 py-3 rounded hover:bg-night transition-colors"
+          >
+            {t('signUp')}
+          </Link>
+          <Link
+            href={`/student/login${nextQuery}`}
+            className="inline-flex items-center justify-center w-full border border-blue text-blue font-sans font-semibold uppercase tracking-[0.08em] text-xs px-5 py-3 rounded hover:bg-blue hover:text-white transition-colors"
+          >
+            {t('signIn')}
+          </Link>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/student/AccountChrome.js
+++ b/src/components/student/AccountChrome.js
@@ -1,0 +1,51 @@
+import { getTranslations } from 'next-intl/server';
+import { Link } from '@/i18n/navigation';
+import SignOutButton from '@/components/student/SignOutButton';
+
+/*
+  Shared shell for the student account SECTION pages (accommodation, gigs).
+  Renders the back-to-hub link, greeting, sign-out, and the discrete tab bar
+  that lets the student switch between sections without returning to the hub.
+  The hub landing (/student/account) does NOT use this — it shows the big
+  buttons instead.
+*/
+export default async function AccountChrome({ locale, student, active, children }) {
+  const t = await getTranslations({ locale, namespace: 'student.account' });
+
+  const tabs = [
+    { id: 'accommodation', label: t('tabAccommodation'), href: '/student/account/accommodation' },
+    { id: 'gigs', label: t('tabHolidayGigs'), href: '/student/account/gigs' },
+  ];
+
+  return (
+    <div className="mx-auto max-w-3xl px-5 py-12 md:py-16">
+      <div className="flex items-start justify-between gap-4 mb-2">
+        <Link href="/student/account" className="label-caps text-yellow hover:text-night transition-colors">
+          ← {t('backToAccount')}
+        </Link>
+        <SignOutButton />
+      </div>
+      <h1 className="font-display text-3xl md:text-4xl text-night mb-1">{t('heading')}</h1>
+      <p className="text-night/60 mb-8">{student.display_name} · {student.email}</p>
+
+      <nav className="flex gap-1 border-b border-night/10 mb-8">
+        {tabs.map((tab) => (
+          <Link
+            key={tab.id}
+            href={tab.href}
+            aria-current={active === tab.id ? 'page' : undefined}
+            className={`px-4 py-2.5 text-sm font-medium -mb-px border-b-2 transition-colors ${
+              active === tab.id
+                ? 'border-blue text-blue'
+                : 'border-transparent text-night/55 hover:text-night'
+            }`}
+          >
+            {tab.label}
+          </Link>
+        ))}
+      </nav>
+
+      {children}
+    </div>
+  );
+}

--- a/src/components/student/SavedGigs.js
+++ b/src/components/student/SavedGigs.js
@@ -1,0 +1,45 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/navigation';
+import GigCard from '@/components/GigCard';
+import Card from '@/components/ui/Card';
+import Icon from '@/components/ui/Icon';
+import { useGigFavorites } from '@/components/GigFavoritesProvider';
+
+/*
+  Saved-gigs grid for the account's Holiday Gigs section — the direct mirror of
+  SavedListings. The server hands over an already-transformed gigs array; this
+  client wrapper intersects it with the live GigFavoritesProvider set so an
+  unsave here drops the card immediately (optimistic) instead of waiting for a
+  refresh. Before the provider has loaded we trust the server snapshot.
+*/
+export default function SavedGigs({ gigs }) {
+  const t = useTranslations('gigs.favorites');
+  const { favorites, loaded } = useGigFavorites();
+
+  const visible = loaded ? gigs.filter((g) => favorites.has(g.gig_id)) : gigs;
+
+  if (visible.length === 0) {
+    return (
+      <Card tone="parchment" className="p-12 text-center">
+        <Icon name="heart" className="w-12 h-12 mx-auto text-night/30 mb-3" />
+        <p className="font-display text-xl text-night/60 mb-5">{t('empty')}</p>
+        <Link
+          href="/gigs"
+          className="inline-flex items-center justify-center bg-blue text-white font-sans font-semibold uppercase tracking-[0.08em] text-xs px-5 py-3 rounded hover:bg-night transition-colors"
+        >
+          {t('browse')}
+        </Link>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+      {visible.map((gig) => (
+        <GigCard key={gig.gig_id} gig={gig} />
+      ))}
+    </div>
+  );
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -665,8 +665,8 @@
     "signup": {
       "portal": "Student portal",
       "title": "Create your StudentX account",
-      "subtitle": "One account to message landlords, save searches, and track inquiries.",
-      "brandBlurb": "Verified student housing in Thessaloniki — message landlords directly without leaving StudentX.",
+      "subtitle": "One account for accommodation, holiday gigs, and everything StudentX offers.",
+      "brandBlurb": "Everything you need as a student — accommodation, holiday gigs, and more — in one place.",
       "nameLabel": "Full name",
       "namePlaceholder": "Maria Papadopoulou",
       "emailLabel": "Email address",
@@ -686,8 +686,8 @@
     "login": {
       "portal": "Student portal",
       "title": "Welcome back",
-      "subtitle": "Sign in to continue messaging landlords and tracking inquiries.",
-      "brandBlurb": "Pick up your conversations with landlords right where you left off.",
+      "subtitle": "Sign in to your StudentX account.",
+      "brandBlurb": "Your student life — accommodation, holiday gigs, and more — all in one place.",
       "emailLabel": "Email address",
       "emailPlaceholder": "you@example.com",
       "passwordLabel": "Password",
@@ -772,7 +772,22 @@
       "lastMessageAt": "Last message {when}",
       "openThread": "Open chat",
       "loadError": "Couldn't load your inquiries. Try refreshing the page.",
-      "signOut": "Sign out"
+      "signOut": "Sign out",
+      "hubSubtitle": "Everything you've saved and started, in one place.",
+      "hubAccommodation": "Accommodation",
+      "hubAccommodationSub": "Saved listings and your landlord conversations",
+      "hubHolidayGigs": "Holiday Gigs",
+      "hubHolidayGigsSub": "Saved gigs and the ones you've applied to",
+      "tabAccommodation": "Accommodation",
+      "tabHolidayGigs": "Holiday Gigs",
+      "backToAccount": "Account",
+      "gigsInterestsTitle": "My gig interests",
+      "gigsInterestsEmpty": "You haven't expressed interest in any gigs yet.",
+      "gigsInterestsCta": "Browse Holiday Gigs",
+      "interestStatusSent": "Sent",
+      "interestSentOn": "Sent {when}",
+      "viewGig": "View gig",
+      "unpaidLabel": "Unpaid"
     },
     "chat": {
       "title": "Conversation",
@@ -1056,6 +1071,19 @@
       "success": "Sent! We'll be in touch about next steps.",
       "errorGeneric": "Something went wrong. Please try again.",
       "tooShort": "Please write at least 10 characters."
+    },
+    "favorites": {
+      "save": "Save gig",
+      "saved": "Saved",
+      "saveAria": "Save this gig",
+      "removeAria": "Remove from saved gigs",
+      "close": "Close",
+      "gateTitle": "Save this gig",
+      "gateBody": "Sign in to save gigs and keep track of the ones you've applied to.",
+      "panelTitle": "Saved gigs",
+      "empty": "You haven't saved any gigs yet.",
+      "browse": "Browse Holiday Gigs",
+      "loadError": "Couldn't load your saved gigs. Try refreshing the page."
     }
   }
 }

--- a/supabase/migrations/062_gig_favorites_and_inquiry_reads.sql
+++ b/supabase/migrations/062_gig_favorites_and_inquiry_reads.sql
@@ -1,0 +1,71 @@
+-- ============================================================
+-- Migration 062: Holiday Gigs — student favourites + interest reads.
+-- ============================================================
+--
+-- Two additions backing the student account's Holiday Gigs section
+-- (mirrors the accommodation surface: a saved shortlist + a list of
+-- things the student has reached out about):
+--
+--   1. gig_favorites — a student can "save" (heart) a gig. One row per
+--      (student, gig) pair; re-saving is a no-op via the composite PK.
+--      Mirrors student_favorites (migration 053) exactly.
+--
+--   2. A SELECT-own-rows policy on gig_inquiries so a student can read
+--      back the gig interests they submitted (the "applications" tracker).
+--      gig_inquiries was insert-only for students (migration 061); this
+--      adds read access scoped to the caller's own rows. Inserts still
+--      require student_user_id = auth.uid(); reads match the same owner.
+
+-- ---------------------------------------------------------------------------
+-- 1. gig_favorites
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS gig_favorites (
+  student_id  UUID        NOT NULL REFERENCES students(student_id) ON DELETE CASCADE,
+  gig_id      UUID        NOT NULL REFERENCES gigs(gig_id)         ON DELETE CASCADE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (student_id, gig_id)
+);
+
+-- Composite PK covers the "list my saved gigs" read (leading student_id).
+-- Postgres does not auto-index the gig_id FK column, so add one to keep the
+-- ON DELETE CASCADE from a gig delete off a sequential scan.
+CREATE INDEX IF NOT EXISTS idx_gig_favorites_gig_id ON gig_favorites(gig_id);
+
+ALTER TABLE gig_favorites ENABLE ROW LEVEL SECURITY;
+
+-- A student can only see / create / remove their OWN saved gigs. The subquery
+-- resolves the caller's student_id under the existing "Students read own row"
+-- policy on students (auth_user_id = auth.uid()).
+DROP POLICY IF EXISTS "Students read own gig favorites" ON gig_favorites;
+CREATE POLICY "Students read own gig favorites"
+  ON gig_favorites FOR SELECT
+  USING (
+    student_id IN (SELECT student_id FROM students WHERE auth_user_id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS "Students insert own gig favorites" ON gig_favorites;
+CREATE POLICY "Students insert own gig favorites"
+  ON gig_favorites FOR INSERT
+  WITH CHECK (
+    student_id IN (SELECT student_id FROM students WHERE auth_user_id = auth.uid())
+  );
+
+DROP POLICY IF EXISTS "Students delete own gig favorites" ON gig_favorites;
+CREATE POLICY "Students delete own gig favorites"
+  ON gig_favorites FOR DELETE
+  USING (
+    student_id IN (SELECT student_id FROM students WHERE auth_user_id = auth.uid())
+  );
+
+GRANT SELECT, INSERT, DELETE ON gig_favorites TO authenticated;
+
+-- ---------------------------------------------------------------------------
+-- 2. gig_inquiries: let a student read their own submitted interests.
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "Students read own gig inquiries" ON gig_inquiries;
+CREATE POLICY "Students read own gig inquiries"
+  ON gig_inquiries FOR SELECT
+  TO authenticated
+  USING (student_user_id = auth.uid());
+
+GRANT SELECT ON gig_inquiries TO authenticated;


### PR DESCRIPTION
## Summary

Repositions the student-facing surface around StudentX's everything-app positioning: a service-agnostic sign-in portal, and a homepage-style account **hub** that leads into each gated service's own section. Ships the **Holiday Gigs** account section in full; the **Accommodation** section is today's account content relocated under the same hub + tab bar.

### Sign-in portal
- Neutralized the accommodation-only copy on the student **login** and **signup** pages (subtitle + side blurb) so the portal isn't framed around messaging landlords.

### Account hub + sections
- `/student/account` — rebuilt as a button hub (Accommodation · Holiday Gigs), mirroring the homepage. Extensible to future gated services.
- Section pages share a discrete **tab bar** (`AccountChrome`) for one-click switching without returning to the hub:
  - `/student/account/accommodation` — saved listings + landlord conversations (relocated from the old account page).
  - `/student/account/gigs` — **mirrors it**: saved-gigs shortlist (optimistic unsave via `SavedGigs`, matching `SavedListings`) + an interests/applications tracker.

### Holiday Gigs favourites
- Gig save/heart on gig cards and the gig detail page (`GigFavoritesProvider` + `GigFavoriteButton`), backed by `/api/me/gig-favorites` — a sibling of the listings shortlist, with the same optimistic toggle + sign-in gate.

### Database — migration 062 (applied to prod during review)
- `gig_favorites` table + RLS (own rows only), mirroring `student_favorites`.
- A SELECT-own-rows policy on `gig_inquiries` so a student can read back the interests they submitted.

## Verification
- `npm run lint` — 0 errors (pre-existing `practice/` `<img>` warnings only)
- `npm run test` — **263/263 pass**
- `npm run build` — green; all new routes compile (`/student/account`, `/account/accommodation`, `/account/gigs`, `/api/me/gig-favorites`)
- Browser (no auth): neutralized login copy ✅; gig save-heart + sign-in gate ✅
- Migration 062 applied + verified in prod (gig_favorites: 3 policies; gig_inquiries: 2 policies)
- Note: the signed-in account hub/section pages are to be verified by the author with a real student login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)