### PR TITLE
feat(practice): intro video gate on General Physiology predicted lab exam

### DIFF
--- a/content/practice/ausom/semester-2/general-physiology/predicted-lab-exam.json
+++ b/content/practice/ausom/semester-2/general-physiology/predicted-lab-exam.json
@@ -4,8 +4,12 @@
   "title": "Predicted Laboratory Exam",
   "kind": "topic",
   "description": "Flashcards: read each predicted open-ended question, attempt your own answer, then hit Answer to reveal a bullet-point mark scheme and the relevant slide(s). Repeat-weighted from the 2024/2025 lab papers — at least one question per lab presentation (Cell Transport, Neurophysiology, Skeletal Muscle, Blood).",
-  "version": 1,
+  "version": 2,
   "updatedAt": "2026-06-17",
+  "intro": {
+    "video": "/practice/ausom/semester-2/general-physiology/predicted-lab-exam/intro.mp4",
+    "title": "A word from Marcus Aurelius AI"
+  },
   "questions": [
     {
       "id": "q01",

--- a/src/components/practice/FlashcardPlayer.js
+++ b/src/components/practice/FlashcardPlayer.js
@@ -89,6 +89,54 @@ function AnswerButton({ children, onClick }) {
   );
 }
 
+// Intro gate shown before the first card on every fresh start (see the
+// `started` flag below). Native <video> controls, no autoplay — it plays once
+// when the student hits play and never loops. The "Start the exam" button
+// dismisses the gate and drops them onto card 1.
+function IntroGate({ intro, onStart, startLabel, videoLabel }) {
+  return (
+    <>
+      {intro.title && (
+        <h2
+          style={{
+            fontFamily: 'var(--font-inter-tight, var(--font-inter), system-ui, sans-serif)',
+            fontWeight: 600,
+            fontSize: 26,
+            letterSpacing: '-0.01em',
+            lineHeight: 1.2,
+            color: INK,
+            margin: '0 0 12px',
+          }}
+        >
+          {intro.title}
+        </h2>
+      )}
+      {intro.description && (
+        <p style={{ margin: '0 0 20px', fontSize: 15, lineHeight: 1.55, color: 'rgba(10,37,64,0.6)' }}>
+          {intro.description}
+        </p>
+      )}
+      <video
+        src={intro.video}
+        poster={intro.poster}
+        controls
+        playsInline
+        preload="metadata"
+        aria-label={videoLabel}
+        style={{
+          display: 'block',
+          width: '100%',
+          borderRadius: 14,
+          border: '1px solid rgba(10,37,64,0.10)',
+          background: '#000',
+          marginBottom: 26,
+        }}
+      />
+      <PrimaryButton onClick={onStart}>{startLabel}</PrimaryButton>
+    </>
+  );
+}
+
 export default function FlashcardPlayer({ test, subject, onReportIssue }) {
   const t = useTranslations('student.practice.player');
   const listHref = `/student/ausom/semester-2/${subject}`;
@@ -97,6 +145,10 @@ export default function FlashcardPlayer({ test, subject, onReportIssue }) {
   const [current, setCurrent] = useState(0);
   const [revealed, setRevealed] = useState(false);
   const [finished, setFinished] = useState(false);
+  // Intro gate: shown before card 1 on every fresh start (initial load and
+  // after Start-over). `started` flips once the student hits "Start the exam".
+  const [started, setStarted] = useState(false);
+  const showIntro = Boolean(test.intro?.video) && !started && !finished;
   const [lightbox, setLightbox] = useState(null); // { src, alt } | null
   const [reportCtx, setReportCtx] = useState(null);
 
@@ -122,7 +174,10 @@ export default function FlashcardPlayer({ test, subject, onReportIssue }) {
     setCurrent(0);
     setRevealed(false);
     setFinished(false);
+    setStarted(false); // re-show the intro on a fresh start
   }, []);
+
+  const handleStart = useCallback(() => setStarted(true), []);
 
   const handleReport = useCallback(() => {
     const ctx = { subject, testId: test.id, questionId: q.id, version: test.version };
@@ -136,7 +191,7 @@ export default function FlashcardPlayer({ test, subject, onReportIssue }) {
   // Keyboard: Enter / Space reveals the card, then advances. Disabled while a
   // modal or the lightbox is open, on the completion screen, or when typing.
   useEffect(() => {
-    if (finished || lightbox || reportCtx) return undefined;
+    if (showIntro || finished || lightbox || reportCtx) return undefined;
     function onKey(e) {
       const el = e.target;
       if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) return;
@@ -148,7 +203,7 @@ export default function FlashcardPlayer({ test, subject, onReportIssue }) {
     }
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [finished, lightbox, reportCtx, revealed, handleNext, handleReveal]);
+  }, [showIntro, finished, lightbox, reportCtx, revealed, handleNext, handleReveal]);
 
   const lightboxEl = lightbox ? (
     <Lightbox
@@ -169,6 +224,20 @@ export default function FlashcardPlayer({ test, subject, onReportIssue }) {
       onClose={closeReport}
     />
   ) : null;
+
+  // Intro gate — before card 1 on every fresh start.
+  if (showIntro) {
+    return (
+      <Shell back={<BackRow href={listHref} label={t('review.backToTests')} />}>
+        <IntroGate
+          intro={test.intro}
+          onStart={handleStart}
+          startLabel={t('intro.start')}
+          videoLabel={t('intro.videoLabel')}
+        />
+      </Shell>
+    );
+  }
 
   // Completion screen.
   if (finished) {

--- a/src/lib/practice/schema.js
+++ b/src/lib/practice/schema.js
@@ -117,6 +117,11 @@ export const QuestionSchema = z
  * @property {number} version      Bump on every edit (feeds the edit loop).
  * @property {string} updatedAt    ISO date.
  * @property {Question[]} questions
+ * @property {{ video: string, poster?: string, title?: string, description?: string }} [intro]
+ *           Optional intro screen shown before the first card/question. `video`
+ *           is a public-root path (e.g. "/practice/.../intro.mp4"); the player
+ *           renders it with native controls (no autoplay) behind a "Start"
+ *           button on every fresh start.
  */
 export const PracticeTestSchema = z.object({
   id: z.string().min(1),
@@ -127,6 +132,14 @@ export const PracticeTestSchema = z.object({
   version: z.number().int().positive(),
   updatedAt: z.string().min(1),
   questions: z.array(QuestionSchema).min(1),
+  intro: z
+    .object({
+      video: z.string().min(1),
+      poster: z.string().optional(),
+      title: z.string().optional(),
+      description: z.string().optional(),
+    })
+    .optional(),
 });
 
 /**

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -910,6 +910,10 @@
           "completeBody": "You've been through all {total} cards.",
           "restart": "Start over",
           "imageLabel": "Specimen image"
+        },
+        "intro": {
+          "videoLabel": "Introduction video",
+          "start": "Start the exam"
         }
       },
       "report": {


### PR DESCRIPTION
## What

Adds an introduction-video screen before the **General Physiology → Predicted Laboratory Exam** flashcard deck, at `/student/ausom/semester-2/general-physiology/predicted-lab-exam`.

The student now sees a **"A word from Marcus Aurelius AI"** gate with the intro video and a **Start the exam** button, then lands on card 1.

## Behaviour
- **Plays once** — native `<video>` with `controls`, `loop=false`, `autoplay=false`. Click-to-play; plays through (0:12) and stops.
- **Not annoying on repeat** — it's a one-time gate, not an inline player on every card. Re-shows only on a *fresh* start (initial open / "Start over"), never mid-deck. Flashcards have no resume, so there's nothing to skip past.

## Changes
- `schema.js` — optional `intro` block (`video`, `poster?`, `title?`, `description?`) on `PracticeTest`, so any future test can opt in just by adding an `intro.video` path.
- `FlashcardPlayer.js` — `IntroGate` component, `started` flag, keyboard guard so Enter/Space don't reveal the hidden card behind the gate.
- `content/.../predicted-lab-exam.json` — wires the video, bumps `version` 1→2.
- `en.json` — `intro.start` / `intro.videoLabel` strings.
- `public/.../predicted-lab-exam/intro.mp4` — the 5.6 MB asset, served statically (same convention as the question images; not bundled into the Worker).

No DB migration. Lint clean.

## Verified
Confirmed live in dev (desktop + mobile 375px): gate renders, video loads cleanly (readyState 4, no error, `loop=false`/`autoplay=false`), and **Start the exam** drops onto card 1 of 8.

## Note
The video is committed into the repo. Fine at this size; if intro videos spread to many tests, worth routing through Supabase Storage / R2 to keep the repo lean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)