### PR TITLE
perf(bundle): trim login-page JS — filtered client messages + drop motion (#260)

### DIFF
--- a/__tests__/lib/pickMessages.test.js
+++ b/__tests__/lib/pickMessages.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { pickMessages, CLIENT_NAMESPACES } from '@/lib/pickMessages';
+import messages from '@/messages/en.json';
+
+describe('pickMessages', () => {
+  it('keeps only the allow-listed top-level namespaces', () => {
+    const input = { a: { x: 1 }, b: { y: 2 }, c: { z: 3 } };
+    expect(pickMessages(input, ['a', 'c'])).toEqual({ a: { x: 1 }, c: { z: 3 } });
+  });
+
+  it('ignores allow-list entries not present in the catalog', () => {
+    expect(pickMessages({ a: 1 }, ['a', 'missing'])).toEqual({ a: 1 });
+  });
+
+  it('every CLIENT_NAMESPACES entry exists in en.json', () => {
+    for (const ns of CLIENT_NAMESPACES) {
+      expect(messages, `en.json is missing top-level namespace "${ns}"`).toHaveProperty(ns);
+    }
+  });
+});
+
+// --- Allow-list completeness: scan 'use client' files and make sure every
+// namespace they pass to useTranslations() is covered by CLIENT_NAMESPACES.
+// This is the safety net for the #260 message-filtering optimization: if a
+// client component starts using a new namespace and nobody updates the list,
+// this fails instead of shipping a runtime MISSING_MESSAGE to users.
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) out.push(...walk(full));
+    else if (/\.(js|jsx)$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+function clientNamespacesUsed() {
+  const srcDir = join(process.cwd(), 'src');
+  const used = new Map(); // topLevel -> file where first seen
+  for (const file of walk(srcDir)) {
+    const code = readFileSync(file, 'utf8');
+    // A real client component declares the directive as its first statement.
+    // Checking the trimmed start (not includes) avoids matching files that
+    // merely mention 'use client' inside a comment or string.
+    const head = code.trimStart();
+    if (!head.startsWith("'use client'") && !head.startsWith('"use client"')) continue;
+    const re = /useTranslations\(\s*['"]([^'"]+)['"]\s*\)/g;
+    let m;
+    while ((m = re.exec(code)) !== null) {
+      const top = m[1].split('.')[0];
+      if (!used.has(top)) used.set(top, file);
+    }
+  }
+  return used;
+}
+
+describe('CLIENT_NAMESPACES completeness', () => {
+  it('covers every namespace used by a client component', () => {
+    const used = clientNamespacesUsed();
+    const allow = new Set(CLIENT_NAMESPACES);
+    const missing = [...used.entries()]
+      .filter(([ns]) => !allow.has(ns))
+      .map(([ns, file]) => `"${ns}" (e.g. ${file})`);
+    expect(
+      missing,
+      `Client components use namespaces not in CLIENT_NAMESPACES (src/lib/pickMessages.js): ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('does not over-list namespaces no client component uses (keeps the trim tight)', () => {
+    const used = clientNamespacesUsed();
+    const unused = CLIENT_NAMESPACES.filter((ns) => !used.has(ns));
+    expect(unused, `CLIENT_NAMESPACES lists namespaces no client component uses: ${unused.join(', ')}`).toEqual([]);
+  });
+});

--- a/src/app/[locale]/layout.js
+++ b/src/app/[locale]/layout.js
@@ -3,6 +3,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, setRequestLocale } from 'next-intl/server';
 import { notFound } from 'next/navigation';
 import { routing } from '@/i18n/routing';
+import { pickMessages, CLIENT_NAMESPACES } from '@/lib/pickMessages';
 import Navbar from '@/components/Navbar';
 import SessionSync from '@/components/SessionSync';
 import FavoritesProvider from '@/components/FavoritesProvider';
@@ -85,7 +86,9 @@ export default async function LocaleLayout({ children, params }) {
   }
 
   setRequestLocale(locale);
-  const messages = await getMessages();
+  // Ship only the namespaces client components use to the browser (#260);
+  // server components still read the full catalog via getTranslations().
+  const messages = pickMessages(await getMessages(), CLIENT_NAMESPACES);
 
   return (
     <html

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -152,10 +152,26 @@ input[type="range"]::-moz-range-thumb {
   0%, 100% { transform: translate(-50%, -50%) rotate(45deg) scale(1); }
   50%      { transform: translate(-50%, -50%) rotate(45deg) scale(1.6); }
 }
+
+/*
+  EncryptButton gradient sweep (#260) — replaces the motion/react motion.span
+  so the auth pages don't ship an animation library. The scale(1.25) keeps the
+  element's `scale-125` while the keyframe drives translateY; the wrapper's
+  group-hover opacity still gates it to hover only.
+*/
+@keyframes encrypt-sweep {
+  from { transform: translateY(100%) scale(1.25); }
+  to   { transform: translateY(-100%) scale(1.25); }
+}
+.encrypt-sweep {
+  animation: encrypt-sweep 1s linear infinite alternate;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .bauhaus-rotate,
   .bauhaus-orbit,
-  .bauhaus-pulse {
+  .bauhaus-pulse,
+  .encrypt-sweep {
     animation: none !important;
   }
 }

--- a/src/components/ui/EncryptButton.js
+++ b/src/components/ui/EncryptButton.js
@@ -1,7 +1,6 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import { motion } from 'motion/react';
 
 /*
   EncryptButton — scramble-on-hover submit button, re-skinned to the brand
@@ -70,26 +69,26 @@ export default function EncryptButton({
   };
 
   return (
-    <motion.button
+    // Motion replaced with CSS (#260) to keep `motion/react` off the auth-page
+    // bundle: the scale press is Tailwind transform utilities, the gradient
+    // sweep is the `.encrypt-sweep` keyframe in globals.css (reduced-motion
+    // aware). The scramble effect is plain setInterval — untouched.
+    <button
       type={type}
       disabled={disabled}
-      whileHover={disabled ? undefined : { scale: 1.025 }}
-      whileTap={disabled ? undefined : { scale: 0.975 }}
       onMouseEnter={scramble}
       onMouseLeave={stopScramble}
-      className={`group relative overflow-hidden rounded-lg border-[1px] border-night bg-night px-4 py-2 font-mono font-medium uppercase text-stone/80 transition-colors hover:text-white disabled:cursor-not-allowed disabled:opacity-60 ${className}`}
+      className={`group relative overflow-hidden rounded-lg border-[1px] border-night bg-night px-4 py-2 font-mono font-medium uppercase text-stone/80 transition-[color,transform] hover:text-white enabled:hover:scale-[1.025] enabled:active:scale-[0.975] disabled:cursor-not-allowed disabled:opacity-60 ${className}`}
       {...rest}
     >
       <div className="relative z-10 flex items-center justify-center gap-2">
         <LockIcon />
         <span>{display}</span>
       </div>
-      <motion.span
-        initial={{ y: '100%' }}
-        animate={{ y: '-100%' }}
-        transition={{ repeat: Infinity, repeatType: 'mirror', duration: 1, ease: 'linear' }}
-        className="duration-300 absolute inset-0 z-0 scale-125 bg-gradient-to-t from-blue/0 from-40% via-blue/100 to-blue/0 to-60% opacity-0 transition-opacity group-hover:opacity-100"
+      <span
+        aria-hidden="true"
+        className="encrypt-sweep absolute inset-0 z-0 scale-125 bg-gradient-to-t from-blue/0 from-40% via-blue/100 to-blue/0 to-60% opacity-0 transition-opacity group-hover:opacity-100"
       />
-    </motion.button>
+    </button>
   );
 }

--- a/src/lib/pickMessages.js
+++ b/src/lib/pickMessages.js
@@ -1,0 +1,37 @@
+// Trims the next-intl message catalog down to the namespaces that 'use client'
+// components actually consume, before it's handed to NextIntlClientProvider
+// (#260). Server components use getTranslations() and read the full catalog on
+// the server, so they're unaffected — this only shrinks what gets serialized
+// into the HTML + client bundle on every page.
+
+/**
+ * Returns only the top-level namespaces in `topLevelKeys`.
+ * @param {Record<string, unknown>} messages full message catalog (en.json)
+ * @param {string[]} topLevelKeys top-level namespace names to keep
+ */
+export function pickMessages(messages, topLevelKeys) {
+  const allow = new Set(topLevelKeys);
+  return Object.fromEntries(
+    Object.entries(messages).filter(([key]) => allow.has(key)),
+  );
+}
+
+// Top-level message namespaces consumed by 'use client' components — the only
+// ones the browser needs. Regenerate with:
+//
+//   grep -rln "'use client'" src | xargs grep -hoE "useTranslations\('[^']+'\)" \
+//     | sed "s/useTranslations('//;s/')//" | cut -d. -f1 | sort -u
+//
+// The completeness test (__tests__/lib/pickMessages.test.js) re-runs that scan
+// and fails if a client component starts using a namespace missing here, so
+// this list can't silently rot into a MISSING_MESSAGE bug.
+export const CLIENT_NAMESPACES = [
+  'admin',
+  'gigs',
+  'landlord',
+  'listing',
+  'loaders',
+  'nav',
+  'propylaea',
+  'student',
+];


### PR DESCRIPTION
Closes #260. Independent — off `main`.

## Part A — namespace-filtered messages
`NextIntlClientProvider` was handed the **full** `en.json`, inlining every namespace into every page's HTML + client bundle. New `src/lib/pickMessages.js` exports `pickMessages()` + a `CLIENT_NAMESPACES` allow-list, and `layout.js` ships only those. Server components read the full catalog via `getTranslations()`, unaffected.

**Client namespaces (8):** `admin, gigs, landlord, listing, loaders, nav, propylaea, student` (no bare `useTranslations()` calls exist). **Dropped (server-only, 6):** `about, footer, home, inquiry, listingCard, results`.

**Safety net:** `__tests__/lib/pickMessages.test.js` re-runs the client-file scan and **fails CI** if a client component starts using a namespace not in the allow-list (or if the list over-lists). Keeps Part A from rotting into a runtime `MISSING_MESSAGE`.

## Part B — drop `motion/react` from `EncryptButton`
Scale press → Tailwind `enabled:hover:scale-[1.025] enabled:active:scale-[0.975]`; gradient sweep → `.encrypt-sweep` keyframe in `globals.css` (added to the existing `prefers-reduced-motion: reduce` disable block). The `setInterval` scramble is untouched. Keeps the animation library off the auth chunk graph.

## Verification
- Lint clean, full suite green (incl. 5 new pickMessages tests), `npm run build` ✓ compiled.
- ⚠️ **Part A needs a manual console sweep before merge** (I can't drive the authenticated app headless): watch for next-intl `MISSING_MESSAGE` across home, /property hub, results, quiz, listing + contact gate, and the student/landlord auth + dashboard/inquiries/settings flows. The completeness test covers *static* usage; a dynamic/computed namespace would slip past.
- ⚠️ Before/after compressed-transfer numbers need the issue's `curl` probe against preview/prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)