### PR TITLE
perf: dedupe SessionSync cookie-sync POSTs (#259)

### DIFF
--- a/src/components/SessionSync.js
+++ b/src/components/SessionSync.js
@@ -14,24 +14,39 @@ import { getSupabaseBrowser } from '@/lib/supabaseBrowser';
 // onAuthStateChange. We re-POST the new token so the cookie keeps up
 // with rotation, otherwise server-side auth would fail an hour after
 // sign-in even though the client still believes it's signed in.
+//
+// Dedupe (#259): the initial-sync IIFE and the SIGNED_IN event both POST,
+// and a fresh login has already synced the cookie itself — so the same token
+// was being POSTed up to several times, each a wasted Worker invocation + JWT
+// verify. Track the last successfully-synced token at module scope (survives
+// re-renders; resets on a full page load, which is exactly when the cookie
+// might genuinely be stale) and skip duplicates. A token refresh rotates the
+// access token (~hourly) → new string → the POST goes through, so the cookie
+// still keeps up with rotation.
+let lastSyncedToken = null;
+
 export default function SessionSync() {
   useEffect(() => {
     const supabase = getSupabaseBrowser();
     let cancelled = false;
 
     async function postSession(accessToken) {
+      if (accessToken === lastSyncedToken) return; // already synced this token
       try {
-        await fetch('/api/auth/session', {
+        const res = await fetch('/api/auth/session', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ access_token: accessToken }),
         });
+        // Only remember it on success — a failed sync must stay retryable.
+        if (res.ok) lastSyncedToken = accessToken;
       } catch {
-        // Best-effort — the next state change will retry.
+        // Best-effort — the next state change will retry (token not recorded).
       }
     }
 
     async function clearSession() {
+      lastSyncedToken = null; // sign-out must always re-sync next time
       try {
         await fetch('/api/auth/session', { method: 'DELETE' });
       } catch {}


### PR DESCRIPTION
Closes #259. Independent — branches off `main` (includes #288).

## What
`SessionSync` POSTs `/api/auth/session` from both the mount-time initial sync **and** every `onAuthStateChange`-with-session event. After a login the page already synced the cookie, so the `SIGNED_IN` event re-POSTs the same token — several duplicate Worker invocations + JWT verifies per login (5 observed in #288's repro).

Tracks `lastSyncedToken` at module scope and skips duplicate POSTs. Resets on a full page load (cookie may be genuinely stale then) and on sign-out; only records on a `2xx` so a failed sync stays retryable. Token refresh rotates the access token (new string) so cookie rotation still works.

Scoped to `SessionSync.js` only — I skipped the optional login-page `markSessionSynced` coupling the issue mentions, so this stays independent of the #253/#265 login-page stack.

## Verification
- Lint clean, full suite green (263)
- ⚠️ Manual network-tab check recommended: log in → one POST; navigate → no new POSTs; sign out + back in → fires again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)