### PR TITLE
perf(infra): experiment — edge-cache the login/signup shells (#261)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -131,6 +131,21 @@ const nextConfig = {
         source: '/student/:path*',
         headers: PRIVATE_CACHE_HEADERS,
       },
+      // EXPERIMENT (#261): the login/signup SHELLS are identical for every
+      // visitor — both are 'use client' forms whose auth + ?next=/?roleConflict=
+      // behavior is entirely client-side (useSearchParams in Suspense), and
+      // neither page nor its layout chain reads cookies()/headers() server-side
+      // (verified). Let the edge cache them so first paint doesn't pay a Worker
+      // render + cold start. These come AFTER the PRIVATE rules above so the
+      // public value wins for these exact paths (last match wins — VERIFY with
+      // the curl in the PR, don't trust it). Everything else under /student/* and
+      // /landlord/* stays private. ABORT: if a deploy still returns
+      // `private, no-cache` (OpenNext force-privates request-scoped routes —
+      // CLAUDE.md quirk #1), revert these four rules and close #261 wontfix.
+      { source: '/student/login', headers: PUBLIC_CACHE_HEADERS },
+      { source: '/student/signup', headers: PUBLIC_CACHE_HEADERS },
+      { source: '/property/:city/landlord/login', headers: PUBLIC_CACHE_HEADERS },
+      { source: '/property/:city/landlord/signup', headers: PUBLIC_CACHE_HEADERS },
       // Vary: Cookie on listing detail responses so Cloudflare's edge
       // treats anon (no sb-access-token) and authed (with cookie)
       // requests as separate cache entries — prevents serving the


### PR DESCRIPTION
Closes #261 (experiment). Independent — off `main`. **Measure-first; do not merge until the abort condition below is checked on a deploy.**

## What
Adds four `PUBLIC_CACHE_HEADERS` rules (after the `PRIVATE` `/student/*` + `/landlord/*` rules) for `/student/login`, `/student/signup`, `/property/:city/landlord/login`, `/property/:city/landlord/signup`. The shells are `'use client'` forms; `?next=`/`?roleConflict=`/`?email=` are handled client-side via `useSearchParams`, so a cached shell is correct for all of them (and Cloudflare keys on the full URL anyway).

## Safety prerequisite — verified ✅
`grep` for `cookies()`/`headers()`/`requireStudent`/`requireLandlord` across both login pages **and their full layout chains** (`[locale]/layout.js`, `property/layout.js`, `property/[city]/layout.js`) → **none**. The page render sets no `Set-Cookie` (the cookie is set by the separate `/api/auth/*` routes), so there's nothing user-specific to leak into a cached shell.

## ⚠️ Parked for you — deploy + verify (the whole point of the experiment)
I did not deploy. After deploy:
```bash
curl -sD - -o /dev/null https://studentx.uk/student/login | grep -iE "cache-control|cf-cache-status"
# want: public, s-maxage=300 …  then cf-cache-status: HIT on the 2nd call
# also confirm NO Set-Cookie on the response
```
**Abort:** if it still says `private, no-cache` after deploy (OpenNext force-private won — CLAUDE.md quirk #1), revert these four rules and close #261 wontfix with the curl output. Note: "last match wins" for duplicate header keys is assumed — verify with the curl, don't trust it.

## Verification done here
- `npm run build` ✓ compiled (config is valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)