### PR TITLE
perf(infra): experiment — enable Cloudflare Smart Placement (#262)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,6 +12,15 @@
   "main": "cf/worker-entry.mjs",
   "compatibility_date": "2025-04-01",
   "compatibility_flags": ["nodejs_compat"],
+  // EXPERIMENT (#262): Smart Placement. Most authed routes make 1–3 sequential
+  // Supabase calls (auth-verify fallback, requireStudent/requireLandlord + page
+  // queries, /api/auth/bootstrap, the server-rendered dashboard); running the
+  // Worker near the DB beats running near the user for those. Public pages are
+  // CDN-cached and unaffected. Needs 24–48 h of traffic to learn — measure
+  // /api/auth/me, /student/account, /student/login TTFB before vs after (see
+  // #262). Decision rule: keep if authed/API TTFB improves and login TTFB
+  // doesn't regress > ~50 ms; otherwise remove this key and redeploy.
+  "placement": { "mode": "smart" },
   // Workers AI binding — powers site-agnostic listing extraction
   // (@cf/meta/llama-3.1-8b-instruct) in the pending-listings ingest pipeline.
   // No external API keys. Only bound on the Worker (preview/deploy), NOT in


### PR DESCRIPTION
Closes #262 (experiment). Independent — off `main`. **Measure-first; one-line revert.**

## What
Adds `"placement": { "mode": "smart" }` to `wrangler.jsonc`. Authed routes make 1–3 sequential Supabase calls; Smart Placement lets Cloudflare run the Worker near the DB when that wins, collapsing per-call edge→Supabase RTT (measured floor ~76–174 ms/query). Public pages are CDN-cached and unaffected.

## ⚠️ Parked for you — deploy, then measure (the point of the experiment)
1. Note the Supabase region (dashboard → project `ecluqurlfbvkxrnoyhaq` → Settings → General) — I couldn't read it from here.
2. Deploy; confirm placement took: `wrangler deployments list --name studentx` or the Worker → Settings page.
3. **Wait 24–48 h** (it needs traffic to learn), then run the before/after TTFB protocol from #262:
   ```bash
   for i in $(seq 1 10); do curl -so /dev/null -w "ttfb:%{time_starttransfer}\n" https://studentx.uk/api/auth/me; done
   for i in $(seq 1 10); do curl -so /dev/null -w "ttfb:%{time_starttransfer}\n" https://studentx.uk/student/account; done
   for i in $(seq 1 10); do curl -so /dev/null -w "ttfb:%{time_starttransfer}\n" https://studentx.uk/student/login; done
   ```
   Baselines (2026-06-12, warm): /api/auth/me 67–167 ms; /student/account 113–185 ms; /student/login 101–214 ms.

**Decision rule:** keep if authed/API TTFB improves and login TTFB doesn't regress > ~50 ms; otherwise remove the `placement` key and redeploy. Don't combine with #261 in the same measurement window or the numbers are confounded. The synthetic canary (every 15 min) doubles as the regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)