### PR TITLE
perf(auth): prefetch the post-login destination while the user types (#257)

### DIFF
--- a/__tests__/api/authBootstrap.test.js
+++ b/__tests__/api/authBootstrap.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SB_ACCESS_TOKEN_COOKIE } from '@/lib/authCookies';
+
+// Hoisted mocks for the SUT's supabaseServer dependencies (#253).
+const getUserFromToken = vi.fn();
+const getSupabaseWithToken = vi.fn();
+const cleanupFreshOrphanAuthUser = vi.fn();
+
+vi.mock('@/lib/supabaseServer', () => ({
+  getUserFromToken: (...args) => getUserFromToken(...args),
+  getSupabaseWithToken: (...args) => getSupabaseWithToken(...args),
+  cleanupFreshOrphanAuthUser: (...args) => cleanupFreshOrphanAuthUser(...args),
+}));
+
+const { POST } = await import('@/app/api/auth/bootstrap/route');
+
+beforeEach(() => {
+  getUserFromToken.mockReset();
+  getSupabaseWithToken.mockReset();
+  cleanupFreshOrphanAuthUser.mockReset();
+});
+
+const USER = () => ({ id: 'auth-1', email: 'x@example.com', created_at: new Date().toISOString() });
+
+function req(body, { raw } = {}) {
+  return new Request('http://localhost/api/auth/bootstrap', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: raw !== undefined ? raw : JSON.stringify(body),
+  });
+}
+
+// supabase.rpc('create_student_profile', ...) → result
+function rpcSupabase(result) {
+  return { rpc: vi.fn(async () => result) };
+}
+
+// supabase.from(table).select().eq().maybeSingle() → { data, error: null }
+function probeSupabase({ student = null, landlord = null } = {}) {
+  const chain = (data) => ({
+    select: () => ({ eq: () => ({ maybeSingle: async () => ({ data, error: null }) }) }),
+  });
+  return {
+    from: vi.fn((table) => (table === 'students' ? chain(student) : chain(landlord))),
+  };
+}
+
+function cookieValue(res) {
+  return res.cookies.get(SB_ACCESS_TOKEN_COOKIE)?.value;
+}
+
+describe('POST /api/auth/bootstrap — validation', () => {
+  it('400 when access_token is missing', async () => {
+    const res = await POST(req({ role: 'student' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when role is missing or not student/landlord', async () => {
+    expect((await POST(req({ access_token: 'jwt' }))).status).toBe(400);
+    expect((await POST(req({ access_token: 'jwt', role: 'admin' }))).status).toBe(400);
+  });
+
+  it('400 on invalid JSON body', async () => {
+    const res = await POST(req(null, { raw: 'not json{' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('401 when the token does not validate', async () => {
+    getUserFromToken.mockResolvedValue(null);
+    const res = await POST(req({ access_token: 'bad', role: 'student' }));
+    expect(res.status).toBe(401);
+    expect(cookieValue(res)).toBeUndefined();
+  });
+});
+
+describe('POST /api/auth/bootstrap — student', () => {
+  it('200 + cookie on the happy path', async () => {
+    getUserFromToken.mockResolvedValue(USER());
+    getSupabaseWithToken.mockReturnValue(
+      rpcSupabase({ data: { student_id: 'S1', display_name: 'Foo' }, error: null }),
+    );
+    const res = await POST(req({ access_token: 'jwt', role: 'student' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ ok: true, role: 'student', name: 'Foo' });
+    expect(cookieValue(res)).toBe('jwt');
+    expect(cleanupFreshOrphanAuthUser).not.toHaveBeenCalled();
+  });
+
+  it('409 role_conflict + NO cookie + cleanup when email is already a landlord', async () => {
+    getUserFromToken.mockResolvedValue(USER());
+    getSupabaseWithToken.mockReturnValue(
+      rpcSupabase({
+        data: null,
+        error: { code: '23505', message: 'Email x already registered as a landlord' },
+      }),
+    );
+    const res = await POST(req({ access_token: 'jwt', role: 'student' }));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: 'role_conflict', conflict_role: 'landlord' });
+    expect(cookieValue(res)).toBeUndefined();
+    expect(cleanupFreshOrphanAuthUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('500 + NO cookie on a non-conflict RPC error', async () => {
+    getUserFromToken.mockResolvedValue(USER());
+    getSupabaseWithToken.mockReturnValue(
+      rpcSupabase({ data: null, error: { code: '42501', message: 'permission denied' } }),
+    );
+    const res = await POST(req({ access_token: 'jwt', role: 'student' }));
+    expect(res.status).toBe(500);
+    expect(cookieValue(res)).toBeUndefined();
+    expect(cleanupFreshOrphanAuthUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/auth/bootstrap — landlord', () => {
+  it('200 + cookie when a landlords row exists', async () => {
+    getUserFromToken.mockResolvedValue(USER());
+    getSupabaseWithToken.mockReturnValue(probeSupabase({ landlord: { name: 'LL Inc' } }));
+    const res = await POST(req({ access_token: 'jwt', role: 'landlord' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, role: 'landlord', name: 'LL Inc' });
+    expect(cookieValue(res)).toBe('jwt');
+  });
+
+  it('409 student-conflict + NO cookie when only a students row exists', async () => {
+    getUserFromToken.mockResolvedValue(USER());
+    getSupabaseWithToken.mockReturnValue(probeSupabase({ student: { display_name: 'Stu' } }));
+    const res = await POST(req({ access_token: 'jwt', role: 'landlord' }));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: 'role_conflict', conflict_role: 'student' });
+    expect(cookieValue(res)).toBeUndefined();
+  });
+
+  it('200 + cookie + role:null for an orphan (neither row)', async () => {
+    getUserFromToken.mockResolvedValue(USER());
+    getSupabaseWithToken.mockReturnValue(probeSupabase({}));
+    const res = await POST(req({ access_token: 'jwt', role: 'landlord' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, role: null });
+    expect(cookieValue(res)).toBe('jwt');
+  });
+});

--- a/src/app/[locale]/property/[city]/landlord/login/page.js
+++ b/src/app/[locale]/property/[city]/landlord/login/page.js
@@ -52,14 +52,14 @@ function LandlordLoginInner() {
     setError('');
     setStage('auth');
 
-    // Per-stage timing (#265). t0 marks the start; tAuth/tProbe are filled as
-    // each leg resolves so emit() can report per-stage deltas. Beacon is
+    // Per-stage timing (#265). t0 marks the start; tAuth/tBootstrap are filled
+    // as each leg resolves so emit() can report per-stage deltas. Beacon is
     // fire-and-forget (keepalive) and never affects control flow.
     const t0 = performance.now();
     const coldHint = firstLandlordSubmitSinceLoad;
     firstLandlordSubmitSinceLoad = false;
     let tAuth = 0;
-    let tProbe = 0;
+    let tBootstrap = 0;
     let lastAttempt = 0;
     const emit = (extra = {}) =>
       reportLoginTiming({
@@ -67,7 +67,7 @@ function LandlordLoginInner() {
         attempt: lastAttempt,
         coldHint,
         auth: tAuth ? Math.round(tAuth - t0) : 0,
-        probe: tProbe && tAuth ? Math.round(tProbe - tAuth) : 0,
+        bootstrap: tBootstrap && tAuth ? Math.round(tBootstrap - tAuth) : 0,
         total: Math.round(performance.now() - t0),
         ...extra,
       });
@@ -116,33 +116,46 @@ function LandlordLoginInner() {
           // stays 'auth' through the probe so the button doesn't flash
           // "redirecting" when it's actually about to show the conflict banner.
           const token = data.session?.access_token;
-          let role = 'landlord'; // unknown probe → defer to the dashboard's own guards
+          // One server-side round-trip (#253): bootstrap validates the token,
+          // confirms the role, and — for a real landlord — sets the auth cookie
+          // BEFORE navigation. That eager cookie is what lets the dashboard
+          // server-render instead of gating on a client probe (#254).
+          let bootstrap = null;
           if (token) {
             try {
-              const meRes = await withTimeout(
-                fetch('/api/auth/me', { headers: { Authorization: `Bearer ${token}` } }),
+              const bootstrapRes = await withTimeout(
+                fetch('/api/auth/bootstrap', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ access_token: token, role: 'landlord' }),
+                }),
                 8000,
               );
-              if (meRes.ok) {
-                const { user } = await meRes.json();
-                role = user?.role ?? null;
-              }
+              bootstrap = {
+                status: bootstrapRes.status,
+                body:
+                  bootstrapRes.status === 409
+                    ? await bootstrapRes.json().catch(() => ({}))
+                    : null,
+              };
             } catch {
-              /* transient probe failure shouldn't block a real landlord */
+              /* transient bootstrap failure shouldn't block a real landlord */
             }
           }
-          tProbe = performance.now();
+          tBootstrap = performance.now();
 
-          if (role === 'student') {
+          // 409 student-conflict → sign out and show the banner. Stage stays
+          // 'auth' so the button doesn't flash "redirecting".
+          if (bootstrap?.status === 409 && bootstrap.body?.conflict_role === 'student') {
             emit({ conflict: 'student' });
             await signOutSafely(supabase);
             setStudentConflict(true);
             return;
           }
 
-          // role 'landlord', or a null orphan / probe-unavailable: proceed. A
-          // null orphan is bounced safely by the dashboard's server-side
-          // requireLandlord guard, so it needn't be special-cased here.
+          // 200, a null orphan, or a transient/5xx bootstrap failure: proceed.
+          // The dashboard's server-side requireLandlord guard bounces bad
+          // sessions, so a failed probe needn't block a real landlord.
           emit();
           setStage('redirect');
           router.push('/property/thessaloniki/landlord/dashboard');

--- a/src/app/[locale]/property/[city]/landlord/login/page.js
+++ b/src/app/[locale]/property/[city]/landlord/login/page.js
@@ -45,6 +45,10 @@ function LandlordLoginInner() {
   // Supabase round-trip. Fire-and-forget; cheap GET, no auth.
   useEffect(() => {
     fetch('/api/health', { cache: 'no-store' }).catch(() => {});
+    // Warm the dashboard RSC payload + route chunks too (#257), so the
+    // post-auth navigation is a cache hit. No-op in `next dev`.
+    router.prefetch('/property/thessaloniki/landlord/dashboard');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   async function handleSubmit(e) {

--- a/src/app/[locale]/student/login/page.js
+++ b/src/app/[locale]/student/login/page.js
@@ -49,6 +49,11 @@ function StudentLoginInner() {
   // Supabase round-trip. Fire-and-forget; cheap GET, no auth.
   useEffect(() => {
     fetch('/api/health', { cache: 'no-store' }).catch(() => {});
+    // Warm the destination RSC payload + route chunks too (#257), so the
+    // post-auth navigation is a cache hit instead of a 100–300 ms fetch.
+    // safeNext is validated internal-path-only; no-op in `next dev`.
+    router.prefetch(safeNext || '/student/account');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   async function handleSubmit(e) {

--- a/src/app/[locale]/student/login/page.js
+++ b/src/app/[locale]/student/login/page.js
@@ -56,15 +56,14 @@ function StudentLoginInner() {
     setError('');
     setStage('auth');
 
-    // Per-stage timing (#265). t0 marks the start; tAuth/tSync/tProbe are
+    // Per-stage timing (#265). t0 marks the start; tAuth/tBootstrap are
     // filled as each leg resolves so emit() can report per-stage deltas.
     // Beacon is fire-and-forget (keepalive) and never affects control flow.
     const t0 = performance.now();
     const coldHint = firstStudentSubmitSinceLoad;
     firstStudentSubmitSinceLoad = false;
     let tAuth = 0;
-    let tSync = 0;
-    let tProbe = 0;
+    let tBootstrap = 0;
     let lastAttempt = 0;
     const emit = (extra = {}) =>
       reportLoginTiming({
@@ -72,8 +71,7 @@ function StudentLoginInner() {
         attempt: lastAttempt,
         coldHint,
         auth: tAuth ? Math.round(tAuth - t0) : 0,
-        sync: tSync && tAuth ? Math.round(tSync - tAuth) : 0,
-        probe: tProbe && tSync ? Math.round(tProbe - tSync) : 0,
+        bootstrap: tBootstrap && tAuth ? Math.round(tBootstrap - tAuth) : 0,
         total: Math.round(performance.now() - t0),
         ...extra,
       });
@@ -117,60 +115,46 @@ function StudentLoginInner() {
 
           setStage('redirect');
 
-          // Sync cookie eagerly so the next navigation's RSC sees auth without
-          // waiting for SessionSync's onAuthStateChange to fire.
+          // One server-side round-trip (#253): validate the token, provision
+          // the students row (idempotent), and set the auth cookie — replacing
+          // the old sequential /api/auth/session + /api/student/profile hops.
           if (data.session?.access_token) {
-            const sessionRes = await withTimeout(
-              fetch('/api/auth/session', {
+            const bootstrapRes = await withTimeout(
+              fetch('/api/auth/bootstrap', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ access_token: data.session.access_token }),
+                body: JSON.stringify({
+                  access_token: data.session.access_token,
+                  role: 'student',
+                }),
               }),
               8000,
             );
-            tSync = performance.now();
-            // If the cookie sync returns non-2xx (401 bad token, 500, …), the
-            // destination RSC sees a guest and bounces straight back to login —
-            // which reads to the user as "my correct password didn't work".
-            // Surface it instead of navigating into a silent loop.
-            if (!sessionRes.ok) {
-              emit({ error: true, stage: 'sync' });
-              setError(t('sessionError'));
-              return;
+            tBootstrap = performance.now();
+
+            // 409 → this email is already a landlord. Deep-link back to login
+            // with the conflict banner (same UX as the old profile-probe path).
+            if (bootstrapRes.status === 409) {
+              const bootstrapBody = await bootstrapRes.json().catch(() => ({}));
+              if (bootstrapBody.conflict_role === 'landlord') {
+                emit({ conflict: 'landlord' });
+                const conflictUrl = new URL(window.location.href);
+                conflictUrl.searchParams.set('roleConflict', 'landlord');
+                if (data.session.user?.email) {
+                  conflictUrl.searchParams.set('email', data.session.user.email);
+                }
+                window.location.assign(conflictUrl.toString());
+                return;
+              }
             }
 
-            // Idempotent profile probe — ensures a students row exists
-            // even if the signup trigger was skipped (e.g. pre-seeded
-            // landlord email collision). Returns the existing row when
-            // one is already present, so this is a no-op on happy path.
-            try {
-              const profileRes = await withTimeout(
-                fetch('/api/student/profile', {
-                  method: 'POST',
-                  headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${data.session.access_token}`,
-                  },
-                  body: JSON.stringify({ preferred_locale: 'en' }),
-                }),
-                8000,
-              );
-              tProbe = performance.now();
-              if (profileRes.status === 409) {
-                const profileBody = await profileRes.json().catch(() => ({}));
-                if (profileBody.conflict_role === 'landlord') {
-                  emit({ conflict: 'landlord' });
-                  const conflictUrl = new URL(window.location.href);
-                  conflictUrl.searchParams.set('roleConflict', 'landlord');
-                  if (data.session.user?.email) {
-                    conflictUrl.searchParams.set('email', data.session.user.email);
-                  }
-                  window.location.assign(conflictUrl.toString());
-                  return;
-                }
-              }
-            } catch {
-              // Best-effort — proceed with redirect.
+            // Any other non-2xx (401 bad token, 500, …): the destination RSC
+            // would see a guest and bounce back to login — which reads as "my
+            // password didn't work". Surface it instead of looping silently.
+            if (!bootstrapRes.ok) {
+              emit({ error: true, stage: 'bootstrap' });
+              setError(t('sessionError'));
+              return;
             }
           }
 

--- a/src/app/api/auth/bootstrap/route.js
+++ b/src/app/api/auth/bootstrap/route.js
@@ -1,0 +1,112 @@
+import { NextResponse } from 'next/server';
+import { SB_ACCESS_TOKEN_COOKIE, SB_ACCESS_TOKEN_MAX_AGE_SECONDS } from '@/lib/authCookies';
+import {
+  getUserFromToken,
+  getSupabaseWithToken,
+  cleanupFreshOrphanAuthUser,
+} from '@/lib/supabaseServer';
+
+// Single post-login round-trip (#253). After signInWithPassword succeeds the
+// browser used to make two sequential client→Worker hops before navigating:
+// POST /api/auth/session (cookie sync) then POST /api/student/profile for
+// students, or GET /api/auth/me for landlords. Both can run server-side in
+// one request because the Worker→Supabase hops are cheap (the JWT is verified
+// locally via JWKS since #176/#178). This route validates the token, does the
+// role-specific provisioning/probe, sets the auth cookie, and returns —
+// collapsing ~150–400 ms of serial latency per login into one call.
+//
+// On a 409 role conflict the cookie is deliberately NOT set (the client signs
+// out in that case); the token is never echoed back in the response body.
+
+function authCookie(value) {
+  return {
+    name: SB_ACCESS_TOKEN_COOKIE,
+    value,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: SB_ACCESS_TOKEN_MAX_AGE_SECONDS,
+  };
+}
+
+export async function POST(request) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const accessToken = typeof body.access_token === 'string' ? body.access_token : '';
+  if (!accessToken) {
+    return NextResponse.json({ error: 'access_token is required' }, { status: 400 });
+  }
+  const role = body.role === 'student' || body.role === 'landlord' ? body.role : null;
+  if (!role) {
+    return NextResponse.json({ error: 'role must be "student" or "landlord"' }, { status: 400 });
+  }
+
+  // Validate before persisting — same confused-deputy rationale as
+  // /api/auth/session: never write an unverified token into our cookie. This
+  // is the local JWKS fast path, so it costs microseconds on a valid token.
+  const user = await getUserFromToken(accessToken);
+  if (!user) {
+    return NextResponse.json({ error: 'Invalid token' }, { status: 401 });
+  }
+
+  const supabase = getSupabaseWithToken(accessToken);
+
+  if (role === 'student') {
+    // Idempotent provisioning — mirrors POST /api/student/profile. Returns the
+    // existing students row when one is present, so it's a no-op on the happy
+    // path. A prevent_dual_role 23505 means the email is already a landlord.
+    const { data: rows, error } = await supabase.rpc('create_student_profile', {
+      p_display_name: '',
+      p_preferred_locale: 'en',
+    });
+    if (error) {
+      if (error.code === '23505' && /already registered as a landlord/i.test(error.message || '')) {
+        await cleanupFreshOrphanAuthUser(user);
+        return NextResponse.json(
+          { error: 'role_conflict', conflict_role: 'landlord' },
+          { status: 409 },
+        );
+      }
+      console.error('bootstrap: create_student_profile RPC error:', error);
+      return NextResponse.json({ error: 'Failed to bootstrap session' }, { status: 500 });
+    }
+    // PostgREST returns a single object (not an array) for a record-returning fn.
+    const student = Array.isArray(rows) ? rows[0] : rows;
+    const res = NextResponse.json({ ok: true, role: 'student', name: student?.display_name ?? null });
+    res.cookies.set(authCookie(accessToken));
+    return res;
+  }
+
+  // role === 'landlord': mirror GET /api/auth/me's role probe. A students row
+  // with no landlords row is a wrong-role login → 409 (client signs out, no
+  // cookie). A landlords row → proceed. Neither (orphan) or a probe-unavailable
+  // read → proceed with role:null; the dashboard's server-side requireLandlord
+  // guard bounces bad sessions, so it needn't be special-cased here.
+  const [studentRes, landlordRes] = await Promise.all([
+    supabase.from('students').select('display_name').eq('auth_user_id', user.id).maybeSingle(),
+    supabase.from('landlords').select('name').eq('auth_user_id', user.id).maybeSingle(),
+  ]);
+  const student = studentRes.data;
+  const landlord = landlordRes.data;
+
+  if (student && !landlord) {
+    return NextResponse.json(
+      { error: 'role_conflict', conflict_role: 'student' },
+      { status: 409 },
+    );
+  }
+
+  const res = NextResponse.json({
+    ok: true,
+    role: landlord ? 'landlord' : null,
+    name: landlord?.name ?? null,
+  });
+  res.cookies.set(authCookie(accessToken));
+  return res;
+}


### PR DESCRIPTION
Closes #257. **Stacked on #283 (#253)** — base `perf/auth-bootstrap-253`.

## What
Adds `router.prefetch(...)` to both login pages' mount effects (alongside the existing `/api/health` warm-up): student prefetches `safeNext || /student/account`, landlord prefetches the dashboard. The destination RSC payload + route chunks are warmed while the user types, so the post-auth navigation is a cache hit instead of a 100–300 ms fetch at `push()` time.

`router` is next-intl's wrapped `useRouter` (from `@/i18n/navigation`), which exposes `prefetch`.

## Notes
- `prefetch` is a **no-op in `next dev`** — verify on `npm run preview`/prod (network tab shows an RSC request shortly after mount).
- `safeNext` is validated internal-path-only by `safeNextPath`; gated destinations are dynamic/uncached so Next revalidates on real navigation.

## Verification
- Lint clean, 274 tests, build green (on the #253 base). ⚠️ prefetch behavior itself needs a preview/prod check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)