### PR TITLE
fix(auth): bound gotrue auth lock + local-scope pre-login signout + 8 s timeouts

### DIFF
--- a/src/app/[locale]/property/[city]/landlord/login/page.js
+++ b/src/app/[locale]/property/[city]/landlord/login/page.js
@@ -48,23 +48,32 @@ function LandlordLoginInner() {
     setStage('auth');
     try {
       const supabase = getSupabaseBrowser();
-      // PR #138's defence: when a cached browser client has a session
-      // whose token refresh is hung, the next signInWithPassword can
-      // queue behind the stuck refresh on the same HTTP/2 connection.
-      // Clearing first cancels the refresh. getSession() reads from
-      // localStorage synchronously, so when there's no prior session we
-      // skip the signOut and save a ~200–1000 ms Supabase round-trip —
-      // the hung-refresh scenario can only happen when there IS one.
-      const { data: { session: existing } } = await supabase.auth.getSession();
-      if (existing) {
-        await signOutSafely(supabase);
+      // PR #138's defence: when a cached browser client has a session whose
+      // token refresh is hung, the next signInWithPassword can queue behind
+      // the stuck refresh on gotrue's shared auth lock. Clearing first cancels
+      // it. Local scope wipes the session WITHOUT a network /logout, so it adds
+      // no latency on the sign-in path and only runs when a session exists.
+      // If getSession itself contends on the lock, treat that as "a session may
+      // exist" and clear anyway.
+      let hasStaleSession = false;
+      try {
+        const { data: { session: existing } } = await supabase.auth.getSession();
+        hasStaleSession = Boolean(existing);
+      } catch {
+        hasStaleSession = true;
+      }
+      if (hasStaleSession) {
+        await signOutSafely(supabase, { scope: 'local' });
       }
 
       let lastErr;
       for (let attempt = 0; attempt < 2; attempt++) {
         try {
           const { data, error: authError } = await withTimeout(
+            // 8 s: healthy legs finish <1 s; with the one timeout-retry this
+            // bounds a hung flow at ~16 s instead of ~30 s (#264).
             supabase.auth.signInWithPassword({ email, password }),
+            8000,
           );
           if (authError) {
             setError(authError.message);
@@ -83,6 +92,7 @@ function LandlordLoginInner() {
             try {
               const meRes = await withTimeout(
                 fetch('/api/auth/me', { headers: { Authorization: `Bearer ${token}` } }),
+                8000,
               );
               if (meRes.ok) {
                 const { user } = await meRes.json();

--- a/src/app/[locale]/property/[city]/landlord/signup/page.js
+++ b/src/app/[locale]/property/[city]/landlord/signup/page.js
@@ -58,6 +58,8 @@ export default function LandlordSignupPage() {
       const supabase = getSupabaseBrowser();
       const siteUrl = window.location.origin;
       const { data: authData, error: authError } = await withTimeout(
+        // 8 s: healthy auth legs finish <1 s; bounds a hung flow instead of a
+        // 15 s freeze (#264).
         supabase.auth.signUp({
           email,
           password,
@@ -65,6 +67,7 @@ export default function LandlordSignupPage() {
             emailRedirectTo: `${siteUrl}/${locale}/property/thessaloniki/landlord/login`,
           },
         }),
+        8000,
       );
       if (authError) {
         setError(authError.message);
@@ -94,6 +97,7 @@ export default function LandlordSignupPage() {
               profilePhotoUrl ? { name, profile_photo_url: profilePhotoUrl } : { name },
             ),
           }),
+          8000,
         );
         if (!res.ok) {
           await signOutSafely(supabase);

--- a/src/app/[locale]/student/login/page.js
+++ b/src/app/[locale]/student/login/page.js
@@ -52,23 +52,32 @@ function StudentLoginInner() {
     setStage('auth');
     try {
       const supabase = getSupabaseBrowser();
-      // PR #138's defence: when a cached browser client has a session
-      // whose token refresh is hung, the next signInWithPassword can
-      // queue behind the stuck refresh on the same HTTP/2 connection.
-      // Clearing first cancels the refresh. getSession() reads from
-      // localStorage synchronously, so when there's no prior session we
-      // skip the signOut and save a ~200–1000 ms Supabase round-trip —
-      // the hung-refresh scenario can only happen when there IS one.
-      const { data: { session: existing } } = await supabase.auth.getSession();
-      if (existing) {
-        await signOutSafely(supabase);
+      // PR #138's defence: when a cached browser client has a session whose
+      // token refresh is hung, the next signInWithPassword can queue behind
+      // the stuck refresh on gotrue's shared auth lock. Clearing first cancels
+      // it. Local scope wipes the session WITHOUT a network /logout, so it adds
+      // no latency on the sign-in path and only runs when a session exists.
+      // If getSession itself contends on the lock, treat that as "a session may
+      // exist" and clear anyway.
+      let hasStaleSession = false;
+      try {
+        const { data: { session: existing } } = await supabase.auth.getSession();
+        hasStaleSession = Boolean(existing);
+      } catch {
+        hasStaleSession = true;
+      }
+      if (hasStaleSession) {
+        await signOutSafely(supabase, { scope: 'local' });
       }
 
       let lastErr;
       for (let attempt = 0; attempt < 2; attempt++) {
         try {
           const { data, error: authError } = await withTimeout(
+            // 8 s: healthy legs finish <1 s; with the one timeout-retry this
+            // bounds a hung flow at ~16 s instead of ~30 s (#264).
             supabase.auth.signInWithPassword({ email, password }),
+            8000,
           );
           if (authError) {
             setError(authError.message);
@@ -86,6 +95,7 @@ function StudentLoginInner() {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ access_token: data.session.access_token }),
               }),
+              8000,
             );
             // If the cookie sync returns non-2xx (401 bad token, 500, …), the
             // destination RSC sees a guest and bounces straight back to login —
@@ -110,6 +120,7 @@ function StudentLoginInner() {
                   },
                   body: JSON.stringify({ preferred_locale: 'en' }),
                 }),
+                8000,
               );
               if (profileRes.status === 409) {
                 const profileBody = await profileRes.json().catch(() => ({}));

--- a/src/app/[locale]/student/signup/page.js
+++ b/src/app/[locale]/student/signup/page.js
@@ -38,6 +38,8 @@ export default function StudentSignupPage() {
       const supabase = getSupabaseBrowser();
       const siteUrl = window.location.origin;
       const { data: authData, error: authError } = await withTimeout(
+        // 8 s: healthy auth legs finish <1 s; bounds a hung flow instead of a
+        // 15 s freeze (#264).
         supabase.auth.signUp({
           email,
           password,
@@ -46,6 +48,7 @@ export default function StudentSignupPage() {
             data: { display_name: name, role: 'student' },
           },
         }),
+        8000,
       );
       if (authError) {
         setError(authError.message);
@@ -64,6 +67,7 @@ export default function StudentSignupPage() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ access_token: session.access_token }),
           }),
+          8000,
         );
 
         const res = await withTimeout(
@@ -79,6 +83,7 @@ export default function StudentSignupPage() {
             // they signed up through.
             body: JSON.stringify({ display_name: name, preferred_locale: 'en' }),
           }),
+          8000,
         );
         if (!res.ok) {
           await signOutSafely(supabase);

--- a/src/lib/authHelpers.js
+++ b/src/lib/authHelpers.js
@@ -12,9 +12,15 @@ import { reportClientError } from '@/lib/reportClientError';
  * The swallowed failure is still beaconed to /api/log-client-error (#143) so
  * the timeout/rejection is visible in logs — this is the class of silent
  * failure behind the original "stuck on SIGNING IN…" bug.
+ *
+ * `scope` mirrors supabase.auth.signOut's option. Default 'global' revokes the
+ * refresh token server-side (the right choice for an explicit "sign out"
+ * button). Pass `scope: 'local'` for the pre-sign-in housekeeping clear in the
+ * login pages: it wipes the stale browser session WITHOUT a network /logout
+ * round-trip, so it can't add latency or hang on the critical sign-in path.
  */
-export async function signOutSafely(supabase, { timeoutMs = 5000 } = {}) {
-  await withTimeout(supabase.auth.signOut(), timeoutMs).catch((err) => {
+export async function signOutSafely(supabase, { timeoutMs = 5000, scope = 'global' } = {}) {
+  await withTimeout(supabase.auth.signOut({ scope }), timeoutMs).catch((err) => {
     reportClientError('signOut', err);
   });
 }

--- a/src/lib/supabaseBrowser.js
+++ b/src/lib/supabaseBrowser.js
@@ -1,6 +1,48 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, navigatorLock } from '@supabase/supabase-js';
 
 let _client;
+
+// Hard ceiling (ms) on how long any auth call will wait to ACQUIRE gotrue's
+// shared lock. See the comment on boundedAuthLock for why this exists.
+const LOCK_ACQUIRE_TIMEOUT_MS = 5000;
+
+/**
+ * Bounded wrapper around gotrue-js's own Navigator-locks mutex.
+ *
+ * gotrue serialises every auth operation (signInWithPassword, getSession,
+ * signOut, the background token refresh) behind one cross-tab lock. Its
+ * acquire timeout (`lockAcquireTimeout`) is NOT configurable through
+ * supabase-js's `createClient` — only the `lock` function itself is forwarded
+ * — and on some auth-js builds the default acquire waits forever. The failure
+ * that bit us in prod: an auto-refresh fired on page load wedged the lock, and
+ * the user's next sign-in queued behind it. Sign-in froze for ~2 minutes while
+ * Supabase + the Worker were each responding in <1 s — the stall was entirely
+ * client-side lock contention.
+ *
+ * This delegates to the library's own `navigatorLock` (so we keep its
+ * orphaned-lock steal-recovery and the spec edge cases) but forces a finite
+ * acquire bound. A wedged lock now fails fast / self-heals instead of hanging.
+ * Because there is no lockfile in this repo (each deploy resolves `@supabase/*`
+ * to "latest matching"), pinning the bound in our own code keeps it guaranteed
+ * across version drift. On a recent auth-js — whose default is already 5 s with
+ * steal-recovery — this is effectively a no-op.
+ */
+function boundedAuthLock(name, acquireTimeout, fn) {
+  // No Web Locks API (older browser / non-browser import) or the export went
+  // away in a future major: match gotrue's own no-op-lock fallback.
+  if (
+    typeof navigator === 'undefined' ||
+    !navigator.locks ||
+    typeof navigatorLock !== 'function'
+  ) {
+    return fn();
+  }
+  // gotrue passes `acquireTimeout === 0` for the background-refresh tick
+  // ("take the lock only if free right now") — preserve that fast path.
+  // Everything else is capped at our finite bound.
+  const bound = acquireTimeout === 0 ? 0 : LOCK_ACQUIRE_TIMEOUT_MS;
+  return navigatorLock(name, bound, fn);
+}
 
 /**
  * Browser-side Supabase client with session persistence.
@@ -17,6 +59,8 @@ export function getSupabaseBrowser() {
       auth: {
         persistSession: true,
         autoRefreshToken: true,
+        // Bound lock acquisition so a wedged auth op can't freeze sign-in.
+        lock: boundedAuthLock,
       },
     });
   }


### PR DESCRIPTION
## What this fixes

A real student sign-in on prod **froze for ~2 minutes** even though the password was correct. Server-side forensics showed every Supabase leg was fast the whole time:

| Time (UTC) | Event | Server duration |
|---|---|---|
| 15:08:23 | `POST /token` (auto-refresh of a stale session) | 187 ms |
| 15:08:57 | `POST /logout` (pre-sign-in clear) | 119 ms |
| **15:10:52** | `POST /token` (password grant — finally lands) | 279 ms |

The **~1m55s gap** between logout and the successful grant was pure client-side dead time. Cause: gotrue-js serialises every auth operation behind one cross-tab **Navigator-locks** mutex. A token refresh that fires on page load can wedge that lock, and the next `signInWithPassword` queues behind the stuck holder. The login handler's 15 s `withTimeout` + retry then stretched the stall into minutes.

This is **not** covered by the #253–#265 login-latency audit — that audit measured only the healthy path on a clean dev network (its F7 flagged the 15 s timeout as mere "tail-latency UX"). The lock contention is the missing root cause.

## Changes

1. **`supabaseBrowser.js` — bound the auth lock (root-cause fix).** Pass a `lock` that delegates to gotrue's own `navigatorLock` (so we keep its orphaned-lock steal-recovery and spec edge cases) but forces a finite **5 s** acquire bound. supabase-js does **not** forward `lockAcquireTimeout` through `createClient` — only `lock` is forwarded — and this repo has **no lockfile**, so `npm install` resolves `@supabase/*` to "latest matching `^2.101.0`" on every Cloudflare build and the version drifts. Pinning the bound in our own code makes it version-independent. On a recent auth-js (5 s default + steal-recovery already) it's effectively a no-op.

2. **Login pages — local-scope pre-sign-in clear.** `signOutSafely` gains a `scope` option; the login pages' housekeeping clear now uses `signOut({ scope: 'local' })` — it wipes the stale browser session **without** a network `/logout` round-trip (that's the `POST /logout` you see above, on the critical path). `getSession` is also wrapped defensively so a lock-contended read can't throw out of `handleSubmit`.

3. **Auth legs: `withTimeout` 15 s → 8 s** at the login + signup call sites (student + landlord). A genuinely hung leg now surfaces a retryable error in ~8 s instead of ~30 s. **Closes #264** (default in `withTimeout.js` and `signOutSafely`'s 5 s left untouched, per that issue).

## Verification

- `npm run lint` (0 errors), `npm run test` (263 pass), `npm run build` (compiles — confirms the `navigatorLock` named import resolves).
- Smoke-tested a dummy-credential sign-in through the new bounded-lock path in `next dev`: `getSession` → `signInWithPassword` returns "Invalid login credentials", no console errors, button recovers.

## Relationship to the audit issues

Complementary, not overlapping. The biggest remaining wins are still **#253** (collapse post-login round-trips into one `/api/auth/bootstrap`) and **#259** (dedupe SessionSync POSTs — I observed 5 duplicate `/api/auth/session` POSTs in the repro). Those stay as separate PRs. **#265** (per-stage timing beacon) would have caught this class in the field and is worth landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
