### PR TITLE
perf(db): fix auth_rls_initplan on student_favorites policies (#263)

### DIFF
--- a/supabase/migrations/063_student_favorites_rls_initplan.sql
+++ b/supabase/migrations/063_student_favorites_rls_initplan.sql
@@ -1,0 +1,40 @@
+-- ============================================================
+-- Migration 063: student_favorites RLS InitPlan fix (#263).
+-- ============================================================
+--
+-- Supabase performance advisor flags auth_rls_initplan (WARN) on the three
+-- student_favorites policies from migration 053: they call auth.uid() BARE,
+-- so Postgres re-evaluates it per row instead of once per query. Wrapping it
+-- in a scalar subquery — (SELECT auth.uid()) — makes Postgres hoist it into a
+-- one-shot InitPlan. Every other auth-touching policy in this project already
+-- uses this form; these three were the only stragglers.
+--
+-- Pure performance change: the predicate is otherwise byte-identical to 053,
+-- so access semantics are unchanged. SELECT/DELETE policies use USING; the
+-- INSERT policy uses WITH CHECK — matching how they exist today.
+--
+-- (Number is 063: prod's highest applied migration is 062_gig_favorites_and_
+-- inquiry_reads as of 2026-06-18, verified via list_migrations. The #263 issue
+-- text predates 060–062 and its suggested "060" filename would collide.)
+-- ============================================================
+
+ALTER POLICY "Students read own favorites" ON public.student_favorites
+  USING (
+    student_id IN (
+      SELECT student_id FROM students WHERE auth_user_id = (SELECT auth.uid())
+    )
+  );
+
+ALTER POLICY "Students insert own favorites" ON public.student_favorites
+  WITH CHECK (
+    student_id IN (
+      SELECT student_id FROM students WHERE auth_user_id = (SELECT auth.uid())
+    )
+  );
+
+ALTER POLICY "Students delete own favorites" ON public.student_favorites
+  USING (
+    student_id IN (
+      SELECT student_id FROM students WHERE auth_user_id = (SELECT auth.uid())
+    )
+  );


### PR DESCRIPTION
Closes #263. Independent — off `main`.

## What
Wraps the bare `auth.uid()` in the three `student_favorites` RLS policies (migration 053) in `(SELECT auth.uid())` so Postgres evaluates it once per query (InitPlan) instead of per row. Clears the `auth_rls_initplan` advisor WARNings. Pure performance change — the predicate is otherwise byte-identical, so access semantics are unchanged.

## ⚠️ Numbering correction
The #263 issue says "060 is next" — that's stale. Prod's highest applied migration is **`062_gig_favorites_and_inquiry_reads`** (verified via `list_migrations`), and `060`/`061`/`062` already exist in-repo. So this is **`063_student_favorites_rls_initplan.sql`**.

## ⚠️ Prod-apply parked for you
Per the repo convention this should be applied to prod **before** merge. I did **not** apply it (left DB changes for you). To apply + verify:
```
supabase db push    # or Supabase MCP apply_migration
```
then Advisors → Performance and confirm the three `student_favorites` `auth_rls_initplan` warnings are gone. Out of scope (by design, per the issue): the `multiple_permissive_policies` flags on inquiries/inquiry_messages/listing_amenities/location/rent.

## Verification
- `migration-check.yml` will run `supabase start` and apply it in a clean stack on this PR. No `seed.sql` change needed (no schema change).
- ⚠️ Functional RLS check (save/unsave + cross-account isolation) recommended after prod-apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)