### PR TITLE
perf(landlord): server-render the dashboard with streamed widgets (#254)

### DIFF
--- a/__tests__/api/authBootstrap.test.js
+++ b/__tests__/api/authBootstrap.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SB_ACCESS_TOKEN_COOKIE } from '@/lib/authCookies';
+
+// Hoisted mocks for the SUT's supabaseServer dependencies (#253).
+const getUserFromToken = vi.fn();
+const getSupabaseWithToken = vi.fn();
+const cleanupFreshOrphanAuthUser = vi.fn();
+
+vi.mock('@/lib/supabaseServer', () => ({
+  getUserFromToken: (...args) => getUserFromToken(...args),
+  getSupabaseWithToken: (...args) => getSupabaseWithToken(...args),
+  cleanupFreshOrphanAuthUser: (...args) => cleanupFreshOrphanAuthUser(...args),
+}));
+
+const { POST } = await import('@/app/api/auth/bootstrap/route');
+
+beforeEach(() => {
+  getUserFromToken.mockReset();
+  getSupabaseWithToken.mockReset();
+  cleanupFreshOrphanAuthUser.mockReset();
+});
+
+const USER = () => ({ id: 'auth-1', email: 'x@example.com', created_at: new Date().toISOString() });
+
+function req(body, { raw } = {}) {
+  return new Request('http://localhost/api/auth/bootstrap', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: raw !== undefined ? raw : JSON.stringify(body),
+  });
+}
+
+// supabase.rpc('create_student_profile', ...) → result
+function rpcSupabase(result) {
+  return { rpc: vi.fn(async () => result) };
+}
+
+// supabase.from(table).select().eq().maybeSingle() → { data, error: null }
+function probeSupabase({ student = null, landlord = null } = {}) {
+  const chain = (data) => ({
+    select: () => ({ eq: () => ({ maybeSingle: async () => ({ data, error: null }) }) }),
+  });
+  return {
+    from: vi.fn((table) => (table === 'students' ? chain(student) : chain(landlord))),
+  };
+}
+
+function cookieValue(res) {
+  return res.cookies.get(SB_ACCESS_TOKEN_COOKIE)?.value;
+}
+
+describe('POST /api/auth/bootstrap — validation', () => {
+  it('400 when access_token is missing', async () => {
+    const res = await POST(req({ role: 'student' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when role is missing or not student/landlord', async () => {
+    expect((await POST(req({ access_token: 'jwt' }))).status).toBe(400);
+    expect((await POST(req({ access_token: 'jwt', role: 'admin' }))).status).toBe(400);
+  });
+
+  it('400 on invalid JSON body', async () => {
+    const res = await POST(req(null, { raw: 'not json{' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('401 when the token does not validate', async () => {
+    getUserFromToken.mockResolvedValue(null);
+    const res = await POST(req({ access_token: 'bad', role: 'student' }));
+    expect(res.status).toBe(401);
+    expect(cookieValue(res)).toBeUndefined();
+  });
+});
+
+describe('POST /api/auth/bootstrap — student', () => {
+  it('200 + cookie on the happy path', async () => {
+    getUserFromToken.mockResolvedValue(USER());
+    getSupabaseWithToken.mockReturnValue(
+      rpcSupabase({ data: { student_id: 'S1', display_name: 'Foo' }, error: null }),
+    );
+    const res = await POST(req({ access_token: 'jwt', role: 'student' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, role: 'student', name: 'Foo' });
+    expect(cookieValue(res)).toBe('jwt');
+    expect(cleanupFreshOrphanAuthUser).not.toHaveBeenCalled();
+  });
+
+  it('409 role_conflict + NO cookie + cleanup when email is already a landlord', async () => {
+    getUserFromToken.mockResolvedValue(USER());
+    getSupabaseWithToken.mockReturnValue(
+      rpcSupabase({
+        data: null,
+        error: { code: '23505', message: 'Email x already registered as a landlord' },
+      }),
+    );
+    const res = await POST(req({ access_token: 'jwt', role: 'student' }));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: 'role_conflict', conflict_role: 'landlord' });
+    expect(cookieValue(res)).toBeUndefined();
+    expect(cleanupFreshOrphanAuthUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('500 + NO cookie on a non-conflict RPC error', async () => {
+    getUserFromToken.mockResolvedValue(USER());
+    getSupabaseWithToken.mockReturnValue(
+      rpcSupabase({ data: null, error: { code: '42501', message: 'permission denied' } }),
+    );
+    const res = await POST(req({ access_token: 'jwt', role: 'student' }));
+    expect(res.status).toBe(500);
+    expect(cookieValue(res)).toBeUndefined();
+    expect(cleanupFreshOrphanAuthUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/auth/bootstrap — landlord', () => {
+  it('200 + cookie when a landlords row exists', async () => {
+    getUserFromToken.mockResolvedValue(USER());
+    getSupabaseWithToken.mockReturnValue(probeSupabase({ landlord: { name: 'LL Inc' } }));
+    const res = await POST(req({ access_token: 'jwt', role: 'landlord' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, role: 'landlord', name: 'LL Inc' });
+    expect(cookieValue(res)).toBe('jwt');
+  });
+
+  it('409 student-conflict + NO cookie when only a students row exists', async () => {
+    getUserFromToken.mockResolvedValue(USER());
+    getSupabaseWithToken.mockReturnValue(probeSupabase({ student: { display_name: 'Stu' } }));
+    const res = await POST(req({ access_token: 'jwt', role: 'landlord' }));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: 'role_conflict', conflict_role: 'student' });
+    expect(cookieValue(res)).toBeUndefined();
+  });
+
+  it('200 + cookie + role:null for an orphan (neither row)', async () => {
+    getUserFromToken.mockResolvedValue(USER());
+    getSupabaseWithToken.mockReturnValue(probeSupabase({}));
+    const res = await POST(req({ access_token: 'jwt', role: 'landlord' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, role: null });
+    expect(cookieValue(res)).toBe('jwt');
+  });
+});

--- a/src/app/[locale]/property/[city]/landlord/dashboard/page.js
+++ b/src/app/[locale]/property/[city]/landlord/dashboard/page.js
@@ -1,301 +1,328 @@
-'use client';
-
-import { useEffect, useState } from 'react';
-import { useRouter, Link } from '@/i18n/navigation';
-import { useTranslations } from 'next-intl';
+import { Suspense, cache } from 'react';
+import { redirect } from 'next/navigation';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 import Image from 'next/image';
-import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
+
+import { Link } from '@/i18n/navigation';
+import { requireLandlord } from '@/lib/requireStudent';
+import { getSupabase } from '@/lib/supabase';
+import { selectLandlordListings } from '@/lib/landlordListingSelect';
+import { getLandlordResponseTime } from '@/lib/landlordResponseTime';
+import { variantUrl } from '@/lib/photoVariants';
 
 import LandlordShell from '@/components/landlord/LandlordShell';
 import Button from '@/components/ui/Button';
-import { variantUrl } from '@/lib/photoVariants';
 import Card from '@/components/ui/Card';
 import Pill from '@/components/ui/Pill';
 import Icon from '@/components/ui/Icon';
 import VerifiedSeal from '@/components/ui/VerifiedSeal';
 
 /*
-  Propylaea landlord dashboard — widget-based rebuild.
+  Propylaea landlord dashboard — server-rendered (#254).
 
-  Layout:
-    - Stats row (active listings, pending inquiries, views, conversion)
-    - Two-column widget grid:
-        - Left: Your listings (compact rows, max 5 + view all)
-        - Right: Recent inquiries (compact cards, max 5 + view all)
-        - Bottom: Verification card (state-dependent)
+  Was 'use client' with a three-phase gate (LandlordShell session probe →
+  page getSession → 5 parallel fetches). Now it mirrors the student account
+  page: requireLandlord() guards server-side, the shell + topbar greeting
+  paint on the first byte (gated={false}), and each widget streams in its own
+  <Suspense> as its query resolves. requireLandlord() is React.cache()'d, so
+  every loader below resolves it from the per-request cache (one round-trip).
 
-  All existing API contracts are preserved — this is pure UI.
+  All five API routes (/api/landlord/{listings,inquiries,analytics,
+  response-time,billing/subscription}) are preserved — other pages and client
+  flows still consume them. The loaders here copy those routes' queries.
 */
-export default function LandlordDashboardPage() {
-  const t = useTranslations('propylaea.landlord.dashboard');
-  const tLegacy = useTranslations('landlord.dashboard');
-  const router = useRouter();
 
-  const [listings, setListings] = useState([]);
-  const [recentInquiries, setRecentInquiries] = useState([]);
-  const [pendingInquiryCount, setPendingInquiryCount] = useState(0);
-  const [analytics, setAnalytics] = useState(null);
-  const [responseTime, setResponseTime] = useState(null);
-  const [verifiedTier, setVerifiedTier] = useState('none');
-  const [isVerified, setIsVerified] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
+// ---- Per-request data loaders (cache()'d → one query each per request) ----
 
-  async function fetchListings(token) {
-    try {
-      const res = await fetch('/api/landlord/listings', {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (res.ok) {
-        const { listings: data } = await res.json();
-        setListings(data || []);
-      } else {
-        setError('Failed to load listings');
-      }
-    } catch {
-      setError('Failed to load listings');
+const loadListings = cache(async () => {
+  const auth = await requireLandlord();
+  if (!auth || auth.kind === 'wrong-role') return [];
+  const { data, error } = await selectLandlordListings(auth.supabase, auth.landlord.landlord_id);
+  if (error) return [];
+  return data || [];
+});
+
+const loadVerification = cache(async () => {
+  const auth = await requireLandlord();
+  if (!auth || auth.kind === 'wrong-role') return { verifiedTier: 'none', isVerified: false };
+  // verified_tier / is_verified live on the landlords row (NOT Stripe), so the
+  // dashboard reads them directly rather than hitting the billing route's
+  // getActiveSubscription — no Stripe latency on the render path.
+  const { data } = await auth.supabase
+    .from('landlords')
+    .select('verified_tier, is_verified')
+    .eq('landlord_id', auth.landlord.landlord_id)
+    .maybeSingle();
+  return {
+    verifiedTier: data?.verified_tier ?? 'none',
+    isVerified: data?.is_verified === true,
+  };
+});
+
+const loadInquiries = cache(async () => {
+  const auth = await requireLandlord();
+  if (!auth || auth.kind === 'wrong-role') return { recent: [], pendingCount: 0 };
+  const { data, error } = await auth.supabase
+    .from('inquiries')
+    .select(`
+      inquiry_id,
+      listing_id,
+      student_name,
+      student_email,
+      student_phone,
+      message,
+      status,
+      replied_at,
+      created_at,
+      listings ( listing_id, location ( address ) )
+    `)
+    .order('created_at', { ascending: false });
+  if (error) return { recent: [], pendingCount: 0 };
+  const inquiries = data || [];
+  return {
+    recent: inquiries.slice(0, 5),
+    pendingCount: inquiries.filter((i) => i.status === 'pending').length,
+  };
+});
+
+const loadAnalytics = cache(async () => {
+  const auth = await requireLandlord();
+  if (!auth || auth.kind === 'wrong-role') return { conversion_rate: 0, views_last_30_days: 0 };
+  const listings = await loadListings();
+  const listingIds = listings.map((l) => l.listing_id).filter(Boolean);
+  if (listingIds.length === 0) return { conversion_rate: 0, views_last_30_days: 0 };
+
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+  const cutoff = thirtyDaysAgo.toISOString().split('T')[0];
+
+  // Same queries as /api/landlord/analytics: listing_views token-scoped,
+  // inquiries via the anon client (mirrors the route exactly).
+  const [allViewsRes, recentViewsRes, allInquiriesRes] = await Promise.all([
+    auth.supabase.from('listing_views').select('listing_id, view_count').in('listing_id', listingIds),
+    auth.supabase
+      .from('listing_views')
+      .select('listing_id, view_count')
+      .in('listing_id', listingIds)
+      .gte('view_date', cutoff),
+    getSupabase().from('inquiries').select('listing_id, created_at').in('listing_id', listingIds),
+  ]);
+
+  const totalViews = (allViewsRes.data || []).reduce((s, v) => s + v.view_count, 0);
+  const viewsLast30 = (recentViewsRes.data || []).reduce((s, v) => s + v.view_count, 0);
+  const totalInquiries = (allInquiriesRes.data || []).length;
+  const conversionRate = totalViews > 0 ? (totalInquiries / totalViews) * 100 : 0;
+
+  return {
+    conversion_rate: Math.round(conversionRate * 10) / 10,
+    views_last_30_days: viewsLast30,
+  };
+});
+
+const loadResponseTime = cache(async () => {
+  const auth = await requireLandlord();
+  if (!auth || auth.kind === 'wrong-role') return { count: 0, formatted: null };
+  const listings = await loadListings();
+  const listingIds = listings.map((l) => l.listing_id).filter(Boolean);
+  try {
+    return await getLandlordResponseTime(auth.supabase, listingIds);
+  } catch {
+    return { count: 0, formatted: null };
+  }
+});
+
+// ---- Page ----
+
+export default async function LandlordDashboardPage({ params }) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const auth = await requireLandlord();
+  if (!auth || auth.kind === 'wrong-role') {
+    const loginParams = new URLSearchParams();
+    if (auth?.kind === 'wrong-role' && auth.conflict_role) {
+      loginParams.set('roleConflict', auth.conflict_role);
+      if (auth.email) loginParams.set('email', auth.email);
     }
+    const qs = loginParams.toString();
+    redirect(`/property/thessaloniki/landlord/login${qs ? `?${qs}` : ''}`);
   }
 
-  async function fetchInquiries(token) {
-    try {
-      const res = await fetch('/api/landlord/inquiries', {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (res.ok) {
-        const { inquiries } = await res.json();
-        setRecentInquiries((inquiries || []).slice(0, 5));
-        setPendingInquiryCount(
-          (inquiries || []).filter((i) => i.status === 'pending').length
-        );
-      }
-    } catch {}
-  }
-
-  async function fetchAnalytics(token) {
-    try {
-      const res = await fetch('/api/landlord/analytics', {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (res.ok) {
-        const { analytics: data } = await res.json();
-        setAnalytics(data);
-      }
-    } catch {}
-  }
-
-  async function fetchResponseTime(token) {
-    try {
-      const res = await fetch('/api/landlord/response-time', {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (res.ok) {
-        const { responseTime: data } = await res.json();
-        setResponseTime(data);
-      }
-    } catch {}
-  }
-
-  async function fetchSubscription(token) {
-    try {
-      const res = await fetch('/api/landlord/billing/subscription', {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (res.ok) {
-        const { verifiedTier: tier, isVerified: idApproved } = await res.json();
-        setVerifiedTier(tier ?? 'none');
-        setIsVerified(idApproved === true);
-      }
-    } catch {}
-  }
-
-  useEffect(() => {
-    (async () => {
-      const supabase = getSupabaseBrowser();
-      const { data: { session } } = await supabase.auth.getSession();
-      if (!session) return; // LandlordShell handles redirect
-      await Promise.all([
-        fetchListings(session.access_token),
-        fetchAnalytics(session.access_token),
-        fetchInquiries(session.access_token),
-        fetchResponseTime(session.access_token),
-        fetchSubscription(session.access_token),
-      ]);
-      setLoading(false);
-    })();
-  }, []);
-
-  const activeListings = listings.length;
-  const conversionPct = analytics?.conversion_rate ?? 0;
-  const views30d = analytics?.views_last_30_days ?? 0;
-  const hasReplies = (responseTime?.count ?? 0) > 0;
-  const responseTimeValue = hasReplies ? responseTime.formatted : '—';
+  const t = await getTranslations({ locale, namespace: 'propylaea.landlord.dashboard' });
 
   return (
     <LandlordShell
+      gated={false}
+      landlordName={auth.landlord.name}
       eyebrow={t('welcomeEyebrow')}
       title={t('welcomeTitle')}
       actions={
-        <>
-          <Button href="/property/thessaloniki/landlord/listings/new" variant="gold" size="sm">
-            {t('quickNewListing')}
-          </Button>
-        </>
+        <Button href="/property/thessaloniki/landlord/listings/new" variant="gold" size="sm">
+          {t('quickNewListing')}
+        </Button>
       }
     >
-      {error && (
-        <p className="mb-6 text-sm text-red-700 bg-red-50 border border-red-200 rounded-sm px-4 py-3">
-          {error}
-        </p>
-      )}
-
       {/* Stats row */}
-      <section className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 mb-10">
-        <StatTile
-          label={t('statListings')}
-          value={activeListings}
-          loading={loading}
-        />
-        <StatTile
-          label={t('statInquiries')}
-          value={pendingInquiryCount}
-          loading={loading}
-          accent={pendingInquiryCount > 0}
-        />
-        <StatTile
-          label={t('statViews')}
-          value={views30d}
-          loading={loading}
-        />
-        <StatTile
-          label={t('statConversion')}
-          value={`${conversionPct}%`}
-          loading={loading}
-        />
-        <StatTile
-          label={t('statResponseTime')}
-          value={responseTimeValue}
-          loading={loading}
-          caption={!loading && !hasReplies ? t('statResponseTimeEmpty') : undefined}
-        />
-      </section>
+      <Suspense fallback={<StatsRowSkeleton />}>
+        <StatsRow locale={locale} />
+      </Suspense>
 
       {/* Two-column widget grid */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Listings widget */}
         <section className="lg:col-span-2">
-          <Card tone="white" className="p-6">
-            <div className="flex items-center justify-between mb-5">
-              <h2 className="font-display text-2xl text-night">
-                {t('widgetListings')}
-              </h2>
-              <Link
-                href="/property/thessaloniki/landlord/listings"
-                className="label-caps text-blue hover:text-night"
-              >
-                {t('widgetListingsViewAll')} →
-              </Link>
-            </div>
-
-            {loading ? (
-              <ListingsSkeleton />
-            ) : listings.length === 0 ? (
-              <div className="text-center py-12 border border-dashed border-night/15 rounded-sm">
-                <p className="text-night/60 mb-4">
-                  {tLegacy('noListings')}
-                </p>
-                <Button href="/property/thessaloniki/landlord/listings/new" variant="primary" size="sm">
-                  {tLegacy('addFirst')}
-                </Button>
-              </div>
-            ) : (
-              <ul className="divide-y divide-night/10">
-                {listings.slice(0, 5).map((listing) => (
-                  <li key={listing.listing_id} className="py-4 first:pt-0 last:pb-0">
-                    <ListingRow
-                      listing={listing}
-                      isSuper={isVerified && verifiedTier !== 'none'}
-                    />
-                  </li>
-                ))}
-              </ul>
-            )}
-          </Card>
+          <Suspense
+            fallback={<ListingsCardSkeleton title={t('widgetListings')} viewAll={t('widgetListingsViewAll')} />}
+          >
+            <ListingsWidget locale={locale} />
+          </Suspense>
         </section>
 
-        {/* Inquiries widget */}
         <section>
-          <Card tone="white" className="p-6 h-full">
-            <div className="flex items-center justify-between mb-5">
-              <h2 className="font-display text-2xl text-night">
-                {t('widgetInquiries')}
-              </h2>
-              <Link
-                href="/property/thessaloniki/landlord/inquiries"
-                className="label-caps text-blue hover:text-night"
-              >
-                {t('widgetInquiriesViewAll')} →
-              </Link>
-            </div>
-
-            {loading ? (
-              <div className="space-y-4">
-                {[1, 2, 3].map((i) => (
-                  <div key={i} className="h-16 bg-parchment rounded animate-pulse" />
-                ))}
-              </div>
-            ) : recentInquiries.length === 0 ? (
-              <p className="text-night/60 text-sm py-6">
-                {tLegacy('noListings') && 'No inquiries yet.'}
-              </p>
-            ) : (
-              <ul className="space-y-3">
-                {recentInquiries.map((inq) => (
-                  <li key={inq.id || inq.inquiry_id}>
-                    <InquiryRow inquiry={inq} />
-                  </li>
-                ))}
-              </ul>
-            )}
-          </Card>
+          <Suspense
+            fallback={<InquiriesCardSkeleton title={t('widgetInquiries')} viewAll={t('widgetInquiriesViewAll')} />}
+          >
+            <InquiriesWidget locale={locale} />
+          </Suspense>
         </section>
       </div>
 
       {/* Verification card */}
       <section className="mt-6">
-        <VerificationCard tier={verifiedTier} isVerified={isVerified} t={t} />
+        <Suspense fallback={null}>
+          <VerificationWidget locale={locale} />
+        </Suspense>
       </section>
     </LandlordShell>
   );
 }
 
-function StatTile({ label, value, loading, accent, caption }) {
+// ---- Streamed widgets ----
+
+async function StatsRow({ locale }) {
+  const t = await getTranslations({ locale, namespace: 'propylaea.landlord.dashboard' });
+  const [listings, analytics, inquiries, responseTime] = await Promise.all([
+    loadListings(),
+    loadAnalytics(),
+    loadInquiries(),
+    loadResponseTime(),
+  ]);
+
+  const activeListings = listings.length;
+  const pendingInquiryCount = inquiries.pendingCount;
+  const views30d = analytics?.views_last_30_days ?? 0;
+  const conversionPct = analytics?.conversion_rate ?? 0;
+  const hasReplies = (responseTime?.count ?? 0) > 0;
+  const responseTimeValue = hasReplies ? responseTime.formatted : '—';
+
+  return (
+    <section className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 mb-10">
+      <StatTile label={t('statListings')} value={activeListings} />
+      <StatTile label={t('statInquiries')} value={pendingInquiryCount} accent={pendingInquiryCount > 0} />
+      <StatTile label={t('statViews')} value={views30d} />
+      <StatTile label={t('statConversion')} value={`${conversionPct}%`} />
+      <StatTile
+        label={t('statResponseTime')}
+        value={responseTimeValue}
+        caption={!hasReplies ? t('statResponseTimeEmpty') : undefined}
+      />
+    </section>
+  );
+}
+
+async function ListingsWidget({ locale }) {
+  const t = await getTranslations({ locale, namespace: 'propylaea.landlord.dashboard' });
+  const tLegacy = await getTranslations({ locale, namespace: 'landlord.dashboard' });
+  const [listings, verification] = await Promise.all([loadListings(), loadVerification()]);
+  const isSuper = verification.isVerified && verification.verifiedTier !== 'none';
+
+  return (
+    <Card tone="white" className="p-6">
+      <div className="flex items-center justify-between mb-5">
+        <h2 className="font-display text-2xl text-night">{t('widgetListings')}</h2>
+        <Link
+          href="/property/thessaloniki/landlord/listings"
+          className="label-caps text-blue hover:text-night"
+        >
+          {t('widgetListingsViewAll')} →
+        </Link>
+      </div>
+
+      {listings.length === 0 ? (
+        <div className="text-center py-12 border border-dashed border-night/15 rounded-sm">
+          <p className="text-night/60 mb-4">{tLegacy('noListings')}</p>
+          <Button href="/property/thessaloniki/landlord/listings/new" variant="primary" size="sm">
+            {tLegacy('addFirst')}
+          </Button>
+        </div>
+      ) : (
+        <ul className="divide-y divide-night/10">
+          {listings.slice(0, 5).map((listing) => (
+            <li key={listing.listing_id} className="py-4 first:pt-0 last:pb-0">
+              <ListingRow listing={listing} isSuper={isSuper} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}
+
+async function InquiriesWidget({ locale }) {
+  const t = await getTranslations({ locale, namespace: 'propylaea.landlord.dashboard' });
+  const { recent } = await loadInquiries();
+
+  return (
+    <Card tone="white" className="p-6 h-full">
+      <div className="flex items-center justify-between mb-5">
+        <h2 className="font-display text-2xl text-night">{t('widgetInquiries')}</h2>
+        <Link
+          href="/property/thessaloniki/landlord/inquiries"
+          className="label-caps text-blue hover:text-night"
+        >
+          {t('widgetInquiriesViewAll')} →
+        </Link>
+      </div>
+
+      {recent.length === 0 ? (
+        <p className="text-night/60 text-sm py-6">No inquiries yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {recent.map((inq) => (
+            <li key={inq.inquiry_id || inq.id}>
+              <InquiryRow inquiry={inq} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}
+
+async function VerificationWidget({ locale }) {
+  const t = await getTranslations({ locale, namespace: 'propylaea.landlord.dashboard' });
+  const { verifiedTier, isVerified } = await loadVerification();
+  return <VerificationCard tier={verifiedTier} isVerified={isVerified} t={t} />;
+}
+
+// ---- Presentational (pure JSX, no hooks — safe in RSC) ----
+
+function StatTile({ label, value, accent, caption }) {
   return (
     <Card
       tone={accent ? 'night' : 'parchment'}
       border={false}
       className={`p-5 ${accent ? 'text-stone' : ''}`}
     >
-      <p
-        className={`label-caps ${accent ? 'text-yellow' : 'text-night/60'}`}
-      >
-        {label}
-      </p>
+      <p className={`label-caps ${accent ? 'text-yellow' : 'text-night/60'}`}>{label}</p>
       <p
         className={`mt-2 font-display text-4xl md:text-5xl leading-none ${
           accent ? 'text-stone' : 'text-blue'
         }`}
       >
-        {loading ? (
-          <span className="inline-block w-16 h-9 bg-night/10 rounded animate-pulse" />
-        ) : (
-          value
-        )}
+        {value}
       </p>
-      {!loading && caption && (
-        <p className={`mt-2 text-xs ${accent ? 'text-stone/60' : 'text-night/40'}`}>
-          {caption}
-        </p>
+      {caption && (
+        <p className={`mt-2 text-xs ${accent ? 'text-stone/60' : 'text-night/40'}`}>{caption}</p>
       )}
     </Card>
   );
@@ -314,13 +341,7 @@ function ListingRow({ listing, isSuper }) {
     <div className="flex items-center gap-4">
       <div className="relative w-16 h-16 rounded-sm bg-parchment overflow-hidden shrink-0">
         {photo ? (
-          <Image
-            src={variantUrl(photo, 'thumb')}
-            alt={address}
-            fill
-            className="object-cover"
-            sizes="64px"
-          />
+          <Image src={variantUrl(photo, 'thumb')} alt={address} fill className="object-cover" sizes="64px" />
         ) : (
           <div className="flex items-center justify-center h-full text-night/20">
             <Icon name="photo" className="w-6 h-6" />
@@ -352,16 +373,10 @@ function ListingRow({ listing, isSuper }) {
 function InquiryRow({ inquiry }) {
   const status = inquiry.status || 'pending';
   const statusVariant =
-    status === 'pending' ? 'pending'
-    : status === 'replied' ? 'info'
-    : 'amenity';
+    status === 'pending' ? 'pending' : status === 'replied' ? 'info' : 'amenity';
   const statusLabel =
-    status === 'pending' ? 'New'
-    : status === 'replied' ? 'Replied'
-    : 'Closed';
-  const date = inquiry.created_at
-    ? new Date(inquiry.created_at).toLocaleDateString()
-    : '';
+    status === 'pending' ? 'New' : status === 'replied' ? 'Replied' : 'Closed';
+  const date = inquiry.created_at ? new Date(inquiry.created_at).toLocaleDateString() : '';
   const inquiryId = inquiry.inquiry_id || inquiry.id;
 
   return (
@@ -375,14 +390,8 @@ function InquiryRow({ inquiry }) {
         </p>
         <Pill variant={statusVariant}>{statusLabel}</Pill>
       </div>
-      {inquiry.message && (
-        <p className="text-xs text-night/60 line-clamp-2">
-          {inquiry.message}
-        </p>
-      )}
-      {date && (
-        <p className="label-caps text-night/40 mt-1">{date}</p>
-      )}
+      {inquiry.message && <p className="text-xs text-night/60 line-clamp-2">{inquiry.message}</p>}
+      {date && <p className="label-caps text-night/40 mt-1">{date}</p>}
     </Link>
   );
 }
@@ -397,9 +406,7 @@ function VerificationCard({ tier, isVerified, t }) {
         <VerifiedSeal size={52} />
         <div className="flex-1">
           <p className="label-caps text-yellow">{t('widgetVerification')}</p>
-          <p className="font-display text-2xl text-night mt-1">
-            {t('verifiedTitle')}
-          </p>
+          <p className="font-display text-2xl text-night mt-1">{t('verifiedTitle')}</p>
           <p className="text-night/70 text-sm mt-1">{t('verifiedBody')}</p>
         </div>
       </Card>
@@ -415,12 +422,8 @@ function VerificationCard({ tier, isVerified, t }) {
             <VerifiedSeal size={52} />
             <div>
               <p className="label-caps text-yellow">{t('widgetVerification')}</p>
-              <p className="font-display text-2xl text-night mt-1">
-                {t('subscribedAwaitingIdTitle')}
-              </p>
-              <p className="text-night/70 text-sm mt-1 max-w-md">
-                {t('subscribedAwaitingIdBody')}
-              </p>
+              <p className="font-display text-2xl text-night mt-1">{t('subscribedAwaitingIdTitle')}</p>
+              <p className="text-night/70 text-sm mt-1 max-w-md">{t('subscribedAwaitingIdBody')}</p>
             </div>
           </div>
           <Button href="/property/thessaloniki/landlord/verification" variant="gold" size="md">
@@ -466,12 +469,8 @@ function VerificationCard({ tier, isVerified, t }) {
           </div>
           <div>
             <p className="label-caps text-yellow">{t('widgetVerification')}</p>
-            <p className="font-display text-2xl text-stone mt-1">
-              {t('unverifiedTitle')}
-            </p>
-            <p className="text-stone/70 text-sm mt-1 max-w-md">
-              {t('unverifiedBody')}
-            </p>
+            <p className="font-display text-2xl text-stone mt-1">{t('unverifiedTitle')}</p>
+            <p className="text-stone/70 text-sm mt-1 max-w-md">{t('unverifiedBody')}</p>
           </div>
         </div>
         <Button href="/property/thessaloniki/landlord/get-verified" variant="gold" size="md">
@@ -482,21 +481,56 @@ function VerificationCard({ tier, isVerified, t }) {
   );
 }
 
-function ListingsSkeleton() {
+// ---- Suspense skeletons (titles passed in so the card chrome paints with the
+// real heading; only the data body pulses) ----
+
+function StatsRowSkeleton() {
   return (
-    <ul className="divide-y divide-night/10">
-      {[1, 2, 3].map((i) => (
-        <li
-          key={i}
-          className="py-4 flex items-center gap-4 first:pt-0 last:pb-0"
-        >
-          <div className="w-16 h-16 rounded-sm bg-parchment animate-pulse" />
-          <div className="flex-1 space-y-2">
-            <div className="h-4 w-2/3 bg-parchment rounded animate-pulse" />
-            <div className="h-3 w-1/3 bg-parchment rounded animate-pulse" />
-          </div>
-        </li>
+    <section className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 mb-10">
+      {[1, 2, 3, 4, 5].map((i) => (
+        <Card key={i} tone="parchment" border={false} className="p-5">
+          <div className="h-3 w-16 bg-night/10 rounded animate-pulse" />
+          <div className="mt-3 h-9 w-16 bg-night/10 rounded animate-pulse" />
+        </Card>
       ))}
-    </ul>
+    </section>
+  );
+}
+
+function ListingsCardSkeleton({ title, viewAll }) {
+  return (
+    <Card tone="white" className="p-6">
+      <div className="flex items-center justify-between mb-5">
+        <h2 className="font-display text-2xl text-night">{title}</h2>
+        <span className="label-caps text-blue/60">{viewAll} →</span>
+      </div>
+      <ul className="divide-y divide-night/10">
+        {[1, 2, 3].map((i) => (
+          <li key={i} className="py-4 flex items-center gap-4 first:pt-0 last:pb-0">
+            <div className="w-16 h-16 rounded-sm bg-parchment animate-pulse" />
+            <div className="flex-1 space-y-2">
+              <div className="h-4 w-2/3 bg-parchment rounded animate-pulse" />
+              <div className="h-3 w-1/3 bg-parchment rounded animate-pulse" />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}
+
+function InquiriesCardSkeleton({ title, viewAll }) {
+  return (
+    <Card tone="white" className="p-6 h-full">
+      <div className="flex items-center justify-between mb-5">
+        <h2 className="font-display text-2xl text-night">{title}</h2>
+        <span className="label-caps text-blue/60">{viewAll} →</span>
+      </div>
+      <div className="space-y-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-16 bg-parchment rounded animate-pulse" />
+        ))}
+      </div>
+    </Card>
   );
 }

--- a/src/app/[locale]/property/[city]/landlord/login/page.js
+++ b/src/app/[locale]/property/[city]/landlord/login/page.js
@@ -52,14 +52,14 @@ function LandlordLoginInner() {
     setError('');
     setStage('auth');
 
-    // Per-stage timing (#265). t0 marks the start; tAuth/tProbe are filled as
-    // each leg resolves so emit() can report per-stage deltas. Beacon is
+    // Per-stage timing (#265). t0 marks the start; tAuth/tBootstrap are filled
+    // as each leg resolves so emit() can report per-stage deltas. Beacon is
     // fire-and-forget (keepalive) and never affects control flow.
     const t0 = performance.now();
     const coldHint = firstLandlordSubmitSinceLoad;
     firstLandlordSubmitSinceLoad = false;
     let tAuth = 0;
-    let tProbe = 0;
+    let tBootstrap = 0;
     let lastAttempt = 0;
     const emit = (extra = {}) =>
       reportLoginTiming({
@@ -67,7 +67,7 @@ function LandlordLoginInner() {
         attempt: lastAttempt,
         coldHint,
         auth: tAuth ? Math.round(tAuth - t0) : 0,
-        probe: tProbe && tAuth ? Math.round(tProbe - tAuth) : 0,
+        bootstrap: tBootstrap && tAuth ? Math.round(tBootstrap - tAuth) : 0,
         total: Math.round(performance.now() - t0),
         ...extra,
       });
@@ -116,33 +116,46 @@ function LandlordLoginInner() {
           // stays 'auth' through the probe so the button doesn't flash
           // "redirecting" when it's actually about to show the conflict banner.
           const token = data.session?.access_token;
-          let role = 'landlord'; // unknown probe → defer to the dashboard's own guards
+          // One server-side round-trip (#253): bootstrap validates the token,
+          // confirms the role, and — for a real landlord — sets the auth cookie
+          // BEFORE navigation. That eager cookie is what lets the dashboard
+          // server-render instead of gating on a client probe (#254).
+          let bootstrap = null;
           if (token) {
             try {
-              const meRes = await withTimeout(
-                fetch('/api/auth/me', { headers: { Authorization: `Bearer ${token}` } }),
+              const bootstrapRes = await withTimeout(
+                fetch('/api/auth/bootstrap', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ access_token: token, role: 'landlord' }),
+                }),
                 8000,
               );
-              if (meRes.ok) {
-                const { user } = await meRes.json();
-                role = user?.role ?? null;
-              }
+              bootstrap = {
+                status: bootstrapRes.status,
+                body:
+                  bootstrapRes.status === 409
+                    ? await bootstrapRes.json().catch(() => ({}))
+                    : null,
+              };
             } catch {
-              /* transient probe failure shouldn't block a real landlord */
+              /* transient bootstrap failure shouldn't block a real landlord */
             }
           }
-          tProbe = performance.now();
+          tBootstrap = performance.now();
 
-          if (role === 'student') {
+          // 409 student-conflict → sign out and show the banner. Stage stays
+          // 'auth' so the button doesn't flash "redirecting".
+          if (bootstrap?.status === 409 && bootstrap.body?.conflict_role === 'student') {
             emit({ conflict: 'student' });
             await signOutSafely(supabase);
             setStudentConflict(true);
             return;
           }
 
-          // role 'landlord', or a null orphan / probe-unavailable: proceed. A
-          // null orphan is bounced safely by the dashboard's server-side
-          // requireLandlord guard, so it needn't be special-cased here.
+          // 200, a null orphan, or a transient/5xx bootstrap failure: proceed.
+          // The dashboard's server-side requireLandlord guard bounces bad
+          // sessions, so a failed probe needn't block a real landlord.
           emit();
           setStage('redirect');
           router.push('/property/thessaloniki/landlord/dashboard');

--- a/src/app/[locale]/student/login/page.js
+++ b/src/app/[locale]/student/login/page.js
@@ -56,15 +56,14 @@ function StudentLoginInner() {
     setError('');
     setStage('auth');
 
-    // Per-stage timing (#265). t0 marks the start; tAuth/tSync/tProbe are
+    // Per-stage timing (#265). t0 marks the start; tAuth/tBootstrap are
     // filled as each leg resolves so emit() can report per-stage deltas.
     // Beacon is fire-and-forget (keepalive) and never affects control flow.
     const t0 = performance.now();
     const coldHint = firstStudentSubmitSinceLoad;
     firstStudentSubmitSinceLoad = false;
     let tAuth = 0;
-    let tSync = 0;
-    let tProbe = 0;
+    let tBootstrap = 0;
     let lastAttempt = 0;
     const emit = (extra = {}) =>
       reportLoginTiming({
@@ -72,8 +71,7 @@ function StudentLoginInner() {
         attempt: lastAttempt,
         coldHint,
         auth: tAuth ? Math.round(tAuth - t0) : 0,
-        sync: tSync && tAuth ? Math.round(tSync - tAuth) : 0,
-        probe: tProbe && tSync ? Math.round(tProbe - tSync) : 0,
+        bootstrap: tBootstrap && tAuth ? Math.round(tBootstrap - tAuth) : 0,
         total: Math.round(performance.now() - t0),
         ...extra,
       });
@@ -117,60 +115,46 @@ function StudentLoginInner() {
 
           setStage('redirect');
 
-          // Sync cookie eagerly so the next navigation's RSC sees auth without
-          // waiting for SessionSync's onAuthStateChange to fire.
+          // One server-side round-trip (#253): validate the token, provision
+          // the students row (idempotent), and set the auth cookie — replacing
+          // the old sequential /api/auth/session + /api/student/profile hops.
           if (data.session?.access_token) {
-            const sessionRes = await withTimeout(
-              fetch('/api/auth/session', {
+            const bootstrapRes = await withTimeout(
+              fetch('/api/auth/bootstrap', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ access_token: data.session.access_token }),
+                body: JSON.stringify({
+                  access_token: data.session.access_token,
+                  role: 'student',
+                }),
               }),
               8000,
             );
-            tSync = performance.now();
-            // If the cookie sync returns non-2xx (401 bad token, 500, …), the
-            // destination RSC sees a guest and bounces straight back to login —
-            // which reads to the user as "my correct password didn't work".
-            // Surface it instead of navigating into a silent loop.
-            if (!sessionRes.ok) {
-              emit({ error: true, stage: 'sync' });
-              setError(t('sessionError'));
-              return;
+            tBootstrap = performance.now();
+
+            // 409 → this email is already a landlord. Deep-link back to login
+            // with the conflict banner (same UX as the old profile-probe path).
+            if (bootstrapRes.status === 409) {
+              const bootstrapBody = await bootstrapRes.json().catch(() => ({}));
+              if (bootstrapBody.conflict_role === 'landlord') {
+                emit({ conflict: 'landlord' });
+                const conflictUrl = new URL(window.location.href);
+                conflictUrl.searchParams.set('roleConflict', 'landlord');
+                if (data.session.user?.email) {
+                  conflictUrl.searchParams.set('email', data.session.user.email);
+                }
+                window.location.assign(conflictUrl.toString());
+                return;
+              }
             }
 
-            // Idempotent profile probe — ensures a students row exists
-            // even if the signup trigger was skipped (e.g. pre-seeded
-            // landlord email collision). Returns the existing row when
-            // one is already present, so this is a no-op on happy path.
-            try {
-              const profileRes = await withTimeout(
-                fetch('/api/student/profile', {
-                  method: 'POST',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${data.session.access_token}`,
-                  },
-                  body: JSON.stringify({ preferred_locale: 'en' }),
-                }),
-                8000,
-              );
-              tProbe = performance.now();
-              if (profileRes.status === 409) {
-                const profileBody = await profileRes.json().catch(() => ({}));
-                if (profileBody.conflict_role === 'landlord') {
-                  emit({ conflict: 'landlord' });
-                  const conflictUrl = new URL(window.location.href);
-                  conflictUrl.searchParams.set('roleConflict', 'landlord');
-                  if (data.session.user?.email) {
-                    conflictUrl.searchParams.set('email', data.session.user.email);
-                  }
-                  window.location.assign(conflictUrl.toString());
-                  return;
-                }
-              }
-            } catch {
-              // Best-effort — proceed with redirect.
+            // Any other non-2xx (401 bad token, 500, …): the destination RSC
+            // would see a guest and bounce back to login — which reads as "my
+            // password didn't work". Surface it instead of looping silently.
+            if (!bootstrapRes.ok) {
+              emit({ error: true, stage: 'bootstrap' });
+              setError(t('sessionError'));
+              return;
             }
           }
 

--- a/src/app/api/auth/bootstrap/route.js
+++ b/src/app/api/auth/bootstrap/route.js
@@ -1,0 +1,112 @@
+import { NextResponse } from 'next/server';
+import { SB_ACCESS_TOKEN_COOKIE, SB_ACCESS_TOKEN_MAX_AGE_SECONDS } from '@/lib/authCookies';
+import {
+  getUserFromToken,
+  getSupabaseWithToken,
+  cleanupFreshOrphanAuthUser,
+} from '@/lib/supabaseServer';
+
+// Single post-login round-trip (#253). After signInWithPassword succeeds the
+// browser used to make two sequential client→Worker hops before navigating:
+// POST /api/auth/session (cookie sync) then POST /api/student/profile for
+// students, or GET /api/auth/me for landlords. Both can run server-side in
+// one request because the Worker→Supabase hops are cheap (the JWT is verified
+// locally via JWKS since #176/#178). This route validates the token, does the
+// role-specific provisioning/probe, sets the auth cookie, and returns —
+// collapsing ~150–400 ms of serial latency per login into one call.
+//
+// On a 409 role conflict the cookie is deliberately NOT set (the client signs
+// out in that case); the token is never echoed back in the response body.
+
+function authCookie(value) {
+  return {
+    name: SB_ACCESS_TOKEN_COOKIE,
+    value,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: SB_ACCESS_TOKEN_MAX_AGE_SECONDS,
+  };
+}
+
+export async function POST(request) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const accessToken = typeof body.access_token === 'string' ? body.access_token : '';
+  if (!accessToken) {
+    return NextResponse.json({ error: 'access_token is required' }, { status: 400 });
+  }
+  const role = body.role === 'student' || body.role === 'landlord' ? body.role : null;
+  if (!role) {
+    return NextResponse.json({ error: 'role must be "student" or "landlord"' }, { status: 400 });
+  }
+
+  // Validate before persisting — same confused-deputy rationale as
+  // /api/auth/session: never write an unverified token into our cookie. This
+  // is the local JWKS fast path, so it costs microseconds on a valid token.
+  const user = await getUserFromToken(accessToken);
+  if (!user) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
+  }
+
+  const supabase = getSupabaseWithToken(accessToken);
+
+  if (role === 'student') {
+    // Idempotent provisioning — mirrors POST /api/student/profile. Returns the
+    // existing students row when one is present, so it's a no-op on the happy
+    // path. A prevent_dual_role 23505 means the email is already a landlord.
+    const { data: rows, error } = await supabase.rpc('create_student_profile', {
+      p_display_name: '',
+      p_preferred_locale: 'en',
+    });
+    if (error) {
+      if (error.code === '23505' && /already registered as a landlord/i.test(error.message || '')) {
+        await cleanupFreshOrphanAuthUser(user);
+        return NextResponse.json(
+          { error: 'role_conflict', conflict_role: 'landlord' },
+          { status: 409 },
+        );
+      }
+      console.error('bootstrap: create_student_profile RPC error:', error);
+      return NextResponse.json({ error: 'Failed to bootstrap session' }, { status: 500 });
+    }
+    // PostgREST returns a single object (not an array) for a record-returning fn.
+    const student = Array.isArray(rows) ? rows[0] : rows;
+    const res = NextResponse.json({ ok: true, role: 'student', name: student?.display_name ?? null });
+    res.cookies.set(authCookie(accessToken));
+    return res;
+  }
+
+  // role === 'landlord': mirror GET /api/auth/me's role probe. A students row
+  // with no landlords row is a wrong-role login → 409 (client signs out, no
+  // cookie). A landlords row → proceed. Neither (orphan) or a probe-unavailable
+  // read → proceed with role:null; the dashboard's server-side requireLandlord
+  // guard bounces bad sessions, so it needn't be special-cased here.
+  const [studentRes, landlordRes] = await Promise.all([
+    supabase.from('students').select('display_name').eq('auth_user_id', user.id).maybeSingle(),
+    supabase.from('landlords').select('name').eq('auth_user_id', user.id).maybeSingle(),
+  ]);
+  const student = studentRes.data;
+  const landlord = landlordRes.data;
+
+  if (student && !landlord) {
+    return NextResponse.json(
+      { error: 'role_conflict', conflict_role: 'student' },
+      { status: 409 },
+    );
+  }
+
+  const res = NextResponse.json({
+    ok: true,
+    role: landlord ? 'landlord' : null,
+    name: landlord?.name ?? null,
+  });
+  res.cookies.set(authCookie(accessToken));
+  return res;
+}

--- a/src/app/api/landlord/listings/route.js
+++ b/src/app/api/landlord/listings/route.js
@@ -5,53 +5,7 @@ import { canCreateListing } from '@/lib/stripe';
 import { recomputeMissingDistances } from '@/lib/recomputeDistances';
 import { normalizeTitle } from '@/lib/listingTitle';
 import { normalizeSingleLine, normalizeMultiLine } from '@/lib/textNormalize';
-
-const LANDLORD_LISTING_SELECT = `
-  listing_id,
-  landlord_id,
-  is_featured,
-  title,
-  rent_id,
-  location_id,
-  property_type_id,
-  description,
-  photos,
-  sqm,
-  floor,
-  available_from,
-  min_duration_months,
-  created_at,
-  updated_at,
-  rent ( rent_id, monthly_price, currency, bills_included, deposit ),
-  location ( location_id, address, neighborhood, lat, lng ),
-  property_types ( property_type_id, name ),
-  listing_amenities ( amenities ( amenity_id, name ) )
-`;
-
-// Pre-migration fallback: identical to LANDLORD_LISTING_SELECT minus columns
-// that may not yet exist in prod. When adding a column to LANDLORD_LISTING_SELECT
-// that ships ahead of its migration, also omit it here so the GET handler can
-// degrade gracefully instead of darking the landlord portal.
-const LANDLORD_LISTING_SELECT_FALLBACK = `
-  listing_id,
-  landlord_id,
-  is_featured,
-  title,
-  rent_id,
-  location_id,
-  property_type_id,
-  description,
-  photos,
-  sqm,
-  floor,
-  available_from,
-  created_at,
-  updated_at,
-  rent ( rent_id, monthly_price, currency, bills_included, deposit ),
-  location ( location_id, address, neighborhood, lat, lng ),
-  property_types ( property_type_id, name ),
-  listing_amenities ( amenities ( amenity_id, name ) )
-`;
+import { selectLandlordListings } from '@/lib/landlordListingSelect';
 
 const ALLOWED_MIN_DURATIONS = [1, 5, 9];
 
@@ -89,25 +43,11 @@ export async function GET(request) {
   if (!landlordId) return NextResponse.json({ error: 'Landlord profile not found' }, { status: 404 });
 
   const authedSupabase = getSupabaseWithToken(token);
-  let { data, error } = await authedSupabase
-    .from('listings')
-    .select(LANDLORD_LISTING_SELECT)
-    .eq('landlord_id', landlordId)
-    .order('created_at', { ascending: false });
+  const { data, error } = await selectLandlordListings(authedSupabase, landlordId);
 
   if (error) {
-    console.warn('Landlord listings query failed, retrying without min_duration_months:', error.message);
-    const fallback = await authedSupabase
-      .from('listings')
-      .select(LANDLORD_LISTING_SELECT_FALLBACK)
-      .eq('landlord_id', landlordId)
-      .order('created_at', { ascending: false });
-
-    if (fallback.error) {
-      console.error('Failed to fetch landlord listings:', fallback.error);
-      return NextResponse.json({ error: 'Failed to fetch listings' }, { status: 500 });
-    }
-    data = fallback.data;
+    console.error('Failed to fetch landlord listings:', error);
+    return NextResponse.json({ error: 'Failed to fetch listings' }, { status: 500 });
   }
 
   return NextResponse.json({ listings: data });

--- a/src/components/landlord/LandlordShell.js
+++ b/src/components/landlord/LandlordShell.js
@@ -28,17 +28,30 @@ const NAV_ITEMS = [
   { key: 'settings', href: '/property/thessaloniki/landlord/settings', icon: 'cog' },
 ];
 
-export default function LandlordShell({ title, eyebrow, actions, children }) {
+export default function LandlordShell({
+  title,
+  eyebrow,
+  actions,
+  children,
+  // gated (default true): client pages let the shell run the Supabase auth
+  // gate + greeting fetch. A server-gated page (the dashboard, #254) passes
+  // gated={false} so the shell renders immediately — its own requireLandlord()
+  // already guarded auth, and landlordName is supplied as a prop.
+  gated = true,
+  landlordName: landlordNameProp = '',
+}) {
   const t = useTranslations('propylaea.landlord.nav');
   const tLoaders = useTranslations('loaders');
   const router = useRouter();
   const pathname = usePathname();
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [landlordName, setLandlordName] = useState('');
-  const [sessionReady, setSessionReady] = useState(false);
+  const [landlordName, setLandlordName] = useState(landlordNameProp);
+  // When ungated, there is nothing to wait for — paint on first render.
+  const [sessionReady, setSessionReady] = useState(!gated);
 
-  // Auth gate — centralized here, so each page doesn't re-check.
+  // Auth gate — centralized here, so each gated page doesn't re-check.
   useEffect(() => {
+    if (!gated) return; // server-gated page owns auth + greeting
     (async () => {
       const supabase = getSupabaseBrowser();
       const {
@@ -56,18 +69,20 @@ export default function LandlordShell({ title, eyebrow, actions, children }) {
       // the shell only reads, and POST-on-every-mount would attempt to
       // create a landlord row for any authed user — including students,
       // which now hits the prevent_dual_role trigger from migration 036.
-      try {
-        const profileRes = await fetch('/api/landlord/profile', {
-          headers: { Authorization: `Bearer ${session.access_token}` },
-        });
-        if (profileRes.ok) {
-          const { landlord } = await profileRes.json();
-          if (landlord?.name) setLandlordName(landlord.name);
-        }
-      } catch {}
+      if (!landlordNameProp) {
+        try {
+          const profileRes = await fetch('/api/landlord/profile', {
+            headers: { Authorization: `Bearer ${session.access_token}` },
+          });
+          if (profileRes.ok) {
+            const { landlord } = await profileRes.json();
+            if (landlord?.name) setLandlordName(landlord.name);
+          }
+        } catch {}
+      }
       setSessionReady(true);
     })();
-  }, [router]);
+  }, [router, gated, landlordNameProp]);
 
   async function handleSignOut() {
     const supabase = getSupabaseBrowser();
@@ -75,8 +90,8 @@ export default function LandlordShell({ title, eyebrow, actions, children }) {
     router.push('/property/thessaloniki/landlord/login');
   }
 
-  // Loading state while auth gate is resolving
-  if (!sessionReady) {
+  // Loading state while the gated auth check resolves (never shown when ungated)
+  if (gated && !sessionReady) {
     return (
       <div className="min-h-screen bg-stone flex items-center justify-center">
         <BauhausLoader

--- a/src/lib/landlordListingSelect.js
+++ b/src/lib/landlordListingSelect.js
@@ -1,0 +1,77 @@
+// Shared listing-select definitions for the landlord-owned listings view.
+// Imported by BOTH the listings API route (src/app/api/landlord/listings/route.js)
+// and the server-rendered dashboard (#254) so the column set + the pre-migration
+// fallback can't drift between them.
+
+export const LANDLORD_LISTING_SELECT = `
+  listing_id,
+  landlord_id,
+  is_featured,
+  title,
+  rent_id,
+  location_id,
+  property_type_id,
+  description,
+  photos,
+  sqm,
+  floor,
+  available_from,
+  min_duration_months,
+  created_at,
+  updated_at,
+  rent ( rent_id, monthly_price, currency, bills_included, deposit ),
+  location ( location_id, address, neighborhood, lat, lng ),
+  property_types ( property_type_id, name ),
+  listing_amenities ( amenities ( amenity_id, name ) )
+`;
+
+// Pre-migration fallback: identical to LANDLORD_LISTING_SELECT minus columns
+// that may not yet exist in prod. When adding a column to LANDLORD_LISTING_SELECT
+// that ships ahead of its migration, also omit it here so the query can degrade
+// gracefully instead of darking the landlord portal.
+export const LANDLORD_LISTING_SELECT_FALLBACK = `
+  listing_id,
+  landlord_id,
+  is_featured,
+  title,
+  rent_id,
+  location_id,
+  property_type_id,
+  description,
+  photos,
+  sqm,
+  floor,
+  available_from,
+  created_at,
+  updated_at,
+  rent ( rent_id, monthly_price, currency, bills_included, deposit ),
+  location ( location_id, address, neighborhood, lat, lng ),
+  property_types ( property_type_id, name ),
+  listing_amenities ( amenities ( amenity_id, name ) )
+`;
+
+/**
+ * Fetch a landlord's own listings (newest first), with the pre-migration
+ * fallback baked in. `supabase` MUST be token-scoped (RLS applies). Returns
+ * the same `{ data, error }` shape as a Supabase query so callers keep their
+ * own error handling. Single source of truth shared by the API route and the
+ * server-rendered dashboard.
+ */
+export async function selectLandlordListings(supabase, landlordId) {
+  const primary = await supabase
+    .from('listings')
+    .select(LANDLORD_LISTING_SELECT)
+    .eq('landlord_id', landlordId)
+    .order('created_at', { ascending: false });
+  if (!primary.error) return primary;
+
+  console.warn(
+    'Landlord listings query failed, retrying without min_duration_months:',
+    primary.error.message,
+  );
+  return supabase
+    .from('listings')
+    .select(LANDLORD_LISTING_SELECT_FALLBACK)
+    .eq('landlord_id', landlordId)
+    .order('created_at', { ascending: false });
+}


### PR DESCRIPTION
Closes #254. **Stacked on #283 (#253)** → base is `perf/auth-bootstrap-253`. Merge #265 → #253 → this in order.

## What
Rewrites `/property/[city]/landlord/dashboard` from a `'use client'` triple-gate to a server component that mirrors the student account page:

- `requireLandlord()` guards server-side; guest/wrong-role → redirect to landlord login with `roleConflict`/`email`.
- `LandlordShell` gains **`gated={false}`** + **`landlordName`** props → shell + greeting paint on the first byte, **no `BauhausLoader` phase**.
- Four streamed widgets (stats / listings / inquiries / verification), each in its own `<Suspense>`; `cache()`'d loaders dedupe `requireLandlord()` and the shared listings query across boundaries so they stream independently.

## Drift guard
`LANDLORD_LISTING_SELECT` + the pre-migration fallback move to `src/lib/landlordListingSelect.js`, imported by **both** the API route and the dashboard. The route's GET is now a 3-line call into the shared `selectLandlordListings()` — behavior byte-identical.

## Stripe
The verification widget reads `verified_tier`/`is_verified` directly off the `landlords` row (not `getActiveSubscription`), so streaming never blocks on Stripe. All five `/api/landlord/*` routes are preserved (other pages/clients still use them).

## ⚠️ Behavior difference to confirm
The old client shell redirected **unconfirmed-email** landlords to `/verify-email`. The server page models the student account page, which has no such check, so an unconfirmed-email landlord with a valid session would now reach the dashboard. The issue spec didn't mention it. **Flagging for your call** — easy to add an `auth.user.email_confirmed_at` guard if you want parity.

## Verification
- `npm run build` ✓ compiled — dashboard is `ƒ` (dynamic), no RSC/client-boundary errors
- Full suite green (274), lint clean
- ⚠️ Not exercised with a live landlord session — recommend a manual pass (signed-out redirect, student-role redirect+banner, real landlord with/without listings, throttled network to watch widgets stream) before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)