### PR TITLE
perf(observability): per-stage login timing beacon (#265)

### DIFF
--- a/__tests__/api/logClientError.test.js
+++ b/__tests__/api/logClientError.test.js
@@ -21,6 +21,19 @@ describe('log-client-error route', () => {
     expect(spy.mock.calls[0][0]).toContain('boom');
   });
 
+  it('accepts the login-timing context (#265)', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const res = await POST(
+      makeReq({ context: 'login-timing', message: '{"auth":312,"total":685,"flow":"student"}' }),
+    );
+    expect(res.status).toBe(204);
+    expect(spy.mock.calls[0][0]).toContain('context=login-timing');
+    // The route JSON.stringifies the message string, so inner quotes are
+    // escaped in the log line — assert on the stage names, not exact quoting.
+    expect(spy.mock.calls[0][0]).toContain('flow');
+    expect(spy.mock.calls[0][0]).toContain('student');
+  });
+
   it('coerces an unknown context to "unknown"', async () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const res = await POST(makeReq({ context: 'evil<script>', message: 'x' }));

--- a/src/app/[locale]/property/[city]/landlord/login/page.js
+++ b/src/app/[locale]/property/[city]/landlord/login/page.js
@@ -6,11 +6,16 @@ import { useRouter, Link } from '@/i18n/navigation';
 import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 import { withTimeout } from '@/lib/withTimeout';
 import { signOutSafely } from '@/lib/authHelpers';
+import { reportLoginTiming } from '@/lib/reportClientError';
 import { useTranslations } from 'next-intl';
 
 import AuthShell from '@/components/landlord/AuthShell';
 import FormField from '@/components/landlord/FormField';
 import EncryptButton from '@/components/ui/EncryptButton';
+
+// The first submit since page load pays Worker cold-start latency the most;
+// tag the timing beacon (#265) with that so warm vs cold samples separate.
+let firstLandlordSubmitSinceLoad = true;
 
 function LandlordLoginInner() {
   const t = useTranslations('landlord.login');
@@ -46,6 +51,27 @@ function LandlordLoginInner() {
     e.preventDefault();
     setError('');
     setStage('auth');
+
+    // Per-stage timing (#265). t0 marks the start; tAuth/tProbe are filled as
+    // each leg resolves so emit() can report per-stage deltas. Beacon is
+    // fire-and-forget (keepalive) and never affects control flow.
+    const t0 = performance.now();
+    const coldHint = firstLandlordSubmitSinceLoad;
+    firstLandlordSubmitSinceLoad = false;
+    let tAuth = 0;
+    let tProbe = 0;
+    let lastAttempt = 0;
+    const emit = (extra = {}) =>
+      reportLoginTiming({
+        flow: 'landlord',
+        attempt: lastAttempt,
+        coldHint,
+        auth: tAuth ? Math.round(tAuth - t0) : 0,
+        probe: tProbe && tAuth ? Math.round(tProbe - tAuth) : 0,
+        total: Math.round(performance.now() - t0),
+        ...extra,
+      });
+
     try {
       const supabase = getSupabaseBrowser();
       // PR #138's defence: when a cached browser client has a session whose
@@ -68,6 +94,7 @@ function LandlordLoginInner() {
 
       let lastErr;
       for (let attempt = 0; attempt < 2; attempt++) {
+        lastAttempt = attempt;
         try {
           const { data, error: authError } = await withTimeout(
             // 8 s: healthy legs finish <1 s; with the one timeout-retry this
@@ -75,7 +102,9 @@ function LandlordLoginInner() {
             supabase.auth.signInWithPassword({ email, password }),
             8000,
           );
+          tAuth = performance.now();
           if (authError) {
+            emit({ error: true, stage: 'auth' });
             setError(authError.message);
             return;
           }
@@ -102,8 +131,10 @@ function LandlordLoginInner() {
               /* transient probe failure shouldn't block a real landlord */
             }
           }
+          tProbe = performance.now();
 
           if (role === 'student') {
+            emit({ conflict: 'student' });
             await signOutSafely(supabase);
             setStudentConflict(true);
             return;
@@ -112,6 +143,7 @@ function LandlordLoginInner() {
           // role 'landlord', or a null orphan / probe-unavailable: proceed. A
           // null orphan is bounced safely by the dashboard's server-side
           // requireLandlord guard, so it needn't be special-cased here.
+          emit();
           setStage('redirect');
           router.push('/property/thessaloniki/landlord/dashboard');
           return;
@@ -121,6 +153,7 @@ function LandlordLoginInner() {
           break;
         }
       }
+      emit({ error: true, stage: 'exception' });
       setError(lastErr?.message || 'Something went wrong. Please try again.');
     } finally {
       setStage('');

--- a/src/app/[locale]/student/login/page.js
+++ b/src/app/[locale]/student/login/page.js
@@ -7,12 +7,17 @@ import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 import { withTimeout } from '@/lib/withTimeout';
 import { signOutSafely } from '@/lib/authHelpers';
 import { safeNextPath } from '@/lib/safeNext';
+import { reportLoginTiming } from '@/lib/reportClientError';
 import { useTranslations } from 'next-intl';
 
 import AuthShell from '@/components/landlord/AuthShell';
 import FormField from '@/components/landlord/FormField';
 import EncryptButton from '@/components/ui/EncryptButton';
 import OAuthProviders from '@/components/student/OAuthProviders';
+
+// The first submit since page load pays Worker cold-start latency the most;
+// tag the timing beacon (#265) with that so warm vs cold samples separate.
+let firstStudentSubmitSinceLoad = true;
 
 function StudentLoginInner() {
   const t = useTranslations('student.login');
@@ -50,6 +55,29 @@ function StudentLoginInner() {
     e.preventDefault();
     setError('');
     setStage('auth');
+
+    // Per-stage timing (#265). t0 marks the start; tAuth/tSync/tProbe are
+    // filled as each leg resolves so emit() can report per-stage deltas.
+    // Beacon is fire-and-forget (keepalive) and never affects control flow.
+    const t0 = performance.now();
+    const coldHint = firstStudentSubmitSinceLoad;
+    firstStudentSubmitSinceLoad = false;
+    let tAuth = 0;
+    let tSync = 0;
+    let tProbe = 0;
+    let lastAttempt = 0;
+    const emit = (extra = {}) =>
+      reportLoginTiming({
+        flow: 'student',
+        attempt: lastAttempt,
+        coldHint,
+        auth: tAuth ? Math.round(tAuth - t0) : 0,
+        sync: tSync && tAuth ? Math.round(tSync - tAuth) : 0,
+        probe: tProbe && tSync ? Math.round(tProbe - tSync) : 0,
+        total: Math.round(performance.now() - t0),
+        ...extra,
+      });
+
     try {
       const supabase = getSupabaseBrowser();
       // PR #138's defence: when a cached browser client has a session whose
@@ -72,6 +100,7 @@ function StudentLoginInner() {
 
       let lastErr;
       for (let attempt = 0; attempt < 2; attempt++) {
+        lastAttempt = attempt;
         try {
           const { data, error: authError } = await withTimeout(
             // 8 s: healthy legs finish <1 s; with the one timeout-retry this
@@ -79,7 +108,9 @@ function StudentLoginInner() {
             supabase.auth.signInWithPassword({ email, password }),
             8000,
           );
+          tAuth = performance.now();
           if (authError) {
+            emit({ error: true, stage: 'auth' });
             setError(authError.message);
             return;
           }
@@ -97,11 +128,13 @@ function StudentLoginInner() {
               }),
               8000,
             );
+            tSync = performance.now();
             // If the cookie sync returns non-2xx (401 bad token, 500, …), the
             // destination RSC sees a guest and bounces straight back to login —
             // which reads to the user as "my correct password didn't work".
             // Surface it instead of navigating into a silent loop.
             if (!sessionRes.ok) {
+              emit({ error: true, stage: 'sync' });
               setError(t('sessionError'));
               return;
             }
@@ -122,9 +155,11 @@ function StudentLoginInner() {
                 }),
                 8000,
               );
+              tProbe = performance.now();
               if (profileRes.status === 409) {
                 const profileBody = await profileRes.json().catch(() => ({}));
                 if (profileBody.conflict_role === 'landlord') {
+                  emit({ conflict: 'landlord' });
                   const conflictUrl = new URL(window.location.href);
                   conflictUrl.searchParams.set('roleConflict', 'landlord');
                   if (data.session.user?.email) {
@@ -139,6 +174,7 @@ function StudentLoginInner() {
             }
           }
 
+          emit();
           if (safeNext) {
             // useRouter.push with a locale-prefixed path won't accept ?, so we
             // hand a raw URL to window.location for paths that include query
@@ -156,6 +192,7 @@ function StudentLoginInner() {
           break;
         }
       }
+      emit({ error: true, stage: 'exception' });
       setError(lastErr?.message || 'Something went wrong. Please try again.');
     } finally {
       setStage('');

--- a/src/app/api/log-client-error/route.js
+++ b/src/app/api/log-client-error/route.js
@@ -16,6 +16,9 @@ const ALLOWED_CONTEXTS = new Set([
   'login-session-sync',
   'login',
   'signup',
+  // Per-stage login timing beacon (#265). Payload is a JSON stage map of
+  // millisecond durations; logged here so it surfaces in `wrangler tail`.
+  'login-timing',
 ]);
 const MAX_MESSAGE = 500;
 const MAX_DETAIL = 200;

--- a/src/lib/reportClientError.js
+++ b/src/lib/reportClientError.js
@@ -23,3 +23,26 @@ export function reportClientError(context, detail) {
     // Reporting must never break the calling flow.
   }
 }
+
+// Fire-and-forget timing beacon for the login flow (#265). `stages` is a flat
+// object of millisecond durations plus context flags, e.g.
+// { auth: 312, sync: 141, total: 685, flow: 'student', attempt: 0 }.
+// Same transport + guarantees as reportClientError: never throws, never
+// blocks, and `keepalive` lets it survive the navigation that follows login.
+export function reportLoginTiming(stages) {
+  if (typeof window === 'undefined') return;
+  try {
+    fetch('/api/log-client-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        context: 'login-timing',
+        message: JSON.stringify(stages).slice(0, 500),
+        detail: '',
+      }),
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    // Reporting must never break the calling flow.
+  }
+}


### PR DESCRIPTION
Closes #265.

## What
Adds `reportLoginTiming(stages)` to `src/lib/reportClientError.js` (same fire-and-forget + `keepalive` transport as `reportClientError`) and instruments both login handlers to emit one beacon per submit with per-stage millisecond deltas:

- **Student:** `auth` (signInWithPassword) → `sync` (`/api/auth/session`) → `probe` (`/api/student/profile`) → `total`
- **Landlord:** `auth` → `probe` (`/api/auth/me`) → `total`

Each beacon carries `flow`, `attempt`, `coldHint` (first submit since page load), and — on the failure/conflict exits — an `error`/`conflict` flag with the stage it died at. No email or user identifier is included.

`'login-timing'` added to `ALLOWED_CONTEXTS` in `/api/log-client-error`.

## Why
This is the **"land first"** issue: it turns "login felt slow" into real per-stage distributions from Thessaloniki devices, giving before/after evidence for the #253/#254/#255/#256 optimizations.

## Reading the data
`wrangler tail --name studentx` and filter `context=login-timing`; each line's message is the JSON stage map.

## Verification
- `npm run lint` clean on all four touched files
- Full suite green (264 tests), incl. a new `login-timing` case in `__tests__/api/logClientError.test.js`
- Beacon is `await`-free in the login flow — cannot block or break login
- ⚠️ Not exercised end-to-end in a browser (needs live Supabase auth + real credentials) — recommend a manual `wrangler tail` check on preview once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)